### PR TITLE
Rename flush to compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - 🦞 **OpenClaw's memory, everywhere** — OpenClaw has one of the best memory designs in open-source AI: **markdown as the single source of truth** — simple, human-readable, `git`-friendly, zero vendor lock-in
 - ⚡ **Smart dedup** — SHA-256 content hashing means unchanged content is never re-embedded
 - 🔄 **Live sync** — File watcher auto-indexes on changes, deletes stale chunks when files are removed
-- 🧹 **Memory flush** — LLM-powered summarization compresses old memories, just like OpenClaw's flush cycle
+- 🧹 **Memory compact** — LLM-powered summarization compresses old memories, just like OpenClaw's compact cycle
 - 🧩 **Claude Code plugin included** — A real-world example: **[ccplugin/](ccplugin/README.md)** gives Claude persistent memory across sessions with zero config
 
 ## 🔍 How It Works
@@ -56,7 +56,7 @@
   │  File watcher (1500ms debounce) ──▶ auto re-index / delete stale  │
   └────────────────────────────────────────────────────────────────────┘
 
-  ┌─── Flush ──────────────────────────────────────────────────────────┐
+  ┌─── Compact ─────────────────────────────────────────────────────────┐
   │  Retrieve chunks ──▶ LLM summarize ──▶ write memory/YYYY-MM-DD.md │
   └────────────────────────────────────────────────────────────────────┘
 ```
@@ -344,19 +344,19 @@ memsearch watch ./docs/ ./notes/
 memsearch watch ./docs/ --debounce-ms 3000
 ```
 
-### Flush (compress memories)
+### Compact (compress memories)
 
 Summarize indexed chunks into a condensed memory using an LLM:
 
 ```bash
-memsearch flush
+memsearch compact
 
 # Use a specific LLM
-memsearch flush --llm-provider anthropic
-memsearch flush --llm-provider gemini
+memsearch compact --llm-provider anthropic
+memsearch compact --llm-provider gemini
 
-# Only flush chunks from a specific source
-memsearch flush --source ./docs/old-notes.md
+# Only compact chunks from a specific source
+memsearch compact --source ./docs/old-notes.md
 ```
 
 ### Configuration management
@@ -398,8 +398,8 @@ export OPENAI_BASE_URL="https://..."   # optional, for proxies / Azure
 export GOOGLE_API_KEY="..."
 export VOYAGE_API_KEY="..."
 
-# LLM for flush/summarization (set the one you use)
-export ANTHROPIC_API_KEY="..."         # for flush with Anthropic
+# LLM for compact/summarization (set the one you use)
+export ANTHROPIC_API_KEY="..."         # for compact with Anthropic
 ```
 
 ## 🔌 Embedding Providers
@@ -421,7 +421,7 @@ memsearch is designed to be a drop-in memory backend for projects following [Ope
 | Memory layout | `MEMORY.md` + `memory/YYYY-MM-DD.md` | ✅ Same |
 | Chunk ID format | `hash(source:startLine:endLine:contentHash:model)` | ✅ Same |
 | Dedup strategy | Content-hash primary key | ✅ Same |
-| Flush target | Append to daily markdown log | ✅ Same |
+| Compact target | Append to daily markdown log | ✅ Same |
 | Source of truth | Markdown files (vector DB is derived) | ✅ Same |
 | File watch debounce | 1500ms | ✅ Same default |
 | Vector backend | Built-in | Milvus (Lite / Server / Zilliz Cloud) |

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -218,7 +218,7 @@ This plugin is built entirely on the [`memsearch`](../README.md) CLI — every h
 | `index <paths>` | Manual / rebuild | One-shot index of markdown files (`--force` to re-index all) |
 | `expand <chunk_hash>` | Agent (L2 disclosure) | Show full markdown section around a chunk, with anchor metadata |
 | `transcript <jsonl>` | Agent (L3 disclosure) | Parse Claude Code JSONL transcript into readable conversation turns |
-| `flush` | Manual | LLM-powered compression of old memories into summaries |
+| `compact` | Manual | LLM-powered compression of old memories into summaries |
 | `config init\|list\|get\|set` | Quick Start | Interactive config wizard, view/modify settings |
 | `stats` | Manual | Show index statistics (collection size, chunk count) |
 | `reset` | Manual | Drop all indexed data (requires `--yes` to confirm) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ memsearch follows [OpenClaw](https://github.com/openclaw/openclaw)'s memory arch
 | Memory layout | `MEMORY.md` + `memory/YYYY-MM-DD.md` | Same |
 | Chunk ID format | `hash(source:startLine:endLine:contentHash:model)` | Same |
 | Dedup strategy | Content-hash primary key | Same |
-| Flush target | Append to daily markdown log | Same |
+| Compact target | Append to daily markdown log | Same |
 | Source of truth | Markdown files (vector DB is derived) | Same |
 | File watch debounce | 1500ms | Same default |
 
@@ -81,14 +81,14 @@ graph LR
     D -->|stale| DEL[Delete from Milvus]
 ```
 
