### PR TITLE
Add real-world examples to progressive disclosure docs

### DIFF
--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -166,46 +166,212 @@ On every user prompt, the `UserPromptSubmit` hook injects the top-3 semantic sea
 
 This happens transparently -- no action from Claude or the user is required.
 
-**Example injection:**
+**Example injection** (this is what Claude sees before processing each message):
 
 ```
 ## Relevant Memories
-- [memory/2026-02-08.md:Session 14:30]  Implemented caching system with Redis L1
-  and in-process LRU L2. Fixed N+1 query issue in order-service using selectinload...
-  `chunk_hash: a1b2c3d4e5f6`
+- [.memsearch/memory/2026-02-12.md:04:16]  使用远程 Milvus Server 测试
+  `claude -p` 模式，索引了 4 个 chunks，search 正常返回相关结果。确认
+  `claude -p` 模式不触发任何 hooks...
+  `chunk_hash: 47b5475122b992b6`
+- [.memsearch/memory/2026-02-11.md:11:02]  修复 watch 启动时不索引已有文件的
+  问题。ccplugin stop.sh 增加显式 memsearch index 调用...
+  `chunk_hash: 31cbaf74856ad1ed`
 ```
+
+The preview is enough for Claude to answer most follow-up questions. But when it needs the full picture, it moves to L2.
 
 ### L2: On-Demand Expand
 
-When an L1 preview is not enough, Claude can run the `memsearch expand` command to retrieve the full markdown section surrounding a chunk:
+When an L1 preview is not enough, Claude runs `memsearch expand` to retrieve the **full markdown section** surrounding a chunk:
 
 ```bash
-# Show full section
-memsearch expand a1b2c3d4e5f6
-
-# JSON output with anchor metadata (for programmatic L3 drill-down)
-memsearch expand a1b2c3d4e5f6 --json-output
-
-# Show N lines of context before/after instead of the full section
-memsearch expand a1b2c3d4e5f6 --lines 10
+$ memsearch expand 47b5475122b992b6
 ```
 
-The output includes the full markdown content plus the embedded anchor metadata, which links to the original session transcript.
+**Example output:**
+
+```
+Source: .memsearch/memory/2026-02-12.md (lines 96-111)
+Heading: 04:16
+Session: 433f8bc3-a5a8-46a2-8285-71941dc96ad0
+Turn: 8ee6995b-2e7c-4e11-92e2-6f07fdfb55c7
+Transcript: /home/user/.claude/projects/.../433f8bc3...46a0.jsonl
+
+### 04:13
+<!-- session:433f8bc3... turn:0a0df619... transcript:/.../433f8bc3...46a0.jsonl -->
+- `claude -p` 模式不触发 SessionStart 和 UserPromptSubmit hooks
+- hooks 依赖正常交互模式
+- Milvus Server 可用，连接到 http://10.100.30.11:19530 验证通过
+- 本地 Milvus Lite 测试完成，index 了 4 个 chunks
+
+### 04:16
+<!-- session:433f8bc3... turn:8ee6995b... transcript:/.../433f8bc3...46a0.jsonl -->
+- 使用远程 Milvus Server 测试 `claude -p` 模式，索引了 4 个 chunks
+- 确认 `claude -p` 模式不触发任何 hooks
+- 正确的测试方式应该用交互模式 `claude` 而非 `-p` 标志
+- 远程 Milvus Server 可用，collection stats 显示 0（已知的 flush 延迟问题）
+```
+
+Now Claude sees the full context including the neighboring `### 04:13` section. The embedded `<!-- session:... -->` anchors link to the original conversation -- if Claude needs to go even deeper, it moves to L3.
+
+Additional flags:
+
+```bash
+# JSON output with anchor metadata (for programmatic L3 drill-down)
+memsearch expand 47b5475122b992b6 --json-output
+
+# Show N lines of context before/after instead of the full section
+memsearch expand 47b5475122b992b6 --lines 10
+```
 
 ### L3: Transcript Drill-Down
 
-When Claude needs the original conversation verbatim -- for instance, to recall exact code snippets or error messages -- it can drill into the JSONL transcript:
+When Claude needs the original conversation verbatim -- for instance, to recall exact code snippets, error messages, or tool outputs -- it drills into the JSONL transcript.
+
+**List all turns** in a session:
 
 ```bash
-# Show an index of all turns in a session
-memsearch transcript /path/to/session.jsonl
-
-# Show context around a specific turn (prefix match on UUID)
-memsearch transcript /path/to/session.jsonl --turn bffc0c1b --context 3
-
-# JSON output for programmatic use
-memsearch transcript /path/to/session.jsonl --turn bffc0c1b --json-output
+$ memsearch transcript /path/to/session.jsonl
 ```
