### PR TITLE
Add plugin marketplace and update install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "memsearch",
+  "version": "1.0.0",
+  "description": "Semantic memory search plugin for Claude Code — markdown-first, backed by Milvus",
+  "owner": {
+    "name": "Zilliz",
+    "email": "support@zilliz.com"
+  },
+  "plugins": [
+    {
+      "name": "memsearch",
+      "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
+      "version": "0.1.2",
+      "source": "./ccplugin",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -81,10 +81,24 @@ https://github.com/user-attachments/assets/31de76cc-81a8-4462-a47d-bd9c394d33e3
 memsearch ships with a **[Claude Code plugin](ccplugin/README.md)** — a real-world example of OpenClaw's memory running outside OpenClaw. It gives Claude **automatic persistent memory** across sessions: every session is summarized to markdown, every prompt triggers a semantic search, and a background watcher keeps the index in sync. No commands to learn, no manual saving — just install and go.
 
 ```bash
-# Install memsearch, then launch Claude with the plugin
+# 1. Install the memsearch CLI
 pip install memsearch
-claude --plugin-dir ./ccplugin
+
+# 2. In Claude Code, add the marketplace and install the plugin
+/plugin marketplace add zilliztech/memsearch
+/plugin install memsearch@memsearch
 ```
+
+<details>
+<summary>🔧 <b>Development mode</b> — install from local clone</summary>
+
+```bash
+git clone https://github.com/zilliztech/memsearch.git
+pip install memsearch
+claude --plugin-dir ./memsearch/ccplugin
+```
+
+</details>
 
 ```
   Session start ──▶ start memsearch watch (singleton) ──▶ inject recent memories

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -3,7 +3,9 @@
 **Automatic persistent memory for Claude Code.** No commands to learn, no manual saving — just install the plugin and Claude remembers what you worked on across sessions.
 
 ```bash
-claude --plugin-dir /path/to/memsearch/ccplugin
+# In Claude Code:
+/plugin marketplace add zilliztech/memsearch
+/plugin install memsearch@memsearch
 ```
 
 ## 💡 Design Principles
@@ -18,21 +20,33 @@ The result: a memory system that's **simple enough to understand in 5 minutes**,
 
 ## 🚀 Quick Start
 
+### Install from Marketplace (recommended)
+
 ```bash
-# 1. Install memsearch
+# 1. Install the memsearch CLI
 pip install memsearch
 
-# 2. Initialize config (if first time)
+# 2. (Optional) Initialize config
 memsearch config init
 
-# 3. Launch Claude with the plugin
-claude --plugin-dir /path/to/memsearch/ccplugin
+# 3. In Claude Code, add the marketplace and install the plugin
+/plugin marketplace add zilliztech/memsearch
+/plugin install memsearch@memsearch
 
 # 4. Have a conversation, then exit. Check your memories:
 cat .memsearch/memory/$(date +%Y-%m-%d).md
 
 # 5. Start a new session — Claude remembers!
-claude --plugin-dir /path/to/memsearch/ccplugin
+```
+
+### Development mode
+
+For contributors or if you want to modify the plugin:
+
+```bash
+git clone https://github.com/zilliztech/memsearch.git
+pip install memsearch
+claude --plugin-dir ./memsearch/ccplugin
 ```
 
 ## ⚙️ How It Works

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -20,29 +20,34 @@ The result: Claude has a persistent, searchable, ever-growing memory -- without 
 
 ## Quick Start
 
+### Install from Marketplace (recommended)
+
 ```bash
-# 1. Install memsearch
+# 1. Install the memsearch CLI
 pip install memsearch
 
-# 2. Initialize config (first time only)
+# 2. (Optional) Initialize config
 memsearch config init
 
-# 3. Launch Claude Code with the plugin
-claude --plugin-dir /path/to/memsearch/ccplugin
+# 3. In Claude Code, add the marketplace and install the plugin
+/plugin marketplace add zilliztech/memsearch
+/plugin install memsearch@memsearch
 
 # 4. Have a conversation, then exit. Check your memories:
 cat .memsearch/memory/$(date +%Y-%m-%d).md
 
 # 5. Start a new session -- Claude automatically remembers!
-claude --plugin-dir /path/to/memsearch/ccplugin
 ```
 
-!!! tip "Finding the plugin directory"
-    If you installed memsearch via pip, the ccplugin directory is inside the package. You can also clone the repo and point to `ccplugin/` directly:
-    ```bash
-    git clone https://github.com/zilliztech/memsearch.git
-    claude --plugin-dir ./memsearch/ccplugin
-    ```
+### Development mode
+
+For contributors or if you want to modify the plugin:
+
+```bash
+git clone https://github.com/zilliztech/memsearch.git
+pip install memsearch
+claude --plugin-dir ./memsearch/ccplugin
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` for Claude Code marketplace distribution
- Update install instructions in README, docs, and ccplugin README to use marketplace as the primary install method (`/plugin marketplace add zilliztech/memsearch`)
- Add development mode install (`claude --plugin-dir`) as alternative for contributors

## Install flow (after this PR)

```bash
# 1. Install the memsearch CLI
pip install memsearch

# 2. In Claude Code:
/plugin marketplace add zilliztech/memsearch
/plugin install memsearch@memsearch
```

## Test plan
- [ ] Verify marketplace.json schema matches official format (`anthropics/claude-code`)
- [ ] Verify `/plugin marketplace add zilliztech/memsearch` works in Claude Code
- [ ] Verify `/plugin install memsearch@memsearch` installs the plugin from `./ccplugin`
- [ ] Verify development mode (`claude --plugin-dir ./memsearch/ccplugin`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)