### PR TITLE
ccplugin: replace push-based memory with skill-based recall

### DIFF
--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -4,7 +4,7 @@ https://github.com/user-attachments/assets/190a9973-8e23-4ca1-b2a4-a5cf09dad10a
 
 **Automatic persistent memory for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).** No commands to learn, no manual saving — just install the plugin and Claude remembers what you worked on across sessions.
 
-Built on Claude Code's native [Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) and [CLI](https://zilliztech.github.io/memsearch/cli/) — no MCP servers, no sidecar services. Everything runs locally as shell scripts and a Python CLI.
+Built on Claude Code's native [Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks), [Skills](https://docs.anthropic.com/en/docs/claude-code/skills), and [CLI](https://zilliztech.github.io/memsearch/cli/) — no MCP servers, no sidecar services. Everything runs locally as shell scripts, a skill definition, and a Python CLI.
 
 ### How the Pieces Fit Together
 
@@ -20,11 +20,14 @@ graph LR
 
     subgraph "Claude Code Plugin (ccplugin)"
         HOOKS["Shell hooks:<br/>SessionStart · UserPromptSubmit<br/>Stop · SessionEnd"]
+        SKILL["Skill:<br/>memory-recall (context: fork)"]
     end
 
     LIB --> CLI
     CLI --> HOOKS
+    CLI --> SKILL
     HOOKS -->|"runs inside"| CC[Claude Code]
+    SKILL -->|"subagent"| CC
 
     style LIB fill:#dce8f5,stroke:#4a86c8,color:#1a2744
     style CLI fill:#fae3d0,stroke:#d08040,color:#1a2744
@@ -32,7 +35,7 @@ graph LR
     style CC fill:#e8d5f5,stroke:#9b59b6,color:#1a2744
 ```
 
-The **memsearch Python library** provides the core engine (chunking, embedding, vector storage, search). The **memsearch CLI** wraps the library into shell-friendly commands. The **Claude Code Plugin** ties those CLI commands to Claude Code's hook lifecycle — so everything happens automatically without user intervention.
+The **memsearch Python library** provides the core engine (chunking, embedding, vector storage, search). The **memsearch CLI** wraps the library into shell-friendly commands. The **Claude Code Plugin** ties those CLI commands to Claude Code's hook lifecycle and skill system — hooks handle session management and memory capture, while the **memory-recall skill** handles intelligent retrieval in a forked subagent context.
 
 ---
 
@@ -89,7 +92,7 @@ cat .memsearch/memory/$(date +%Y-%m-%d).md
 
 ## How It Works
 
-The plugin hooks into **4 Claude Code lifecycle events**. A singleton `memsearch watch` process runs in the background, keeping the vector index in sync with markdown files as they change.
+The plugin hooks into **4 Claude Code lifecycle events** and provides a **memory-recall skill**. A singleton `memsearch watch` process runs in the background, keeping the vector index in sync with markdown files as they change.
 
 ### Lifecycle Diagram
 
@@ -97,7 +100,7 @@ The plugin hooks into **4 Claude Code lifecycle events**. A singleton `memsearch
 stateDiagram-v2
     [*] --> SessionStart
     SessionStart --> WatchRunning: start memsearch watch
