### PR TITLE
Make top navigation tabs sticky on scroll

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
     accent: deep orange
   features:
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
     - navigation.top
     - search.highlight


### PR DESCRIPTION
## Summary
- Add `navigation.tabs.sticky` feature to `mkdocs.yml`
- Top-level page tabs now remain visible when scrolling down, so users don't have to scroll back to the top to navigate between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)