### PR TITLE
ccplugin: bootstrap memsearch via uvx instead of uv run --project

### DIFF
--- a/ccplugin/hooks/common.sh
+++ b/ccplugin/hooks/common.sh
@@ -16,14 +16,19 @@ done
 MEMSEARCH_DIR="${CLAUDE_PROJECT_DIR:-.}/.memsearch"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
-# Find memsearch binary: prefer PATH, fallback to uv run
-MEMSEARCH_CMD=""
-if command -v memsearch &>/dev/null; then
-  MEMSEARCH_CMD="memsearch"
-elif command -v uv &>/dev/null; then
-  # Run uv from the project dir so it can find pyproject.toml
-  MEMSEARCH_CMD="uv run --project ${CLAUDE_PROJECT_DIR:-.} memsearch"
-fi
+# Find memsearch binary: prefer PATH, fallback to uvx
+_detect_memsearch() {
+  MEMSEARCH_CMD=""
+  if command -v memsearch &>/dev/null; then
+    MEMSEARCH_CMD="memsearch"
+  elif command -v uvx &>/dev/null; then
+    MEMSEARCH_CMD="uvx memsearch"
+  fi
+}
+_detect_memsearch
+
+# Short command prefix for injected instructions (falls back to "memsearch" even if unavailable)
+MEMSEARCH_CMD_PREFIX="${MEMSEARCH_CMD:-memsearch}"
 
 # Helper: ensure memory directory exists
 ensure_memory_dir() {

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -4,6 +4,17 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+# Bootstrap: if memsearch not available, install uv and warm up uvx cache
+if [ -z "$MEMSEARCH_CMD" ]; then
+  if ! command -v uvx &>/dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+  # Warm up uvx cache (first run downloads packages, ~2s; subsequent <0.3s)
+  uvx memsearch --version &>/dev/null || true
+  _detect_memsearch
+fi
+
 # Start memsearch watch as a singleton background process.
 # This is the ONLY place indexing is managed — all other hooks just write .md files.
 start_watch
@@ -55,9 +66,9 @@ fi
 # Add memory tools instructions for progressive disclosure
 context+="\n## Memory Tools\n"
 context+="When injected memories above need more context, use these commands via Bash:\n"
-context+="- \`memsearch expand <chunk_hash>\` — show the full section around a memory chunk\n"
-context+="- \`memsearch expand <chunk_hash> --json-output\` — JSON output with anchor metadata for L3 drill-down\n"
-context+="- \`memsearch transcript <jsonl_path> --turn <uuid> --context 3\` — view original conversation turns from the JSONL transcript\n"
+context+="- \`${MEMSEARCH_CMD_PREFIX} expand <chunk_hash>\` — show the full section around a memory chunk\n"
+context+="- \`${MEMSEARCH_CMD_PREFIX} expand <chunk_hash> --json-output\` — JSON output with anchor metadata for L3 drill-down\n"
+context+="- \`${MEMSEARCH_CMD_PREFIX} transcript <jsonl_path> --turn <uuid> --context 3\` — view original conversation turns from the JSONL transcript\n"
 context+="chunk_hash is shown in Relevant Memories injected on each prompt. Anchors (session/turn/transcript path) are embedded in expand output.\n"
 
 if [ -n "$context" ]; then


### PR DESCRIPTION
## Summary
- Replace `uv run --project` fallback with `uvx memsearch` in `common.sh`, so the plugin works for end-users whose project is not memsearch itself
- Add auto-bootstrap in `session-start.sh`: installs uv and warms uvx cache on first run when memsearch is not found
- Use `MEMSEARCH_CMD_PREFIX` in Memory Tools instructions so injected commands match the actual invocation method (e.g. `uvx memsearch expand ...`)

## Test plan
- [ ] Start CC with `--plugin-dir` pointing to ccplugin, verify SessionStart hook bootstraps correctly
- [ ] Send a prompt, verify UserPromptSubmit uses `uvx memsearch search` successfully
- [ ] Check Memory Tools instructions in additionalContext show correct command prefix
- [ ] Verify existing PATH-based `memsearch` installs still take priority over uvx

🤖 Generated with [Claude Code](https://claude.com/claude-code)