-### Watch and Flush
+### Watch and Compact
 
-The file watcher monitors directories for markdown changes and automatically re-indexes modified files. The flush operation compresses indexed chunks into an LLM-generated summary and writes it back to a daily markdown log -- which the watcher then picks up and indexes, closing the loop.
+The file watcher monitors directories for markdown changes and automatically re-indexes modified files. The compact operation compresses indexed chunks into an LLM-generated summary and writes it back to a daily markdown log -- which the watcher then picks up and indexes, closing the loop.
 
 ```mermaid
 graph LR
     W[File Watcher] -->|1500ms debounce| I[Auto re-index]
-    FL[Flush] --> L[LLM Summarize] --> MD["memory/YYYY-MM-DD.md"]
+    FL[Compact] --> L[LLM Summarize] --> MD["memory/YYYY-MM-DD.md"]
     MD -.->|triggers| W
 ```
 
@@ -273,7 +273,7 @@ collection = "memsearch_chunks"
 provider = "openai"
 model = ""                           # empty = provider default
 
-[flush]
+[compact]
 llm_provider = "openai"
 llm_model = ""                       # empty = provider default
 prompt_file = ""                     # custom prompt template path
@@ -319,9 +319,9 @@ graph TB
     style MIL fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
 ```
 
-### The Flush Cycle
+### The Compact Cycle
 
-The flush operation creates a feedback loop that keeps the knowledge base compact:
+The compact operation creates a feedback loop that keeps the knowledge base compact:
 
 ```mermaid
 graph LR
@@ -363,7 +363,7 @@ Data is transmitted externally only when you explicitly choose a remote componen
 |-----------|-------------|---------------|
 | Vector store | Milvus Lite (default) | Milvus Server, Zilliz Cloud |
 | Embeddings | `local`, `ollama` | `openai`, `google`, `voyage` |
-| Flush LLM | Ollama (local) | OpenAI, Anthropic, Gemini |
+| Compact LLM | Ollama (local) | OpenAI, Anthropic, Gemini |
 
 ### API Key Handling
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ Options:
 Commands:
   config      Manage memsearch configuration.
   expand      Expand a memory chunk to show full context.
-  flush       Compress stored memories into a summary.
+  compact     Compress stored memories into a summary.
   index       Index markdown files from PATHS.
   reset       Drop all indexed data.
   search      Search indexed memory for QUERY.
@@ -34,7 +34,7 @@ Commands:
 | `memsearch index` | Scan directories and index markdown files into the vector store |
 | `memsearch search` | Semantic search across indexed chunks using natural language |
 | `memsearch watch` | Monitor directories and auto-index on file changes |
-| `memsearch flush` | Compress indexed chunks into an LLM-generated summary |
+| `memsearch compact` | Compress indexed chunks into an LLM-generated summary |
 | `memsearch expand` | Progressive disclosure L2: show full section around a chunk |
 | `memsearch transcript` | Progressive disclosure L3: view turns from a JSONL transcript |
 | `memsearch config` | Initialize, view, and modify configuration |
@@ -223,7 +223,7 @@ Watching 2 path(s) for changes... (Ctrl+C to stop)
 
 ---
 
-## `memsearch flush`
+## `memsearch compact`
 
 Use an LLM to compress all indexed chunks (or a subset) into a condensed markdown summary. The summary is appended to a daily log file at `memory/YYYY-MM-DD.md` inside the first configured path, keeping markdown as the single source of truth.
 
