### PR TITLE
Docs: add missing links and fix mermaid colors for light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ asyncio.run(main())
 
 </details>
 
+> 📖 Full Python API reference with all parameters → [Python API docs](https://zilliztech.github.io/memsearch/python-api/)
+
 ## 🖥️ CLI Usage
 
 ### Set Up — `config init`
@@ -406,7 +408,7 @@ memsearch works with any Python agent framework. Ready-made examples for:
 
 ## Contributing
 
-Bug reports, feature requests, and pull requests are welcome on [GitHub](https://github.com/zilliztech/memsearch). For questions and discussions, join us on [Discord](https://discord.com/invite/FG6hMJStWu).
+Bug reports, feature requests, and pull requests are welcome! See the [Contributing Guide](CONTRIBUTING.md) for development setup, testing, and plugin development instructions. For questions and discussions, join us on [Discord](https://discord.com/invite/FG6hMJStWu).
 
 ## 📄 License
 

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -26,10 +26,10 @@ graph LR
     CLI --> HOOKS
     HOOKS -->|"runs inside"| CC[Claude Code]
 
-    style LIB fill:#1a2744,stroke:#6ba3d6,color:#a8b2c1
-    style CLI fill:#1a2744,stroke:#e0976b,color:#a8b2c1
-    style HOOKS fill:#1a2744,stroke:#7bc67e,color:#a8b2c1
-    style CC fill:#2a1a44,stroke:#c97bdb,color:#a8b2c1
+    style LIB fill:#dce8f5,stroke:#4a86c8,color:#1a2744
+    style CLI fill:#fae3d0,stroke:#d08040,color:#1a2744
+    style HOOKS fill:#d5f0d6,stroke:#4a9e4e,color:#1a2744
+    style CC fill:#e8d5f5,stroke:#9b59b6,color:#1a2744
 ```
 
 The **memsearch Python library** provides the core engine (chunking, embedding, vector storage, search). The **memsearch CLI** wraps the library into shell-friendly commands. The **Claude Code Plugin** ties those CLI commands to Claude Code's hook lifecycle — so everything happens automatically without user intervention.
@@ -187,9 +187,9 @@ graph TD
     L1["L1: Auto-injected<br/>(UserPromptSubmit hook)"] --> L2["L2: On-demand expand<br/>(memsearch expand)"]
     L2 --> L3["L3: Transcript drill-down<br/>(memsearch transcript)"]
 
-    style L1 fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
-    style L2 fill:#2a3a5c,stroke:#e0976b,color:#a8b2c1
-    style L3 fill:#2a3a5c,stroke:#d66b6b,color:#a8b2c1
+    style L1 fill:#dce8f5,stroke:#4a86c8,color:#1a2744
+    style L2 fill:#fae3d0,stroke:#d08040,color:#1a2744
+    style L3 fill:#f5d5d5,stroke:#c04040,color:#1a2744
 ```
 
 ### L1: Auto-Injected (Automatic)


### PR DESCRIPTION
## Summary

- **README**: Added Python API docs link after the code examples section
- **README**: Linked Contributing section to `CONTRIBUTING.md`
- **ccplugin README**: Changed mermaid diagram nodes from dark backgrounds (`#1a2744`) with dim text to light pastel backgrounds with dark text — much better readability on GitHub's default light mode

## Test plan

- [x] Visual: verify mermaid renders correctly on GitHub light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)