### PR TITLE
Rename ms to mem in docs, examples, and tests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,17 +93,17 @@ import asyncio
 from memsearch import MemSearch
 
 async def main():
-    ms = MemSearch(paths=["./memory/"])
+    mem = MemSearch(paths=["./memory/"])
 
     # Index all markdown files (skips unchanged content automatically)
-    await ms.index()
+    await mem.index()
 
     # Semantic search -- returns ranked results with source attribution
-    results = await ms.search("how to configure Redis?", top_k=5)
+    results = await mem.search("how to configure Redis?", top_k=5)
     for r in results:
         print(f"[{r['score']:.2f}] {r['source']} -- {r['content'][:80]}")
 
-    ms.close()
+    mem.close()
 
 asyncio.run(main())
 ```
@@ -128,14 +128,14 @@ $ memsearch search "that article about distributed consensus"
 Give your AI agent persistent, searchable memory. The agent writes observations to markdown files; memsearch indexes them and retrieves relevant context on the next turn. This is exactly how [OpenClaw](https://github.com/openclaw/openclaw) manages memory, and memsearch ships with a ready-made [Claude Code plugin](claude-plugin.md) that demonstrates the pattern.
 
 ```python
-ms = MemSearch(paths=["./agent-memory/"])
+mem = MemSearch(paths=["./agent-memory/"])
 
 # Agent recalls relevant past experiences before responding
-memories = await ms.search(user_question, top_k=3)
+memories = await mem.search(user_question, top_k=3)
 
 # Agent saves new knowledge after responding
 save_to_markdown("./agent-memory/", today, summary)
-await ms.index()
+await mem.index()
 ```
 
 ### Team Knowledge Sharing
@@ -143,7 +143,7 @@ await ms.index()
 Deploy a shared Milvus server and point multiple team members (or agents) at it. Everyone indexes their own markdown files into the same collection, creating a shared searchable knowledge base.
 
 ```python
-ms = MemSearch(
+mem = MemSearch(
     paths=["./docs/"],
     milvus_uri="http://milvus.internal:19530",
     milvus_token="root:Milvus",

--- a/examples/test_e2e.py
+++ b/examples/test_e2e.py
@@ -2,19 +2,19 @@ import asyncio
 import time
 from memsearch import MemSearch
 
-ms = MemSearch(
+mem = MemSearch(
     paths=["./examples/sample-memory/"],
     milvus_uri="http://10.100.30.11:19530",
 )
 
 # 首先索引现有文件
-asyncio.run(ms.index())
+asyncio.run(mem.index())
 
 # 开始监视
 def on_event(event_type, summary, file_path):
     print(f"[{event_type}] {summary}")
 
-watcher = ms.watch(on_event=on_event)
+watcher = mem.watch(on_event=on_event)
 print("Watching for changes... (Ctrl+C to stop)")
 print("Try editing examples/sample-memory/memory/2026-02-08.md in another terminal")
 
@@ -23,4 +23,4 @@ try:
         time.sleep(1)
 except KeyboardInterrupt:
     watcher.stop()
-    ms.close()
+    mem.close()

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -295,8 +295,8 @@ class MemSearch:
         -------
         ::
 
-            ms = MemSearch(paths=["./docs/"])
-            watcher = ms.watch()
+            mem = MemSearch(paths=["./docs/"])
+            watcher = mem.watch()
             # ... watcher auto-indexes in background ...
             watcher.stop()
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def ms(tmp_path: Path):
+def mem(tmp_path: Path):
     from memsearch.core import MemSearch
 
     m = MemSearch(
@@ -46,12 +46,12 @@ def sample_dir(tmp_path: Path) -> Path:
 
 
 @pytest.mark.asyncio
-async def test_index_and_search(ms, sample_dir: Path):
-    ms._paths = [str(sample_dir)]
-    n = await ms.index()
+async def test_index_and_search(mem, sample_dir: Path):
+    mem._paths = [str(sample_dir)]
+    n = await mem.index()
     assert n > 0
 
-    results = await ms.search("virtual environment python")
+    results = await mem.search("virtual environment python")
     assert len(results) > 0
     # The top result should be about Python / virtual environments
     top = results[0]
@@ -60,9 +60,9 @@ async def test_index_and_search(ms, sample_dir: Path):
 
 
 @pytest.mark.asyncio
-async def test_index_single_file(ms, sample_dir: Path):
-    n = await ms.index_file(sample_dir / "notes.md")
+async def test_index_single_file(mem, sample_dir: Path):
+    n = await mem.index_file(sample_dir / "notes.md")
     assert n > 0
 
-    results = await ms.search("list comprehension")
+    results = await mem.search("list comprehension")
     assert len(results) > 0


### PR DESCRIPTION
## Summary

- Rename `ms` variable to `mem` in all user-facing code for clarity
- `ms` is not immediately obvious as a MemSearch instance; `mem` is self-explanatory

## Changed files

| File | Changes |
|------|---------|
| `docs/index.md` | 3 code blocks |
| `docs/getting-started.md` | All code examples + mermaid diagram |
| `src/memsearch/core.py` | Docstring example in `watch()` |
| `examples/test_e2e.py` | All usages |
| `tests/test_core.py` | Fixture name + all usages |

Internal CLI code (`cli.py`) is unchanged — those variables are not visible to users.

## Test plan

- [x] All 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)