@@ -231,7 +231,7 @@ Use an LLM to compress all indexed chunks (or a subset) into a condensed markdow
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--source` | `-s` | *(all chunks)* | Only flush chunks from this specific source file |
+| `--source` | `-s` | *(all chunks)* | Only compact chunks from this specific source file |
 | `--llm-provider` | | `openai` | LLM backend for summarization (`openai`, `anthropic`, `gemini`) |
 | `--llm-model` | | provider default | Override the LLM model |
 | `--prompt` | | built-in template | Custom prompt template string (must contain `{chunks}` placeholder) |
@@ -252,11 +252,11 @@ Use an LLM to compress all indexed chunks (or a subset) into a condensed markdow
 
 ### Examples
 
-Flush all chunks using the default LLM (OpenAI):
+Compact all chunks using the default LLM (OpenAI):
 
 ```bash
-$ memsearch flush
-Flush complete. Summary:
+$ memsearch compact
+Compact complete. Summary:
 
 ## Key Decisions
 - Use Redis for session caching with 5-minute TTL
@@ -264,11 +264,11 @@ Flush complete. Summary:
 ...
 ```
 
-Flush only chunks from a specific source file:
+Compact only chunks from a specific source file:
 
 ```bash
-$ memsearch flush --source ./docs/old-notes.md
-Flush complete. Summary:
+$ memsearch compact --source ./docs/old-notes.md
+Compact complete. Summary:
 
 ## Old Notes Summary
 - Initial architecture decisions from January meeting...
@@ -277,19 +277,19 @@ Flush complete. Summary:
 Use Anthropic Claude for summarization:
 
 ```bash
-$ memsearch flush --llm-provider anthropic
+$ memsearch compact --llm-provider anthropic
 ```
 
 Use a custom prompt template:
 
 ```bash
-$ memsearch flush --prompt "Summarize these notes into action items:\n{chunks}"
+$ memsearch compact --prompt "Summarize these notes into action items:\n{chunks}"
 ```
 
 Use a prompt file for complex templates:
 
 ```bash
-$ memsearch flush --prompt-file ./prompts/compress.txt
+$ memsearch compact --prompt-file ./prompts/compress.txt
 ```
 
 ### Notes
@@ -483,7 +483,7 @@ Writing to: /home/user/.memsearch/config.toml
 -- Watch --
   Debounce (ms) [1500]:
 
--- Flush --
+-- Compact --
   LLM provider [openai]:
   LLM model (empty for default) []:
   Prompt file path (empty for built-in) []:
@@ -566,7 +566,7 @@ overlap_lines = 2
 [watch]
 debounce_ms = 1500
 
-[flush]
+[compact]
 llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
@@ -595,9 +595,9 @@ provider = "openai"
 | `chunking.max_chunk_size` | int | `1500` | Maximum chunk size in characters |
 | `chunking.overlap_lines` | int | `2` | Number of overlapping lines between adjacent chunks |
 | `watch.debounce_ms` | int | `1500` | File watcher debounce delay in milliseconds |
-| `flush.llm_provider` | string | `openai` | LLM provider for flush summarization |
-| `flush.llm_model` | string | `""` | Override LLM model (empty = provider default) |
-| `flush.prompt_file` | string | `""` | Path to a custom prompt template file |
+| `compact.llm_provider` | string | `openai` | LLM provider for compact summarization |
+| `compact.llm_model` | string | `""` | Override LLM model (empty = provider default) |
+| `compact.prompt_file` | string | `""` | Path to a custom prompt template file |
 
 ---
 
@@ -683,11 +683,11 @@ memsearch reads API keys and configuration overrides from environment variables.
 
 | Variable | Required By | Description |
 |----------|-------------|-------------|
-| `OPENAI_API_KEY` | `openai` embedding provider, `openai` LLM flush provider | OpenAI API key |
+| `OPENAI_API_KEY` | `openai` embedding provider, `openai` LLM compact provider | OpenAI API key |
 | `OPENAI_BASE_URL` | *(optional)* | Override the OpenAI API base URL (for proxies or compatible APIs) |
-| `GOOGLE_API_KEY` | `google` embedding provider, `gemini` LLM flush provider | Google AI API key |
+| `GOOGLE_API_KEY` | `google` embedding provider, `gemini` LLM compact provider | Google AI API key |
 | `VOYAGE_API_KEY` | `voyage` embedding provider | Voyage AI API key |
-| `ANTHROPIC_API_KEY` | `anthropic` LLM flush provider | Anthropic API key |
+| `ANTHROPIC_API_KEY` | `anthropic` LLM compact provider | Anthropic API key |
 | `OLLAMA_HOST` | `ollama` embedding provider *(optional)* | Ollama server URL (default: `http://localhost:11434`) |
 
 ### Configuration Overrides
