### PR TITLE
ccplugin: show API key warning via Claude, skip stop-hook summarization

### DIFF
--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -24,11 +24,12 @@ if [ -z "${OPENAI_API_KEY:-}" ]; then
   MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
   echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
 
-  # Warn via stderr (visible in terminal) — NOT additionalContext, to avoid
-  # the stop hook summarizing "user needs API key" into memory files.
-  echo "[memsearch] OPENAI_API_KEY not set — memory search disabled." >&2
-  echo "[memsearch] Get a key: https://platform.openai.com/api-keys" >&2
-  echo "{}"
+  warn="**memsearch memory plugin** requires \`OPENAI_API_KEY\` to enable semantic memory search.\n\n"
+  warn+="1. Get a key at https://platform.openai.com/api-keys\n"
+  warn+="2. Export it: \`export OPENAI_API_KEY=sk-...\`\n"
+  warn+="\nMemory recording is active (writing to .md files), but search and indexing are disabled until the key is set."
+  json_warn=$(printf '%s' "$warn" | jq -Rs .)
+  echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": $json_warn}}"
   exit 0
 fi
 

--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -11,6 +11,13 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
+# Skip summarization when OPENAI_API_KEY is missing — the session would only
+# contain the "please set your API key" exchange, which is not useful memory.
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  echo '{}'
+  exit 0
+fi
+
 # Extract transcript path from hook input
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 


### PR DESCRIPTION
## Summary
- Restore `additionalContext` warning in `session-start.sh` so users see the setup hint through Claude (stderr is not visible in interactive mode)
- Add `OPENAI_API_KEY` guard in `stop.sh` to skip transcript summarization when the key is missing — prevents "user needs API key" noise from polluting daily memory files

## Test plan
- [x] No API key → session-start injects warning via additionalContext
- [x] No API key → stop hook returns `{}` immediately, no summary written to .md
- [x] With API key → both hooks work normally as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)