### PR TITLE
Add plugin development section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,41 @@ docs/                   # mkdocs-material documentation
 - Code and comments in English.
 - Use `uv` and `pyproject.toml` for dependency management — never `pip install` directly.
 
+## Claude Code Plugin Development
+
+To test the plugin locally without installing from the marketplace, use `--plugin-dir` to point Claude Code at your local checkout:
+
+```bash
+# 1. Make sure memsearch CLI is installed
+pip install memsearch
+
+# 2. Set your embedding API key
+export OPENAI_API_KEY="sk-..."
+
+# 3. Launch Claude Code with the local plugin
+claude --plugin-dir ./ccplugin
+```
+
+This loads hooks directly from `ccplugin/hooks/` — any edits to the shell scripts take effect on the next hook trigger (no restart needed for most hooks, except `SessionStart` which only fires once).
+
+**Testing individual hooks manually:**
+
+```bash
+# Test user-prompt-submit hook (simulates a user prompt)
+echo '{"prompts":[{"content":"what caching solution did we pick?"}]}' | bash ccplugin/hooks/user-prompt-submit.sh
+
+# Test session-start hook
+echo '{}' | bash ccplugin/hooks/session-start.sh
+```
+
+Hooks read from stdin and write JSON to stdout. Check that the output contains valid `additionalContext` fields.
+
+**Debugging tips:**
+
+- Hooks log to stderr — add `echo "debug: ..." >&2` to trace execution without breaking the JSON stdout contract.
+- The watch process PID file is at `.memsearch/.watch.pid` — delete it if the watcher gets stuck.
+- The `stop.sh` hook calls `claude -p --model haiku` internally. Set `stop_hook_active=1` in the environment to skip it during manual testing.
+
 ## Documentation
 
 Docs are in `docs/` and built with mkdocs-material:


### PR DESCRIPTION
## Summary
- Add Claude Code plugin local development instructions (`claude --plugin-dir ./ccplugin`)
- Add manual hook testing examples (stdin JSON → stdout JSON)
- Add debugging tips (stderr logging, PID cleanup, stop hook recursion guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)