@@ -704,9 +704,9 @@ All configuration keys can be set via environment variables using the pattern `M
 | `MEMSEARCH_CHUNKING_MAX_CHUNK_SIZE` | `chunking.max_chunk_size` | Max chunk size (chars) |
 | `MEMSEARCH_CHUNKING_OVERLAP_LINES` | `chunking.overlap_lines` | Overlap lines between chunks |
 | `MEMSEARCH_WATCH_DEBOUNCE_MS` | `watch.debounce_ms` | Debounce delay (ms) |
-| `MEMSEARCH_FLUSH_LLM_PROVIDER` | `flush.llm_provider` | LLM provider for flush |
-| `MEMSEARCH_FLUSH_LLM_MODEL` | `flush.llm_model` | LLM model for flush |
-| `MEMSEARCH_FLUSH_PROMPT_FILE` | `flush.prompt_file` | Path to custom prompt file |
+| `MEMSEARCH_COMPACT_LLM_PROVIDER` | `compact.llm_provider` | LLM provider for compact |
+| `MEMSEARCH_COMPACT_LLM_MODEL` | `compact.llm_model` | LLM model for compact |
+| `MEMSEARCH_COMPACT_PROMPT_FILE` | `compact.prompt_file` | Path to custom prompt file |
 
 ### Examples
 
@@ -719,10 +719,10 @@ $ memsearch search "database schema"
 $ export MEMSEARCH_MILVUS_URI=http://10.0.0.5:19530
 $ memsearch index ./docs/
 
-# Use Google for embedding via env var, Anthropic for flush via CLI
+# Use Google for embedding via env var, Anthropic for compact via CLI
 $ export MEMSEARCH_EMBEDDING_PROVIDER=google
 $ export GOOGLE_API_KEY=AIza...
-$ memsearch flush --llm-provider anthropic
+$ memsearch compact --llm-provider anthropic
 ```
 
 ### Embedding Provider Reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ $ pip install "memsearch[google]"      # Google Gemini embeddings
 $ pip install "memsearch[voyage]"      # Voyage AI embeddings
 $ pip install "memsearch[ollama]"      # Ollama (local, no API key)
 $ pip install "memsearch[local]"       # sentence-transformers (local, no API key)
-$ pip install "memsearch[anthropic]"   # Anthropic (for flush/summarization LLM)
+$ pip install "memsearch[anthropic]"   # Anthropic (for compact/summarization LLM)
 $ pip install "memsearch[all]"         # Everything above
 ```
 
@@ -295,13 +295,13 @@ Set the environment variable for your chosen embedding provider. memsearch reads
 | Voyage AI | `VOYAGE_API_KEY` | Requires `memsearch[voyage]` |
 | Ollama | `OLLAMA_HOST` (optional) | Defaults to `http://localhost:11434` |
 | Local (sentence-transformers) | -- | No API key needed |
-| Anthropic | `ANTHROPIC_API_KEY` | Used by `flush` summarization only |
+| Anthropic | `ANTHROPIC_API_KEY` | Used by `compact` summarization only |
 
 ```bash
 $ export OPENAI_API_KEY="sk-..."         # OpenAI embeddings (default)
 $ export GOOGLE_API_KEY="..."            # Google Gemini embeddings
 $ export VOYAGE_API_KEY="..."            # Voyage AI embeddings
-$ export ANTHROPIC_API_KEY="..."         # Anthropic (for flush summarization)
+$ export ANTHROPIC_API_KEY="..."         # Anthropic (for compact summarization)
 ```
 
 ---
@@ -472,7 +472,7 @@ overlap_lines = 2
 [watch]
 debounce_ms = 1500
 
-[flush]
+[compact]
 llm_provider = "openai"
 llm_model = ""
 prompt_file = ""

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ The vector store is just a derived index — rebuildable anytime.
 - **OpenClaw's memory, everywhere** -- markdown as the single source of truth
 - **Smart dedup** -- SHA-256 content hashing means unchanged content is never re-embedded
 - **Live sync** -- file watcher auto-indexes on changes, deletes stale chunks
