### PR TITLE
ccplugin: output API key warning to stderr instead of additionalContext

### DIFF
--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -24,12 +24,11 @@ if [ -z "${OPENAI_API_KEY:-}" ]; then
   MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
   echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
 
-  warn="**memsearch memory plugin** requires \`OPENAI_API_KEY\` to enable semantic memory search.\n\n"
-  warn+="1. Get a key at https://platform.openai.com/api-keys\n"
-  warn+="2. Export it: \`export OPENAI_API_KEY=sk-...\`\n"
-  warn+="\nMemory recording is active (writing to .md files), but search and indexing are disabled until the key is set."
-  json_warn=$(printf '%s' "$warn" | jq -Rs .)
-  echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": $json_warn}}"
+  # Warn via stderr (visible in terminal) — NOT additionalContext, to avoid
+  # the stop hook summarizing "user needs API key" into memory files.
+  echo "[memsearch] OPENAI_API_KEY not set — memory search disabled." >&2
+  echo "[memsearch] Get a key: https://platform.openai.com/api-keys" >&2
+  echo "{}"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Move the missing `OPENAI_API_KEY` warning from `additionalContext` to **stderr**
- Prevents the stop hook from summarizing "user needs API key" into daily memory files
- User still sees the warning in their terminal; Claude never processes it

## Before
Warning injected via `additionalContext` → Claude responds → stop hook summarizes → memory polluted with setup noise.

## After
Warning printed to stderr (terminal-visible) → hook returns `{}` → nothing for Claude/stop-hook to process.

## Test plan
- [x] No API key → stderr shows warning, stdout is `{}`
- [x] With API key → normal memory flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)