### PR TITLE
docs: redraw systemMessage mockup to match real TUI

### DIFF
--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -486,21 +486,21 @@ Hooks communicate with Claude Code by returning JSON. Two key fields:
 Here is what a session looks like with the plugin installed:
 
 ```
- ╭──────────────────────────────────────────────────────────────╮
- │ ✻ Welcome to Claude Code!                                    │
- │                                                              │
- │   /help for help, /status for your current setup             │
- │   cwd: ~/my-project                                         │
- ╰──────────────────────────────────────────────────────────────╯
+   ✻
+   |
+  ▟█▙     Claude Code v2.x.x
+▐▛███▜▌   Model · Plan
+▝▜█████▛▘  ~/my-project
+ ▘▘ ▝▝
+ ⎿  SessionStart:startup says: [memsearch v0.1.11]        ← systemMessage
+    embedding: openai/text-embedding-3-small | milvus:       (SessionStart hook)
+    ~/.memsearch/milvus.db
 
- ℹ [memsearch v0.1.11] embedding: openai/text-embedding-3-      ← SessionStart
-   small | milvus: ~/.memsearch/milvus.db                          systemMessage
+❯ How does the caching layer work?
 
- > How does the caching layer work?
-
- ℹ [memsearch] Memory available                                  ← UserPromptSubmit
-                                                                   systemMessage
- Based on our previous sessions, the caching layer uses...
+ ⎿  UserPromptSubmit says: [memsearch] Memory available    ← systemMessage
+                                                             (UserPromptSubmit hook)
+✶ Thinking…
 ```
 
 The SessionStart hook also loads the 2 most recent daily logs as `additionalContext` — Claude reads this silently to decide when to invoke the memory-recall skill, but you won't see it in the terminal.

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -643,21 +643,21 @@ Hooks communicate with Claude Code by returning JSON. Two key fields:
 Here is what a session looks like with the plugin installed:
 
 ```
- ╭──────────────────────────────────────────────────────────────╮
- │ ✻ Welcome to Claude Code!                                    │
- │                                                              │
- │   /help for help, /status for your current setup             │
- │   cwd: ~/my-project                                         │
- ╰──────────────────────────────────────────────────────────────╯
+   ✻
+   |
+  ▟█▙     Claude Code v2.x.x
+▐▛███▜▌   Model · Plan
+▝▜█████▛▘  ~/my-project
+ ▘▘ ▝▝
+ ⎿  SessionStart:startup says: [memsearch v0.1.11]        ← systemMessage
+    embedding: openai/text-embedding-3-small | milvus:       (SessionStart hook)
+    ~/.memsearch/milvus.db
 
- ℹ [memsearch v0.1.11] embedding: openai/text-embedding-3-      ← SessionStart
-   small | milvus: ~/.memsearch/milvus.db                          systemMessage
+❯ How does the caching layer work?
 
- > How does the caching layer work?
-
- ℹ [memsearch] Memory available                                  ← UserPromptSubmit
-                                                                   systemMessage
- Based on our previous sessions, the caching layer uses...
+ ⎿  UserPromptSubmit says: [memsearch] Memory available    ← systemMessage
+                                                             (UserPromptSubmit hook)
+✶ Thinking…
 ```
 
 The SessionStart hook also loads the 2 most recent daily logs as `additionalContext` — Claude reads this silently to decide when to invoke the memory-recall skill, but you won't see it in the terminal.


### PR DESCRIPTION
## Summary
- Redraw the ASCII mockup in Troubleshooting to match the actual Claude Code TUI, verified by launching a real session in tmux
- The old mockup used a fabricated box-drawing style that doesn't resemble the real UI
- Updated in both `docs/claude-plugin.md` and `ccplugin/README.md`

## Test plan
- [x] Launched real Claude Code session in tmux to capture actual UI
- [ ] Verify mockup renders correctly in mkdocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)