-- **Memory flush** -- LLM-powered summarization compresses old memories
+- **Memory compact** -- LLM-powered summarization compresses old memories
 - **Claude Code plugin included** -- persistent memory across sessions with zero config
 
 ---

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -35,9 +35,9 @@ _PARAM_MAP = {
     "collection": "milvus.collection",
     "milvus_uri": "milvus.uri",
     "milvus_token": "milvus.token",
-    "llm_provider": "flush.llm_provider",
-    "llm_model": "flush.llm_model",
-    "prompt_file": "flush.prompt_file",
+    "llm_provider": "compact.llm_provider",
+    "llm_model": "compact.llm_model",
+    "prompt_file": "compact.prompt_file",
     "max_chunk_size": "chunking.max_chunk_size",
     "overlap_lines": "chunking.overlap_lines",
     "debounce_ms": "watch.debounce_ms",
@@ -389,13 +389,13 @@ def watch(
 
 
 @cli.command()
-@click.option("--source", "-s", default=None, help="Only flush chunks from this source.")
+@click.option("--source", "-s", default=None, help="Only compact chunks from this source.")
 @click.option("--llm-provider", default=None, help="LLM for summarization.")
 @click.option("--llm-model", default=None, help="Override LLM model.")
 @click.option("--prompt", default=None, help="Custom prompt template (must contain {chunks}).")
 @click.option("--prompt-file", default=None, type=click.Path(exists=True), help="Read prompt template from file.")
 @_common_options
-def flush(
+def compact(
     source: str | None,
     llm_provider: str | None,
     llm_model: str | None,
@@ -418,22 +418,22 @@ def flush(
     ))
 
     prompt_template = prompt
-    if cfg.flush.prompt_file and not prompt_template:
-        prompt_template = Path(cfg.flush.prompt_file).read_text(encoding="utf-8")
+    if cfg.compact.prompt_file and not prompt_template:
+        prompt_template = Path(cfg.compact.prompt_file).read_text(encoding="utf-8")
 
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        summary = _run(ms.flush(
+        summary = _run(ms.compact(
             source=source,
-            llm_provider=cfg.flush.llm_provider,
-            llm_model=cfg.flush.llm_model or None,
+            llm_provider=cfg.compact.llm_provider,
+            llm_model=cfg.compact.llm_model or None,
             prompt_template=prompt_template,
         ))
         if summary:
-            click.echo("Flush complete. Summary:\n")
+            click.echo("Compact complete. Summary:\n")
             click.echo(summary)
         else:
-            click.echo("No chunks to flush.")
+            click.echo("No chunks to compact.")
     finally:
         ms.close()
 
@@ -558,17 +558,17 @@ def config_init(project: bool) -> None:
         "  Debounce (ms)", default=current.watch.debounce_ms, type=int,
     )
 
-    # Flush
-    click.echo("\n── Flush ──")
-    result["flush"] = {}
-    result["flush"]["llm_provider"] = click.prompt(
-        "  LLM provider", default=current.flush.llm_provider,
+    # Compact
+    click.echo("\n── Compact ──")
+    result["compact"] = {}
+    result["compact"]["llm_provider"] = click.prompt(
+        "  LLM provider", default=current.compact.llm_provider,
     )
-    result["flush"]["llm_model"] = click.prompt(
-        "  LLM model (empty for default)", default=current.flush.llm_model,
+    result["compact"]["llm_model"] = click.prompt(
+        "  LLM model (empty for default)", default=current.compact.llm_model,
     )
-    result["flush"]["prompt_file"] = click.prompt(
-        "  Prompt file path (empty for built-in)", default=current.flush.prompt_file,
+    result["compact"]["prompt_file"] = click.prompt(
+        "  Prompt file path (empty for built-in)", default=current.compact.prompt_file,
     )
 
     save_config(result, target)

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -1,4 +1,4 @@
-"""Memory flush — compress and summarize chunks using an LLM.
+"""Memory compact — compress and summarize chunks using an LLM.
 
 Supports OpenAI (default), Anthropic, and Gemini as LLM backends.
 API keys are read from environment variables:
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-FLUSH_PROMPT = """\
+COMPACT_PROMPT = """\
 You are a knowledge compression assistant. Given the following chunks of text \
 from a knowledge base, create a concise but comprehensive summary that preserves \
 all key facts, decisions, code patterns, and actionable insights.
@@ -24,7 +24,7 @@ Write a clear, well-structured markdown summary. Use headings and bullet points.
 Preserve technical details, code snippets, and specific decisions."""
 
 
-async def flush_chunks(
+async def compact_chunks(
     chunks: list[dict[str, Any]],
     *,
     llm_provider: str = "openai",
@@ -43,7 +43,7 @@ async def flush_chunks(
         Override the default model for the provider.
     prompt_template:
         Custom prompt template.  Must contain ``{chunks}`` placeholder.
-        Defaults to the built-in ``FLUSH_PROMPT``.
+        Defaults to the built-in ``COMPACT_PROMPT``.
 
     Returns
     -------
@@ -51,15 +51,15 @@ async def flush_chunks(
         The compressed summary markdown.
     """
     combined = "\n\n---\n\n".join(c["content"] for c in chunks)
-    template = prompt_template or FLUSH_PROMPT
+    template = prompt_template or COMPACT_PROMPT
     prompt = template.format(chunks=combined)
 
     if llm_provider == "openai":
-        return await _flush_openai(prompt, model or "gpt-4o-mini")
+        return await _compact_openai(prompt, model or "gpt-4o-mini")
     elif llm_provider == "anthropic":
-        return await _flush_anthropic(prompt, model or "claude-sonnet-4-5-20250929")
+        return await _compact_anthropic(prompt, model or "claude-sonnet-4-5-20250929")
     elif llm_provider == "gemini":
-        return await _flush_gemini(prompt, model or "gemini-2.0-flash")
+        return await _compact_gemini(prompt, model or "gemini-2.0-flash")
     else:
         raise ValueError(
             f"Unknown LLM provider {llm_provider!r}. "
@@ -67,7 +67,7 @@ async def flush_chunks(
         )
 
 
-async def _flush_openai(prompt: str, model: str) -> str:
+async def _compact_openai(prompt: str, model: str) -> str:
     import openai
 
     kwargs: dict = {}
@@ -84,7 +84,7 @@ async def _flush_openai(prompt: str, model: str) -> str:
     return resp.choices[0].message.content or ""
 
 
-async def _flush_anthropic(prompt: str, model: str) -> str:
+async def _compact_anthropic(prompt: str, model: str) -> str:
     import anthropic
 
     client = anthropic.AsyncAnthropic()  # reads ANTHROPIC_API_KEY
@@ -96,7 +96,7 @@ async def _flush_anthropic(prompt: str, model: str) -> str:
     return resp.content[0].text
 
 
-async def _flush_gemini(prompt: str, model: str) -> str:
+async def _compact_gemini(prompt: str, model: str) -> str:
     from google import genai
 
     client = genai.Client()  # reads GOOGLE_API_KEY

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -35,7 +35,7 @@ class EmbeddingConfig:
 
 
 @dataclass
-class FlushConfig:
+class CompactConfig:
     llm_provider: str = "openai"
     llm_model: str = ""
     prompt_file: str = ""
@@ -56,7 +56,7 @@ class WatchConfig:
 class MemSearchConfig:
     milvus: MilvusConfig = field(default_factory=MilvusConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
-    flush: FlushConfig = field(default_factory=FlushConfig)
+    compact: CompactConfig = field(default_factory=CompactConfig)
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
 
@@ -65,7 +65,7 @@ class MemSearchConfig:
 _SECTION_CLASSES: dict[str, type] = {
     "milvus": MilvusConfig,
     "embedding": EmbeddingConfig,
-    "flush": FlushConfig,
+    "compact": CompactConfig,
     "chunking": ChunkingConfig,
     "watch": WatchConfig,
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ def test_default_config():
     assert cfg.chunking.max_chunk_size == 1500
     assert cfg.chunking.overlap_lines == 2
     assert cfg.watch.debounce_ms == 1500
-    assert cfg.flush.llm_provider == "openai"
+    assert cfg.compact.llm_provider == "openai"
 
 
 def test_load_toml_file(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Rename `flush` → `compact` across the entire codebase, CLI, config, and documentation
- `flush.py` → `compact.py`, `MemSearch.flush()` → `MemSearch.compact()`
- CLI: `memsearch flush` → `memsearch compact`
- Config: `[flush]` → `[compact]`, env vars `MEMSEARCH_FLUSH_*` → `MEMSEARCH_COMPACT_*`
- All docs (README, cli.md, architecture.md, getting-started.md, index.md, ccplugin/README.md) updated

## Test plan
- [x] All 35 tests pass
- [x] `memsearch --help` shows `compact` command
- [x] Milvus internal "segment flush" terminology preserved (not renamed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)