+
+```
+All turns (73):
+
+  6d6210b7-b84  15:15:14  Implement the following plan: ...              [20 tools]
+  3075ee94-0f6  15:20:10  这个ccplugin的例子还要讲要准备 API key...
+  8e45ce0d-9a0  15:23:16  /plugin install memsearch 后面要注释下...       [2 tools]
+  53f5cac3-6d9  15:27:07  claude-mem 链接好像打不开...                    [9 tools]
+  c708b40c-8f8  15:30:45  这些改动提交下push然后提个pr...                [10 tools]
+```
+
+Each line shows the turn UUID prefix, timestamp, content preview, and how many tool calls occurred.
+
+**Drill into a specific turn** with surrounding context:
+
+```bash
+$ memsearch transcript /path/to/session.jsonl --turn 6d6210b7 --context 1
+```
+
+```
+Showing 2 turns around 6d6210b7:
+
+>>> [15:15:14] 6d6210b7
+Implement the following plan:
+
+# Plan: Slim down README, link to docs site
+
+## Context
+README 中 CLI Usage、Configuration、Embedding Providers 等章节与文档站
+内容高度重复。精简 README 保留核心亮点，详细内容链接到文档站。
+...
+
+**Assistant**: 现在我来看看文档站的锚点，确保链接正确。
+```
+
+This recovers the full original conversation -- user messages, assistant responses, and tool call summaries -- so Claude can recall exactly what happened during a past session.
+
+```bash
+# JSON output for programmatic use
+memsearch transcript /path/to/session.jsonl --turn 6d6210b7 --json-output
+```
+
+### What the JSONL Looks Like
+
+The transcript files are standard [JSON Lines](https://jsonlines.org/) -- one JSON object per line. Claude Code writes every message, tool call, and tool result as a separate line. Here is what the key message types look like (abbreviated for readability):
+
+**User message** (human input):
+
+```json
+{
+  "type": "user",
+  "uuid": "6d6210b7-b841-4cd7-a97f-e3c8bb185d06",
+  "parentUuid": "8404eaca-3926-4765-bcb9-6ca4befae466",
+  "sessionId": "433f8bc3-a5a8-46a2-8285-71941dc96ad0",
+  "timestamp": "2026-02-11T15:15:14.284Z",
+  "message": {
+    "role": "user",
+    "content": "Implement the following plan: ..."
+  }
+}
+```
+
+**Assistant message** (text response):
+
+```json
+{
+  "type": "assistant",
+  "uuid": "32da9357-1efe-4985-8a6e-4864bbf58951",
+  "parentUuid": "d99f255c-6ac7-43fa-bcc8-c0dabc4c65cf",
+  "sessionId": "433f8bc3-a5a8-46a2-8285-71941dc96ad0",
+  "timestamp": "2026-02-11T15:15:36.510Z",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {"type": "text", "text": "好的，让我开始编辑 README.md。"}
+    ]
+  }
+}
+```
+
+**Assistant message** (tool call):
+
+```json
+{
+  "type": "assistant",
+  "uuid": "35fa9333-02ff-4b07-9036-ec0e3e290602",
+  "parentUuid": "7ab167db-9a57-4f51-b5d3-eb63a2e6a5ad",
+  "sessionId": "433f8bc3-a5a8-46a2-8285-71941dc96ad0",
+  "timestamp": "2026-02-11T15:15:20.992Z",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "toolu_014CPfherKZMyYbbG5VT4dyX",
+        "name": "Read",
+        "input": {"file_path": "/path/to/README.md"}
+      }
+    ]
+  }
+}
+```
+
+**Tool result** (returned to assistant as a user message):
+
+```json
+{
+  "type": "user",
+  "uuid": "7dd5ac66-c848-4e39-952a-511c94ac66f2",
+  "parentUuid": "35fa9333-02ff-4b07-9036-ec0e3e290602",
+  "sessionId": "433f8bc3-a5a8-46a2-8285-71941dc96ad0",
+  "timestamp": "2026-02-11T15:15:21.005Z",
+  "message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "toolu_014CPfherKZMyYbbG5VT4dyX",
+        "content": "     1→# memsearch\n     2→\n     3→..."
+      }
+    ]
+  }
+}
+```
+
+Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `type` | Message type: `user`, `assistant`, `progress`, `system`, `file-history-snapshot` |
+| `uuid` | Unique ID for this message |
+| `parentUuid` | ID of the previous message (forms a linked chain) |
+| `sessionId` | Session ID (matches the JSONL filename) |
+| `timestamp` | ISO 8601 timestamp |
+| `message.content` | String for user text, or array of `text` / `tool_use` / `tool_result` blocks |
+
+!!! tip "You don't need to parse JSONL manually"
+    The `memsearch transcript` command handles all the parsing, truncation, and formatting. The JSONL structure is documented here for transparency -- most users will never need to read these files directly.
 
 ### Session Anchors
 


### PR DESCRIPTION
## Summary
- Add concrete output examples at each progressive disclosure layer (L1/L2/L3)
- Add new "What the JSONL Looks Like" section showing the 4 key message types with annotated real examples
- All examples taken from actual session transcripts, not synthetic data

Users can now see exactly what each layer returns before trying it themselves.

## Test plan
- [x] `mkdocs build` succeeds
- [x] All JSON examples are valid and properly formatted
- [x] Examples match actual `memsearch expand` and `memsearch transcript` output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)