### PR TITLE
Auto-detect embedding dimension for all providers

### DIFF
--- a/src/memsearch/embeddings/ollama.py
+++ b/src/memsearch/embeddings/ollama.py
@@ -16,7 +16,10 @@ class OllamaEmbedding:
 
         self._client = ollama.AsyncClient()  # reads OLLAMA_HOST
         self._model = model
-        self._dimension = 768  # varies by model; nomic-embed-text is 768
+        # Auto-detect dimension via a trial embed (each model has its own)
+        _sync = ollama.Client()
+        trial = _sync.embed(model=model, input=["dim"])
+        self._dimension = len(trial["embeddings"][0])
 
     @property
     def model_name(self) -> str:


### PR DESCRIPTION
## Summary

- **Ollama**: Replaced hardcoded `768` with a trial embed on init to auto-detect the actual dimension. This fixes silent failures when using models other than `nomic-embed-text` (e.g., `mxbai-embed-large` outputs 1024).
- **Google**: Added a dimension lookup table for known models (`gemini-embedding-001`, `text-embedding-004`) with a trial embed fallback for unknown models.
- **OpenAI**: Added trial embed fallback for unknown models (e.g., custom models via `OPENAI_BASE_URL`). Well-known models (`text-embedding-3-small/large`, `ada-002`) still use the fast lookup table.
- **Voyage**: Same pattern — lookup table for known models, trial embed fallback for unknown ones.
- **Local** (sentence-transformers) already auto-detected via `get_sentence_embedding_dimension()`, no change needed.

## Motivation

Previously, switching embedding models could silently produce dimension mismatches. For example, using `mxbai-embed-large` (1024-dim) with the Ollama provider would still report `dimension=768`, causing Milvus upsert failures or corrupted search results.

## Test plan

- [x] All 33 existing tests pass
- [ ] Manual: test with a non-default Ollama model to verify dimension auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)