### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# Publish to PyPI when a version tag is pushed
+#
+# Usage:
+#   git tag v0.1.0  # Must match the version in pyproject.toml
+#   git push --tags
+
+name: Publish Python Package to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` for automated PyPI publishing
- Triggered on version tag push (`v*`), builds with hatchling, publishes via trusted publisher (OIDC)
- Usage: `git tag v0.1.0 && git push --tags`

## Test plan
- [ ] Configure PyPI trusted publisher for `zilliztech/memsearch` repo
- [ ] Tag a release and verify the workflow triggers and publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)