### PR TITLE
Fix watch not indexing existing files on startup

### DIFF
--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -94,4 +94,7 @@ fi
   echo ""
 } >> "$MEMORY_FILE"
 
+# Index immediately — don't rely on watch (which may be killed by SessionEnd before debounce fires)
+run_memsearch index "$MEMORY_DIR"
+
 echo '{}'

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -134,7 +134,7 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
     - Extracts tool names with input summaries
     - Skips `file-history-snapshot` entries
 4. **Summarizes with Haiku.** Pipes the parsed transcript to `claude -p --model haiku --no-session-persistence` with a system prompt that requests 3-8 bullet points focusing on decisions, problems solved, code changes, and key findings.
-5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. The watcher detects the file change and auto-indexes the new content.
+5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. Then explicitly runs `memsearch index` to ensure the new content is indexed immediately, rather than relying on the watcher's debounce timer (which may not fire before SessionEnd kills the watcher).
 
 #### SessionEnd
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,7 +182,7 @@ $ memsearch search "database migrations" --provider google
 
 ## `memsearch watch`
 
-Start a long-running file watcher that monitors directories for markdown file changes. When a `.md` or `.markdown` file is created or modified, it is automatically re-indexed. When a file is deleted, its chunks are removed from the store.
+Start a long-running file watcher that monitors directories for markdown file changes. On startup, all existing markdown files are indexed first (dedup ensures no wasted API calls for unchanged content). Then the watcher monitors for changes: when a `.md` or `.markdown` file is created or modified, it is automatically re-indexed. When a file is deleted, its chunks are removed from the store.
 
 ### Options
 
@@ -202,6 +202,7 @@ Watch a single directory:
 
 ```bash
 $ memsearch watch ./memory/
+Indexed 8 chunks.
 Watching 1 path(s) for changes... (Ctrl+C to stop)
 Indexed 3 chunks from /home/user/docs/2026-02-11.md
 Removed chunks for /home/user/docs/old-draft.md
@@ -218,6 +219,7 @@ Watching 2 path(s) for changes... (Ctrl+C to stop)
 
 ### Notes
 
+- **Initial index on startup.** The watcher indexes all existing files before it starts monitoring. Content-hash dedup means unchanged files are skipped with zero API calls — only genuinely new or modified content is embedded.
 - **Debounce.** Editors that write files in multiple steps (e.g., write temp file, then rename) can trigger several events in quick succession. The debounce window collapses these into one re-index operation.
 - **Recursive.** The watcher monitors all subdirectories recursively.
 - **Singleton behavior.** Only one watcher process should run per directory set. Running multiple watchers on the same paths will cause duplicate indexing work (though dedup by content hash means the index stays consistent).

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ Redis config for production: enable AOF persistence, set maxmemory-policy
 to volatile-lfu, bind to 127.0.0.1 only...
 
 $ memsearch watch ./memory/
+Indexed 8 chunks.
 Watching 1 path(s) for changes... (Ctrl+C to stop)
 Indexed 2 chunks from memory/2026-02-09.md
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.1.5"
+version = "0.1.6"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -394,6 +394,11 @@ def watch(
     ))
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg))
 
+    # Initial index: ensure existing files are indexed before watching
+    n = _run(ms.index())
+    if n:
+        click.echo(f"Indexed {n} chunks.")
+
     def _on_event(event_type: str, summary: str, file_path) -> None:
         click.echo(summary)
 


### PR DESCRIPTION
## Summary

- **CLI `watch`**: run initial `index()` before starting the file watcher, so pre-existing files are indexed on startup
- **ccplugin `stop.sh`**: explicitly call `memsearch index` after writing the session summary, instead of relying on the watch debounce timer (which may not fire before SessionEnd kills the watcher)
- Bump version to 0.1.6

## Bug

`memsearch watch` only reacted to file changes after startup. Files that already existed (e.g. memory logs from previous sessions) were never indexed, causing the ccplugin to report 0 search results even though memory files were present on disk.

**Root causes:**
1. The CLI watch command called `ms.watch()` without first calling `ms.index()`. The watchdog Observer only fires on new filesystem events — pre-existing files were invisible to it.
2. The ccplugin's Stop hook (async, 120s) writes session summaries to markdown, but SessionEnd may kill the watch process before the 1500ms debounce fires, so summaries were never indexed.

## Fix

The initial `index()` call is safe to run unconditionally — content-hash dedup ensures unchanged chunks are skipped with zero embedding API calls.

## Test plan

- [x] All 33 tests pass
- [ ] Manual: `memsearch watch ./memory/` now prints `Indexed N chunks.` on startup
- [ ] Manual: ccplugin session summary is searchable immediately after session end

🤖 Generated with [Claude Code](https://claude.com/claude-code)