-    SessionStart --> InjectRecent: load recent memories
+    SessionStart --> InjectRecent: load recent memories (cold start)
 
     state WatchRunning {
         [*] --> Watching
@@ -109,9 +112,12 @@ stateDiagram-v2
 
     state Prompting {
         [*] --> UserInput
-        UserInput --> SemanticSearch: UserPromptSubmit hook
-        SemanticSearch --> InjectMemories: top-k results
-        InjectMemories --> ClaudeResponds: Claude processes & replies
+        UserInput --> Hint: UserPromptSubmit hook
+        Hint --> ClaudeProcesses: "[memsearch] Memory available"
+        ClaudeProcesses --> MemoryRecall: needs context?
+        MemoryRecall --> Subagent: memory-recall skill (context: fork)
+        Subagent --> ClaudeResponds: curated summary
+        ClaudeProcesses --> ClaudeResponds: no memory needed
         ClaudeResponds --> UserInput: next turn
         ClaudeResponds --> Summary: Stop hook (async, non-blocking)
         Summary --> WriteMD: append to YYYY-MM-DD.md
@@ -126,8 +132,8 @@ stateDiagram-v2
 
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
-| **SessionStart** | command | no | 10s | Start `memsearch watch` singleton, write session heading to today's `.md`, inject recent memories and Memory Tools instructions via `additionalContext` |
-| **UserPromptSubmit** | command | no | 15s | Semantic search on user prompt (skip if < 10 chars), inject top-3 relevant memories with `chunk_hash` IDs via `additionalContext` |
+| **SessionStart** | command | no | 10s | Start `memsearch watch` singleton, write session heading to today's `.md`, inject recent daily logs as cold-start context via `additionalContext` |
+| **UserPromptSubmit** | command | no | 15s | Lightweight hint: returns `systemMessage` "[memsearch] Memory available" (skip if < 10 chars). No search — recall is handled by the memory-recall skill |
 | **Stop** | command | **yes** | 120s | Parse transcript with `parse-transcript.sh`, call `claude -p --model haiku` to summarize, append summary with session/turn anchors to daily `.md` |
 | **SessionEnd** | command | no | 10s | Stop the `memsearch watch` background process (cleanup) |
 
@@ -139,22 +145,17 @@ Fires once when a Claude Code session begins. This hook:
 
 1. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce.
 2. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
-3. **Injects recent memories.** Reads the last 30 lines from the 2 most recent daily logs. If memsearch is available, also runs `memsearch search "recent session summary" --top-k 3` for semantic results.
-4. **Injects Memory Tools instructions.** Tells Claude about `memsearch expand` and `memsearch transcript` commands for progressive disclosure (L2 and L3).
-
-All of this is returned as `additionalContext` in the hook output JSON.
+3. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
 
 #### UserPromptSubmit
 
 Fires on every user prompt before Claude processes it. This hook:
 
 1. **Extracts the prompt** from the hook input JSON.
-2. **Skips short prompts** (under 10 characters) — greetings and single words are not worth searching.
-3. **Runs semantic search.** Calls `memsearch search "$PROMPT" --top-k 3 --json-output`.
-4. **Formats results** as a compact index with source file, heading, a 200-character preview, and the `chunk_hash` for each result.
-5. **Injects as context.** Returns formatted results under a `## Relevant Memories` heading via `additionalContext`.
+2. **Skips short prompts** (under 10 characters) — greetings and single words don't need memory hints.
+3. **Returns a lightweight hint.** Outputs `systemMessage: "[memsearch] Memory available"` — a visible one-liner that keeps Claude aware of the memory system without performing any search.
 
-This is the key mechanism that makes memory recall automatic — Claude does not need to decide to search, it simply receives relevant context on every prompt.
+The actual memory retrieval is handled by the **memory-recall skill** (see below), which Claude invokes automatically when it judges the user's question needs historical context.
 
 #### Stop
 
@@ -174,39 +175,44 @@ Fires when the user exits Claude Code. Calls `stop_watch` to kill the `memsearch
 
 ## Progressive Disclosure
 
-Memory retrieval uses a **three-layer progressive disclosure model**. Layer 1 is fully automatic; layers 2 and 3 are available on demand when Claude needs more context.
+Memory retrieval uses a **three-layer progressive disclosure model**, all handled autonomously by the **memory-recall skill** running in a forked subagent context. Claude invokes the skill when it judges the user's question needs historical context — no manual intervention required.
 
 ```mermaid
 graph TD
-    L1["L1: Auto-injected<br/>(UserPromptSubmit hook)"] --> L2["L2: On-demand expand<br/>(memsearch expand)"]
+    SKILL["memory-recall skill<br/>(context: fork subagent)"]
+    SKILL --> L1["L1: Search<br/>(memsearch search)"]
+    L1 --> L2["L2: Expand<br/>(memsearch expand)"]
     L2 --> L3["L3: Transcript drill-down<br/>(memsearch transcript)"]
+    L3 --> RETURN["Curated summary<br/>→ main agent"]
 
+    style SKILL fill:#dce8f5,stroke:#4a86c8,color:#1a2744
     style L1 fill:#dce8f5,stroke:#4a86c8,color:#1a2744
     style L2 fill:#fae3d0,stroke:#d08040,color:#1a2744
     style L3 fill:#f5d5d5,stroke:#c04040,color:#1a2744
+    style RETURN fill:#d5f0d6,stroke:#4a9e4e,color:#1a2744
 ```
 
-### L1: Auto-Injected (Automatic)
+### How the Skill Works
 
-On every user prompt, the `UserPromptSubmit` hook injects the top-3 semantic search results. Each result includes the source file, heading, a 200-character content preview, and the `chunk_hash` identifier.
+When Claude detects that a user's question could benefit from past context, it automatically invokes the `memory-recall` skill. The skill runs in a **forked subagent context** (`context: fork`), meaning it has its own context window and does not pollute the main conversation. The subagent:
 
-**Example injection** (this is what Claude sees before processing each message):
+1. **Searches** for relevant memories using `memsearch search`
+2. **Evaluates** which results are truly relevant (skips noise)
+3. **Expands** promising results with `memsearch expand` to get full markdown sections
+4. **Drills into transcripts** when needed with `memsearch transcript`
+5. **Returns a curated summary** to the main agent
 
-```
-## Relevant Memories
-- [.memsearch/memory/2026-02-10.md:09:15]  Added Redis caching middleware
-  to API with 5-minute TTL. Used redis-py async client with connection
-  pooling (max 10 connections). Cache key format: api:v1:{endpoint}:...
-  `chunk_hash: 7a3f9b21e4c08d56`
-- [.memsearch/memory/2026-02-09.md:14:30]  Fixed N+1 query in order-service
-  by switching from lazy loading to selectinload. Reduced /orders response
-  time from 1.2s to 180ms...
-  `chunk_hash: 31cbaf74856ad1ed`
-```
+The main agent only sees the final summary — all intermediate search results, raw expand output, and transcript parsing happen inside the subagent.
 
-### L2: On-Demand Expand
+Users can also manually invoke the skill with `/memory-recall <query>` if Claude doesn't trigger it automatically.
 
-When an L1 preview is not enough, Claude runs `memsearch expand` to retrieve the **full markdown section** surrounding a chunk:
+### L1: Search
+
+The subagent runs `memsearch search` to find relevant chunks from the indexed memory files.
+
+### L2: Expand
+
+For promising search results, the subagent runs `memsearch expand` to retrieve the **full markdown section** surrounding a chunk:
 
 ```bash
 $ memsearch expand 7a3f9b21e4c08d56
@@ -352,26 +358,26 @@ Each file contains session summaries in plain markdown:
 |--------|-----------|------------|
 | **Architecture** | 4 shell hooks + 1 watch process | Node.js/Bun worker service + Express server + React UI |
 | **Integration** | Native hooks + CLI (zero IPC overhead) | MCP server (stdio); tool definitions permanently consume context window |
-| **Memory recall** | **Automatic** — semantic search on every prompt via hook | **Agent-driven** — Claude must explicitly call MCP `search` tool |
-| **Progressive disclosure** | **3-layer, auto-triggered**: hook injects top-k (L1), then `expand` (L2), then `transcript` (L3) | **3-layer, all manual**: `search`, `timeline`, `get_observations` all require explicit tool calls |
+| **Memory recall** | **Skill-based auto-recall** — Claude auto-invokes memory-recall skill in a forked subagent when context is needed | **Agent-driven** — Claude must explicitly call MCP `search` tool |
+| **Progressive disclosure** | **3-layer, skill-driven**: subagent autonomously handles search (L1), expand (L2), transcript (L3) and returns curated summary | **3-layer, all manual**: `search`, `timeline`, `get_observations` all require explicit tool calls |
 | **Session summary cost** | 1 `claude -p --model haiku` call, runs async | Observation on every tool use + session summary (more API calls at scale) |
 | **Vector backend** | [Milvus](https://milvus.io/) — hybrid search (dense + [BM25](https://en.wikipedia.org/wiki/Okapi_BM25)), scales from embedded to distributed cluster | [Chroma](https://www.trychroma.com/) — dense only, limited scaling path |
 | **Storage format** | Transparent `.md` files — human-readable, git-friendly | Opaque SQLite + Chroma binary |
 | **Index sync** | `memsearch watch` singleton — auto-debounced background sync | Automatic observation writes, but no unified background sync |
 | **Data portability** | Copy `.memsearch/memory/*.md` and rebuild | Export from SQLite + Chroma |
 | **Runtime dependency** | Python (`memsearch` CLI) + `claude` CLI | Node.js + Bun + MCP runtime |
-| **Context window cost** | Minimal — hook injects only top-k results as plain text | MCP tool definitions always loaded + each tool call/result consumes context |
+| **Context window cost** | Minimal — skill runs in forked context, only curated summary enters main context | MCP tool definitions always loaded + each tool call/result consumes context |
 | **Cost per session** | ~1 Haiku call for summary | Multiple Claude API calls for observation compression |
 
-### The Key Insight: Automatic vs. Agent-Driven Recall
+### The Key Insight: Skill-Based vs. MCP-Based Recall
 
-The fundamental architectural difference is **when** memory recall happens.
+The fundamental architectural difference is **how** memory recall is orchestrated.
 
-**memsearch injects relevant memories into every prompt via hooks.** Claude does not need to decide whether to search — it simply receives relevant context before processing each message. This means memories are **never missed due to Claude forgetting to look them up**. Progressive disclosure starts automatically at L1 (the hook injects top-k results), and only deeper layers (L2 expand, L3 transcript) require explicit CLI calls from the agent.
+**memsearch uses a skill-based approach.** The `memory-recall` skill runs in a forked subagent context (`context: fork`), meaning all search, expand, and transcript operations happen in an isolated context window. Claude auto-invokes the skill when it judges historical context would be useful. The subagent autonomously handles all three progressive disclosure layers and returns only a curated summary to the main conversation. Combined with cold-start context from the `SessionStart` hook and a lightweight `systemMessage` hint on every prompt, Claude reliably triggers the skill when past context is relevant.
 
-**claude-mem gives Claude MCP tools to search, explore timelines, and fetch observations.** All three layers require Claude to **proactively decide** to invoke them. While this is more flexible (Claude controls when and what to recall), it means memories are only retrieved when Claude thinks to ask. In practice, Claude often does not call the search tool unless the conversation explicitly references past work — which means relevant context can be silently lost.
+**claude-mem gives Claude MCP tools to search, explore timelines, and fetch observations.** All three layers require Claude to **proactively decide** to invoke them in the main conversation context. While this is more flexible (Claude controls when and what to recall), it means memories are only retrieved when Claude thinks to ask, and every search/expand operation consumes the main context window.
 
-The difference is analogous to push vs. pull: memsearch **pushes** memories to Claude on every turn, while claude-mem requires Claude to **pull** them on demand.
+The key advantages of the skill-based approach: (1) the subagent handles multi-step retrieval autonomously without distracting the main agent, (2) intermediate search results don't pollute the main context window, and (3) Claude only recalls memories when they're actually needed — no unnecessary context injection on every prompt.
 
 ---
 
@@ -382,7 +388,7 @@ Claude Code has built-in memory features: `CLAUDE.md` files and auto-memory (the
 | Aspect | Claude Native Memory | memsearch |
 |--------|---------------------|-----------|
 | **Storage** | Single `CLAUDE.md` file (or per-project) | Unlimited daily `.md` files with full history |
-| **Recall mechanism** | File is loaded at session start (no search) | Semantic search on every prompt (embedding-based) |
+| **Recall mechanism** | File is loaded at session start (no search) | Skill-based semantic search — Claude auto-invokes when context is needed |
 | **Granularity** | One monolithic file, manually edited | Per-session bullet points, automatically generated |
 | **Search** | None — Claude reads the whole file or nothing | Hybrid semantic search (dense + BM25) returning top-k relevant chunks |
 | **History depth** | Limited to what fits in one file | Unlimited — every session is logged, every entry is searchable |
@@ -395,7 +401,7 @@ Claude Code has built-in memory features: `CLAUDE.md` files and auto-memory (the
 
 `CLAUDE.md` is a blunt instrument: it loads the entire file into context at session start, regardless of relevance. As the file grows, it wastes context window on irrelevant information and eventually hits size limits. There is no search — Claude cannot selectively recall a specific decision from three weeks ago.
 
-memsearch solves this with **semantic search and progressive disclosure**. Instead of loading everything, it injects only the top-k most relevant memories for each specific prompt. History can grow indefinitely without degrading performance, because the vector index handles the filtering. And the three-layer model means Claude starts with lightweight previews and only drills deeper when needed, keeping context window usage minimal.
+memsearch solves this with **skill-based semantic search and progressive disclosure**. When Claude judges that historical context would help, it auto-invokes the memory-recall skill, which runs in a forked subagent and autonomously searches, expands, and curates relevant memories. History can grow indefinitely without degrading performance, because the vector index handles the filtering. And the three-layer model (search → expand → transcript) runs entirely in the subagent, keeping the main context window clean.
 
 ---
 
@@ -405,14 +411,17 @@ memsearch solves this with **semantic search and progressive disclosure**. Inste
 ccplugin/
 ├── .claude-plugin/
 │   └── plugin.json              # Plugin manifest (name, version, description)
-└── hooks/
-    ├── hooks.json               # Hook definitions (4 lifecycle hooks)
-    ├── common.sh                # Shared setup: env, PATH, memsearch detection, watch management
-    ├── session-start.sh         # Start watch + write session heading + inject memories & tools
-    ├── user-prompt-submit.sh    # Semantic search on prompt -> inject memories with chunk_hash
-    ├── stop.sh                  # Parse transcript -> haiku summary -> append to daily .md
-    ├── parse-transcript.sh      # Deterministic JSONL-to-text parser with truncation
-    └── session-end.sh           # Stop watch process (cleanup)
+├── hooks/
+│   ├── hooks.json               # Hook definitions (4 lifecycle hooks)
+│   ├── common.sh                # Shared setup: env, PATH, memsearch detection, watch management
+│   ├── session-start.sh         # Start watch + write session heading + inject cold-start context
+│   ├── user-prompt-submit.sh    # Lightweight systemMessage hint ("[memsearch] Memory available")
+│   ├── stop.sh                  # Parse transcript -> haiku summary -> append to daily .md
+│   ├── parse-transcript.sh      # Deterministic JSONL-to-text parser with truncation
+│   └── session-end.sh           # Stop watch process (cleanup)
+└── skills/
+    └── memory-recall/
+        └── SKILL.md             # Memory retrieval skill (context: fork subagent)
 ```
 
 ---
@@ -423,11 +432,11 @@ The plugin is built entirely on the [`memsearch`](../README.md) CLI — every ho
 
 | Command | Used By | What It Does |
 |---------|---------|-------------|
-| `search <query>` | UserPromptSubmit hook | Semantic search over indexed memories (`--top-k` for result count, `--json-output` for JSON) |
+| `search <query>` | memory-recall skill | Semantic search over indexed memories (`--top-k` for result count, `--json-output` for JSON) |
 | `watch <paths>` | SessionStart hook | Background watcher that auto-indexes on file changes (1500ms debounce) |
 | `index <paths>` | Manual / rebuild | One-shot index of markdown files (`--force` to re-index all) |
-| `expand <chunk_hash>` | Agent (L2 disclosure) | Show full markdown section around a chunk, with anchor metadata |
-| `transcript <jsonl>` | Agent (L3 disclosure) | Parse Claude Code JSONL transcript into readable conversation turns |
+| `expand <chunk_hash>` | memory-recall skill (L2) | Show full markdown section around a chunk, with anchor metadata |
+| `transcript <jsonl>` | memory-recall skill (L3) | Parse Claude Code JSONL transcript into readable conversation turns |
 | `config init` | Quick Start | Interactive config wizard for first-time setup |
 | `stats` | Manual | Show index statistics (collection size, chunk count) |
 | `reset` | Manual | Drop all indexed data (requires `--yes` to confirm) |

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -66,27 +66,9 @@ if [ -n "$recent_files" ]; then
   done
 fi
 
-# If memsearch is available, also do a semantic search for recent context
-if [ -n "$MEMSEARCH_CMD" ]; then
-  search_results=$($MEMSEARCH_CMD search "recent session summary" --top-k 3 --json-output 2>/dev/null || true)
-  if [ -n "$search_results" ] && [ "$search_results" != "[]" ] && [ "$search_results" != "null" ]; then
-    formatted=$(echo "$search_results" | jq -r '
-      .[]? |
-      "- [\(.source // "unknown"):\(.heading // "")]  \(.content // "" | .[0:200])"
-    ' 2>/dev/null || true)
-    if [ -n "$formatted" ]; then
-      context+="\n## Semantic Search: Recent Sessions\n$formatted\n"
-    fi
-  fi
-fi
-
-# Add memory tools instructions for progressive disclosure
-context+="\n## Memory Tools\n"
-context+="When injected memories above need more context, use these commands via Bash:\n"
-context+="- \`${MEMSEARCH_CMD_PREFIX} expand <chunk_hash>\` — show the full section around a memory chunk\n"
-context+="- \`${MEMSEARCH_CMD_PREFIX} expand <chunk_hash> --json-output\` — JSON output with anchor metadata for L3 drill-down\n"
-context+="- \`${MEMSEARCH_CMD_PREFIX} transcript <jsonl_path> --turn <uuid> --context 3\` — view original conversation turns from the JSONL transcript\n"
-context+="chunk_hash is shown in Relevant Memories injected on each prompt. Anchors (session/turn/transcript path) are embedded in expand output.\n"
+# Note: Detailed memory search is handled by the memory-recall skill (pull-based).
+# The cold-start context above gives Claude enough awareness of recent sessions
+# to decide when to invoke the skill for deeper recall.
 
 if [ -n "$context" ]; then
   json_context=$(printf '%s' "$context" | jq -Rs .)

--- a/ccplugin/hooks/user-prompt-submit.sh
+++ b/ccplugin/hooks/user-prompt-submit.sh
@@ -1,48 +1,21 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: semantic search on every user prompt, inject relevant memories.
-# Returns compact index with chunk_hash + anchor metadata for progressive disclosure.
-# The main Claude agent can drill deeper with `memsearch expand` and `memsearch transcript`.
+# UserPromptSubmit hook: lightweight hint reminding Claude about the memory-recall skill.
+# The actual search + expand is handled by the memory-recall skill (pull-based, context: fork).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
-# Extract prompt text from input
-PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
-
 # Skip short prompts (greetings, single words, etc.)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
 if [ -z "$PROMPT" ] || [ "${#PROMPT}" -lt 10 ]; then
   echo '{}'
   exit 0
 fi
 
-# Need memsearch for semantic search
+# Need memsearch available
 if [ -z "$MEMSEARCH_CMD" ]; then
   echo '{}'
   exit 0
 fi
 
-# Run semantic search
-search_results=$($MEMSEARCH_CMD search "$PROMPT" --top-k 3 --json-output 2>/dev/null || true)
-
-# Check if we got meaningful results
-if [ -z "$search_results" ] || [ "$search_results" = "[]" ] || [ "$search_results" = "null" ]; then
-  echo '{}'
-  exit 0
-fi
-
-# Format results as compact index with chunk_hash for expand/transcript drill-down
-formatted=$(echo "$search_results" | jq -r '
-  to_entries | .[]? |
-  "- [\(.value.source // "unknown"):\(.value.heading // "")] " +
-  " \(.value.content // "" | .[0:200])\n" +
-  "  `chunk_hash: \(.value.chunk_hash // "")`"
-' 2>/dev/null || true)
-
-if [ -z "$formatted" ]; then
-  echo '{}'
-  exit 0
-fi
-
-context="## Relevant Memories\n$formatted"
-json_context=$(printf '%s' "$context" | jq -Rs .)
-echo "{\"hookSpecificOutput\": {\"hookEventName\": \"UserPromptSubmit\", \"additionalContext\": $json_context}}"
+echo '{"systemMessage": "[memsearch] Memory available"}'

--- a/ccplugin/skills/memory-recall/SKILL.md
+++ b/ccplugin/skills/memory-recall/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: memory-recall
+description: "Search and recall relevant memories from past sessions. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge. Also use when you see '[memsearch] Memory available' hints."
+context: fork
+allowed-tools: Bash
+---
+
+You are a memory retrieval agent for memsearch. Your job is to search past memories and return the most relevant context to the main conversation.
+
+## Your Task
+
+Search for memories relevant to: $ARGUMENTS
+
+## Steps
+
+1. **Search**: Run `memsearch search "<query>" --top-k 5 --json-output` to find relevant chunks.
+   - If `memsearch` is not found, try `uvx memsearch` instead.
+   - Choose a search query that captures the core intent of the user's question.
+
+2. **Evaluate**: Look at the search results. Skip chunks that are clearly irrelevant or too generic.
+
+3. **Expand**: For each relevant result, run `memsearch expand <chunk_hash>` to get the full markdown section with surrounding context.
+
+4. **Deep drill (optional)**: If an expanded chunk contains transcript anchors (JSONL path + turn UUID), and the original conversation seems critical, run:
+   ```
+   memsearch transcript <jsonl_path> --turn <uuid> --context 3
+   ```
+   to retrieve the original conversation turns.
+
+5. **Return results**: Output a curated summary of the most relevant memories. Be concise — only include information that is genuinely useful for the user's current question.
+
+## Output Format
+
+Organize by relevance. For each memory include:
+- The key information (decisions, patterns, solutions, context)
+- Source reference (file name, date) for traceability
+
+If nothing relevant is found, simply say "No relevant memories found."


### PR DESCRIPTION
## Summary
- Replace the `UserPromptSubmit` hook's per-prompt semantic search with a **memory-recall skill** (`context: fork`) that runs in a forked subagent context
- The subagent autonomously handles all three progressive disclosure layers (search → expand → transcript) and returns only a curated summary to the main agent
- Simplify `UserPromptSubmit` hook to a lightweight `systemMessage` hint ("[memsearch] Memory available")
- Remove semantic search and Memory Tools instruction injection from `SessionStart` hook (keep cold-start context)

## Why
The previous push-based architecture had three pain points:
1. **Unnecessary injection** — 3 memories injected on every prompt, even when irrelevant
2. **L2/L3 unreachable** — Main agent rarely expanded memories via `memsearch expand`
3. **Main agent distraction** — Memory instructions competed with the user's actual task

The skill-based approach solves all three: Claude only recalls when needed, the subagent handles all layers in isolation, and the main context stays clean.

## Test plan
- [x] Verified with tmux-based interactive CC test session (`claude --debug --plugin-dir ./ccplugin`)
- [x] Memory-needing prompt: Claude auto-invoked `Skill(memsearch:memory-recall)`, subagent ran search + expand, returned curated summary
- [x] Non-memory prompt: Only `[memsearch] Memory available` hint shown, skill not triggered
- [ ] Edge case: `/memory-recall <query>` manual invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)