### PR TITLE
Switch README header to compact icon logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <p align="center">
-  <img src="assets/logo-banner.jpg" alt="memsearch" width="600">
+  <img src="assets/logo-icon.jpg" alt="memsearch" width="120">
 </p>
+
+<h1 align="center">memsearch</h1>
 
 <p align="center">
   <strong><a href="https://github.com/openclaw/openclaw">OpenClaw</a>'s memory, everywhere.</strong>


### PR DESCRIPTION
## Summary
- Replace the wide banner image with the compact square icon (120px) + text title
- Cleaner, less cluttered README header

## Test plan
- [ ] Verify logo renders correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)