### PR TITLE
ccplugin: add python3 fallback for jq dependency

### DIFF
--- a/ccplugin/hooks/parse-transcript.sh
+++ b/ccplugin/hooks/parse-transcript.sh
@@ -13,6 +13,12 @@
 
 set -euo pipefail
 
+# parse-transcript requires jq for JSON processing; gracefully degrade if missing
+if ! command -v jq &>/dev/null; then
+  echo "(transcript parsing skipped — jq not installed)"
+  exit 0
+fi
+
 TRANSCRIPT_PATH="${1:-}"
 MAX_LINES="${MEMSEARCH_MAX_LINES:-200}"
 MAX_CHARS="${MEMSEARCH_MAX_CHARS:-500}"
@@ -63,7 +69,7 @@ tail -n "$MAX_LINES" "$TRANSCRIPT_PATH" | while IFS= read -r line; do
   ts_short=""
   if [ -n "$ts" ]; then
     # Extract HH:MM:SS from ISO timestamp
-    ts_short=$(printf '%s' "$ts" | grep -oP 'T\K[0-9]{2}:[0-9]{2}:[0-9]{2}' 2>/dev/null || echo "")
+    ts_short=$(printf '%s' "$ts" | sed -n 's/.*T\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\).*/\1/p' 2>/dev/null || echo "")
   fi
 
   if [ "$entry_type" = "user" ]; then

--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Prevent infinite loop: if this Stop was triggered by a previous Stop hook, bail out
-STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null)
+STOP_HOOK_ACTIVE=$(_json_val "$INPUT" "stop_hook_active" "false")
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   echo '{}'
   exit 0
@@ -29,7 +29,7 @@ if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
 fi
 
 # Extract transcript path from hook input
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+TRANSCRIPT_PATH=$(_json_val "$INPUT" "transcript_path" "")
 
 if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   echo '{}'

--- a/ccplugin/hooks/user-prompt-submit.sh
+++ b/ccplugin/hooks/user-prompt-submit.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Skip short prompts (greetings, single words, etc.)
-PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+PROMPT=$(_json_val "$INPUT" "prompt" "")
 if [ -z "$PROMPT" ] || [ "${#PROMPT}" -lt 10 ]; then
   echo '{}'
   exit 0


### PR DESCRIPTION
## Summary
- Add `_json_val` and `_json_encode_str` helper functions to `common.sh` that prefer `jq` but fall back to `python3` when `jq` is not installed
- Replace all direct `jq` calls in `stop.sh`, `user-prompt-submit.sh`, and `session-start.sh` with the new helpers
- Add graceful degradation to `parse-transcript.sh` when `jq` is missing (exits cleanly, protected by existing `|| true`)
- Replace `grep -oP` with POSIX `sed -n` in `parse-transcript.sh` for macOS compatibility

Fixes #46

## Test plan
- [ ] Verify all hooks work normally when `jq` is installed (fast path unchanged)
- [ ] Verify hooks work when `jq` is hidden from PATH (python3 fallback)
- [ ] Verify `parse-transcript.sh` exits gracefully without `jq`
- [ ] Verify timestamp extraction works on macOS (sed -n vs grep -oP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)