### PR TITLE
Add cross-references and external links across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,17 @@ memsearch supports three deployment modes — just change `milvus_uri`:
 
 > 📖 Code examples and setup details → [Getting Started — Milvus Backends](https://zilliztech.github.io/memsearch/getting-started/#milvus-backends)
 
+## 🔗 Integrations
+
+memsearch works with any Python agent framework. Ready-made examples for:
+
+- **[LangChain](https://www.langchain.com/)** — use as a `BaseRetriever` in any LCEL chain
+- **[LangGraph](https://langchain-ai.github.io/langgraph/)** — wrap as a tool in a ReAct agent
+- **[LlamaIndex](https://www.llamaindex.ai/)** — plug in as a custom retriever
+- **[CrewAI](https://www.crewai.com/)** — add as a tool for crew agents
+
+> 📖 Copy-paste code for each framework → [Integrations docs](https://zilliztech.github.io/memsearch/integrations/)
+
 ## 📚 Links
 
 - [Documentation](https://zilliztech.github.io/memsearch/) — Getting Started, CLI Reference, Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ The foundational principle of memsearch is simple: **markdown files are the cano
 - **Vendor lock-in.** Each database engine has its own storage format, query language, and migration tooling. Switching costs are high.
 - **Fragile.** Database corruption, version incompatibilities, and backup complexity are real operational concerns for what should be a simple knowledge store.
 
-In memsearch, the vector store is an acceleration layer -- nothing more. If the Milvus database is lost, corrupted, or simply out of date, a single `memsearch index` command rebuilds the entire index from the markdown files.
+In memsearch, the vector store is an acceleration layer -- nothing more. If the [Milvus](https://milvus.io/) database is lost, corrupted, or simply out of date, a single `memsearch index` command rebuilds the entire index from the markdown files.
 
 ```mermaid
 graph LR
@@ -146,7 +146,7 @@ memsearch uses content-addressable storage to avoid redundant embedding API call
 
 ### How It Works
 
-1. Each chunk's content is hashed with SHA-256 (truncated to 16 hex characters).
+1. Each chunk's content is hashed with [SHA-256](https://en.wikipedia.org/wiki/SHA-2) (truncated to 16 hex characters).
 2. A composite chunk ID is computed from the source path, line range, content hash, and embedding model name -- matching OpenClaw's format: `hash(markdown:source:startLine:endLine:contentHash:model)`.
 3. Before embedding, the set of existing chunk IDs for the source file is queried from Milvus.
 4. Only chunks whose composite ID is **not** already present get embedded and upserted.
@@ -194,8 +194,8 @@ The `sparse_vector` field is populated automatically by a Milvus BM25 Function t
 Search combines two retrieval strategies and merges their results:
 
 1. **Dense vector search** -- cosine similarity on the `embedding` field (semantic meaning).
-2. **BM25 sparse search** -- keyword matching on the `sparse_vector` field (exact term overlap).
-3. **RRF reranking** -- Reciprocal Rank Fusion with k=60 merges the two ranked lists into a single result set.
+2. **[BM25](https://en.wikipedia.org/wiki/Okapi_BM25) sparse search** -- keyword matching on the `sparse_vector` field (exact term overlap).
+3. **[RRF](https://en.wikipedia.org/wiki/Reciprocal_rank_fusion) reranking** -- Reciprocal Rank Fusion with k=60 merges the two ranked lists into a single result set.
 
 This hybrid approach catches results that pure semantic search might miss (exact names, error codes, configuration values) while still benefiting from the semantic understanding that dense embeddings provide.
 

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -1,8 +1,8 @@
 # Claude Code Plugin
 
-**Automatic persistent memory for Claude Code.** No commands to learn, no manual saving -- just install the plugin and Claude remembers what you worked on across sessions.
+**Automatic persistent memory for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).** No commands to learn, no manual saving -- just install the plugin and Claude remembers what you worked on across sessions.
 
-The plugin is built entirely on Claude Code's own primitives: **Hooks** for lifecycle events, **CLI** for tool access, and **Agent** for autonomous decisions. No MCP servers, no sidecar services, no extra network round-trips. Everything runs locally as shell scripts and a Python CLI.
+The plugin is built entirely on Claude Code's own primitives: **[Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks)** for lifecycle events, **[CLI](cli.md)** for tool access, and **Agent** for autonomous decisions. No [MCP](https://modelcontextprotocol.io/) servers, no sidecar services, no extra network round-trips. Everything runs locally as shell scripts and a Python CLI.
 
 ### How the pieces fit together
 
@@ -506,7 +506,7 @@ This means:
 | **Memory recall** | **Automatic** -- semantic search on every prompt via hook | **Agent-driven** -- Claude must explicitly call MCP `search` tool |
 | **Progressive disclosure** | **3-layer, auto-triggered**: hook injects top-k (L1), then `expand` (L2), then `transcript` (L3) | **3-layer, all manual**: `search`, `timeline`, `get_observations` all require explicit tool calls |
 | **Session summary cost** | 1 `claude -p --model haiku` call, runs async | Observation on every tool use + session summary (more API calls at scale) |
-| **Vector backend** | Milvus -- hybrid search (dense + BM25), scales from embedded to distributed cluster | Chroma -- dense only, limited scaling path |
+| **Vector backend** | [Milvus](https://milvus.io/) -- [hybrid search](architecture.md#hybrid-search) (dense + BM25), scales from embedded to distributed cluster | [Chroma](https://www.trychroma.com/) -- dense only, limited scaling path |
 | **Storage format** | Transparent `.md` files -- human-readable, git-friendly | Opaque SQLite + Chroma binary |
 | **Index sync** | `memsearch watch` singleton -- auto-debounced background sync | Automatic observation writes, but no unified background sync |
 | **Data portability** | Copy `.memsearch/memory/*.md` and rebuild | Export from SQLite + Chroma |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ Commands:
 | `memsearch stats` | Display index statistics (total chunk count) |
 | `memsearch reset` | Drop all indexed data from the Milvus collection |
 
-> 🔌 Commands marked with 🔌 are designed for the [Claude Code plugin](../ccplugin/README.md)'s progressive disclosure workflow, but work as standalone CLI tools too.
+> 🔌 Commands marked with 🔌 are designed for the [Claude Code plugin](claude-plugin.md)'s progressive disclosure workflow, but work as standalone CLI tools too.
 
 ---
 
@@ -108,7 +108,7 @@ Indexed 42 chunks.
 
 ## `memsearch search`
 
-Run a semantic search query against indexed chunks. Uses hybrid search (dense vector cosine similarity + BM25 full-text) with RRF reranking for best results.
+Run a semantic search query against indexed chunks. Uses [hybrid search](https://milvus.io/docs/multi-vector-search.md) (dense vector cosine similarity + [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) full-text) with [RRF](https://en.wikipedia.org/wiki/Reciprocal_rank_fusion) reranking for best results.
 
 ### Options
 
@@ -307,7 +307,7 @@ $ memsearch compact --prompt-file ./prompts/compress.txt
 
 ## `memsearch expand`
 
-> 🔌 **Claude Code plugin command.** This command is part of the [ccplugin](../ccplugin/README.md)'s three-level progressive disclosure workflow (`search` → `expand` → `transcript`), but works as a standalone CLI tool for any memsearch index.
+> 🔌 **Claude Code plugin command.** This command is part of the [Claude Code plugin](claude-plugin.md)'s three-level progressive disclosure workflow (`search` → `expand` → `transcript`), but works as a standalone CLI tool for any memsearch index.
 
 Look up a chunk by its hash in the index and return the surrounding context from the original source markdown file. This is "progressive disclosure level 2" -- when a search result snippet is not enough, expand it to see the full heading section.
 
@@ -381,7 +381,7 @@ $ memsearch expand a1b2c3d4e5f6 --json-output
 
 ## `memsearch transcript`
 
-> 🔌 **Claude Code plugin command.** This command is part of the [ccplugin](../ccplugin/README.md)'s three-level progressive disclosure workflow (`search` → `expand` → `transcript`), but works as a standalone CLI tool for any JSONL transcript.
+> 🔌 **Claude Code plugin command.** This command is part of the [Claude Code plugin](claude-plugin.md)'s three-level progressive disclosure workflow (`search` → `expand` → `transcript`), but works as a standalone CLI tool for any JSONL transcript.
 
 Parse a JSONL transcript file (e.g., from Claude Code) and display conversation turns. This is "progressive disclosure level 3" -- drill all the way down from a memory chunk to the original conversation that generated it.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,6 +1,6 @@
 # Integrations
 
-memsearch is a plain Python library -- it works with any framework. This page shows ready-made patterns for **LangChain**, **LangGraph**, **LlamaIndex**, and **CrewAI**.
+memsearch is a plain Python library -- it works with any framework. This page shows ready-made patterns for **[LangChain](https://www.langchain.com/)**, **[LangGraph](https://langchain-ai.github.io/langgraph/)**, **[LlamaIndex](https://www.llamaindex.ai/)**, and **[CrewAI](https://www.crewai.com/)**.
 
 !!! note "Prerequisites"
     Each integration requires its own packages:


### PR DESCRIPTION
## Summary
- Add external links for third-party concepts (BM25, RRF, SHA-256, Milvus, Chroma, MCP, Claude Code Hooks)
- Add framework links in integrations.md (LangChain, LangGraph, LlamaIndex, CrewAI)
- Fix CLI doc links from `../ccplugin/README.md` to `claude-plugin.md` (proper docs page)
- Add Integrations section to README with framework list linking to docs

## Test plan
- [ ] Verify all links resolve correctly in `mkdocs serve`
- [ ] Check external links are reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)