### PR TITLE
Show truncation hint in search output

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -158,7 +158,12 @@ def search(
                 click.echo(f"Source: {source}")
                 if heading:
                     click.echo(f"Heading: {heading}")
-                click.echo(content[:500])
+                if len(content) > 500:
+                    click.echo(content[:500])
+                    chunk_hash = r.get("chunk_hash", "")
+                    click.echo(f"  ... [truncated, run 'memsearch expand {chunk_hash}' for full content]")
+                else:
+                    click.echo(content)
     finally:
         ms.close()
 


### PR DESCRIPTION
## Summary

- When `memsearch search` truncates content at 500 chars, now shows a hint: `... [truncated, run 'memsearch expand <chunk_hash>' for full content]`
- Short results (<=500 chars) display in full without any hint

**Before:**
```
--- Result 1 (score: 0.8234) ---
Source: docs/2026-02-10.md
Heading: Architecture Decision
We decided to use a layered config system with TOML files. The priority chain is...
```
(silently cut off — user doesn't know content was truncated)

**After:**
```
--- Result 1 (score: 0.8234) ---
Source: docs/2026-02-10.md
Heading: Architecture Decision
We decided to use a layered config system with TOML files. The priority chain is...
  ... [truncated, run 'memsearch expand abc123def' for full content]
```

## Test plan

- [x] All 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)