### PR TITLE
ccplugin: provider-aware API key check and status display

### DIFF
--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -134,7 +134,15 @@ def resolve_config(cli_overrides: dict[str, Any] | None = None) -> MemSearchConf
     result = deep_merge(result, load_config_file(PROJECT_CONFIG_PATH))
     if cli_overrides:
         result = deep_merge(result, cli_overrides)
-    return _dict_to_config(result)
+    cfg = _dict_to_config(result)
+
+    # Fill in the provider's default model when model is empty
+    if not cfg.embedding.model:
+        from .embeddings import DEFAULT_MODELS
+
+        cfg.embedding.model = DEFAULT_MODELS.get(cfg.embedding.provider, "")
+
+    return cfg
 
 
 def save_config(cfg_dict: dict[str, Any], path: Path | str) -> None:

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -27,6 +27,16 @@ _PROVIDERS: dict[str, tuple[str, str]] = {
     "local": ("memsearch.embeddings.local", "LocalEmbedding"),
 }
 
+# Default model for each provider (mirrors the __init__ defaults in each class).
+# Kept here so callers can resolve the effective model without importing heavy deps.
+DEFAULT_MODELS: dict[str, str] = {
+    "openai": "text-embedding-3-small",
+    "google": "gemini-embedding-001",
+    "voyage": "voyage-3-lite",
+    "ollama": "nomic-embed-text",
+    "local": "all-MiniLM-L6-v2",
+}
+
 _INSTALL_HINTS: dict[str, str] = {
     "openai": 'pip install memsearch  (or: uv add memsearch)',
     "google": 'pip install "memsearch[google]"  (or: uv add "memsearch[google]")',
@@ -75,4 +85,4 @@ def get_provider(
     return cls(**kwargs)
 
 
-__all__ = ["EmbeddingProvider", "get_provider"]
+__all__ = ["DEFAULT_MODELS", "EmbeddingProvider", "get_provider"]


### PR DESCRIPTION
## Summary
- Replace hardcoded `OPENAI_API_KEY` check with dynamic provider-based detection — `ollama`/`local` providers no longer trigger false "key missing" warnings
- SessionStart `systemMessage` now shows embedding provider, model name, and Milvus URI (e.g. `[memsearch] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db`)
- Add `DEFAULT_MODELS` dict to `embeddings/__init__.py` and resolve default model in `resolve_config()` so `memsearch config get embedding.model` returns the effective model name instead of empty string
- `stop.sh` uses the same provider-aware key check

## Test plan
- [x] `uv run python -m pytest` — 33 tests passed
- [x] tmux interactive test: SessionStart shows `openai/text-embedding-3-small` with correct milvus URI
- [x] tmux interactive test: unset `OPENAI_API_KEY` shows `ERROR: OPENAI_API_KEY not set — memory search disabled`
- [x] `memsearch config get embedding.model` returns `text-embedding-3-small` (was empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)