### PR TITLE
Slim down README, link to docs site

### DIFF
--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -26,17 +26,22 @@ The result: a memory system that's **simple enough to understand in 5 minutes**,
 # 1. Install the memsearch CLI
 pip install memsearch
 
-# 2. (Optional) Initialize config
+# 2. Set your embedding API key (OpenAI is the default provider)
+export OPENAI_API_KEY="sk-..."
+
+# 3. (Optional) Initialize config
 memsearch config init
 
-# 3. In Claude Code, add the marketplace and install the plugin
+# 4. In Claude Code, add the marketplace and install the plugin
 /plugin marketplace add zilliztech/memsearch
 /plugin install memsearch
 
-# 4. Have a conversation, then exit. Check your memories:
+# 5. Restart Claude Code for the plugin to take effect, then start chatting:
+claude
 cat .memsearch/memory/$(date +%Y-%m-%d).md
 
-# 5. Start a new session — Claude remembers!
+# 6. Start a new session — Claude remembers!
+claude
 ```
 
 ### Development mode

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -291,7 +291,7 @@ This means:
 
 ## Comparison with claude-mem
 
-[claude-mem](https://github.com/nicobailey/claude-mem) is another memory solution for Claude Code. Here is a detailed comparison:
+[claude-mem](https://github.com/thedotmack/claude-mem) is another memory solution for Claude Code. Here is a detailed comparison:
 
 | Aspect | memsearch | claude-mem |
 |--------|-----------|------------|


### PR DESCRIPTION
## Summary
- Replace verbose CLI Usage / Configuration / Milvus Backend / Embedding Providers / OpenClaw Compatibility sections with concise summaries + links to docs site (462 → 355 lines, -23%)
- Add missing `OPENAI_API_KEY` step and `claude` command to plugin quick start (README + ccplugin/README)
- Add restart note after `/plugin install`
- Fix tagline: "extracts" → "inspired by" to match docs/index.md
- Fix broken claude-mem GitHub link (`nicobailey` → `thedotmack`)

## Test plan
- [ ] Verify all 4 docs site links resolve correctly
- [ ] README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)