### PR TITLE
docs: add UPDATE troubleshooting with upgrade instructions

### DIFF
--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -485,3 +485,20 @@ memsearch config set embedding.provider ollama
 ```
 
 To make it permanent, add the export to your `~/.bashrc`, `~/.zshrc`, or equivalent.
+
+### "UPDATE: v0.x.x available"
+
+The plugin checks PyPI at session start and shows this hint when a newer version exists. How to upgrade depends on your installation method:
+
+```bash
+# If installed via uv tool
+uv tool upgrade memsearch
+
+# If installed via pip
+pip install --upgrade memsearch
+
+# If using uvx (auto-upgraded on each session — you shouldn't see this)
+uvx --upgrade memsearch --version
+```
+
+> **Note:** `uvx` users get automatic upgrades — the plugin runs `uvx --upgrade` on every bootstrap. The `UPDATE` hint primarily helps `pip`/`uv tool` users who have no automatic update mechanism.

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -642,3 +642,20 @@ memsearch config set embedding.provider ollama
 ```
 
 To make it permanent, add the export to your `~/.bashrc`, `~/.zshrc`, or equivalent.
+
+### "UPDATE: v0.x.x available"
+
+The plugin checks PyPI at session start and shows this hint when a newer version exists. How to upgrade depends on your installation method:
+
+```bash
+# If installed via uv tool
+uv tool upgrade memsearch
+
+# If installed via pip
+pip install --upgrade memsearch
+
+# If using uvx (auto-upgraded on each session -- you shouldn't see this)
+uvx --upgrade memsearch --version
+```
+
+> **Note:** `uvx` users get automatic upgrades -- the plugin runs `uvx --upgrade` on every bootstrap. The `UPDATE` hint primarily helps `pip`/`uv tool` users who have no automatic update mechanism.


### PR DESCRIPTION
## Summary
- Add "UPDATE: v0.x.x available" section to Troubleshooting in both `ccplugin/README.md` and `docs/claude-plugin.md`
- Shows upgrade commands for each installation method (`uv tool upgrade`, `pip install --upgrade`, `uvx --upgrade`)
- Notes that `uvx` users get auto-upgrade and shouldn't normally see the hint

## Test plan
- [x] Markdown renders correctly (code blocks, blockquote note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)