### PR TITLE
fix: batch embedding requests to respect provider API limits

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -143,7 +143,13 @@ class MemSearch:
 
         model = self._embedder.model_name
         contents = [c.content for c in chunks]
-        embeddings = await self._embedder.embed(contents)
+
+        # Batch embedding requests to respect provider-specific API limits
+        batch_size = self._embedder.max_batch_size
+        embeddings: list[list[float]] = []
+        for i in range(0, len(contents), batch_size):
+            batch = contents[i:i + batch_size]
+            embeddings.extend(await self._embedder.embed(batch))
 
         records: list[dict[str, Any]] = []
         for i, chunk in enumerate(chunks):

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -15,6 +15,9 @@ class EmbeddingProvider(Protocol):
     @property
     def dimension(self) -> int: ...
 
+    @property
+    def max_batch_size(self) -> int: ...
+
     async def embed(self, texts: list[str]) -> list[list[float]]: ...
 
 

--- a/src/memsearch/embeddings/google.py
+++ b/src/memsearch/embeddings/google.py
@@ -35,6 +35,10 @@ class GoogleEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def max_batch_size(self) -> int:
+        return 100
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from google.genai import types
 

--- a/src/memsearch/embeddings/local.py
+++ b/src/memsearch/embeddings/local.py
@@ -44,6 +44,10 @@ class LocalEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def max_batch_size(self) -> int:
+        return 512
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         loop = asyncio.get_running_loop()
         embeddings = await loop.run_in_executor(

--- a/src/memsearch/embeddings/ollama.py
+++ b/src/memsearch/embeddings/ollama.py
@@ -29,6 +29,10 @@ class OllamaEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def max_batch_size(self) -> int:
+        return 512
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         result = await self._client.embed(model=self._model, input=texts)
         return result["embeddings"]

--- a/src/memsearch/embeddings/openai.py
+++ b/src/memsearch/embeddings/openai.py
@@ -34,6 +34,10 @@ class OpenAIEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def max_batch_size(self) -> int:
+        return 2048
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         resp = await self._client.embeddings.create(input=texts, model=self._model)
         return [item.embedding for item in resp.data]

--- a/src/memsearch/embeddings/voyage.py
+++ b/src/memsearch/embeddings/voyage.py
@@ -26,6 +26,10 @@ class VoyageEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def max_batch_size(self) -> int:
+        return 128
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         result = await self._client.embed(texts, model=self._model)
         return result.embeddings

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -1,0 +1,108 @@
+"""Tests for embedding batch-size handling in _embed_and_store().
+
+Uses a fake embedding provider to verify that large chunk lists are
+split into batches that respect the provider's max_batch_size limit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memsearch.chunker import Chunk
+from memsearch.core import MemSearch
+from memsearch.store import MilvusStore
+
+
+class FakeEmbedder:
+    """Fake embedding provider that records batch sizes."""
+
+    def __init__(self, *, max_batch: int = 4, dim: int = 4) -> None:
+        self._max_batch = max_batch
+        self._dim = dim
+        self.call_sizes: list[int] = []
+
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    @property
+    def max_batch_size(self) -> int:
+        return self._max_batch
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        if len(texts) > self._max_batch:
+            raise ValueError(
+                f"Received {len(texts)} texts, max is {self._max_batch}"
+            )
+        self.call_sizes.append(len(texts))
+        return [[0.0] * self._dim for _ in texts]
+
+
+@pytest.fixture
+def mem_with_fake(tmp_path: Path):
+    """MemSearch instance wired to a FakeEmbedder with max_batch_size=4."""
+    fake = FakeEmbedder(max_batch=4, dim=4)
+    ms = MemSearch.__new__(MemSearch)
+    ms._paths = []
+    ms._max_chunk_size = 1500
+    ms._overlap_lines = 2
+    ms._embedder = fake
+    ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
+    yield ms, fake
+    ms.close()
+
+
+def _make_chunks(n: int) -> list[Chunk]:
+    return [
+        Chunk(
+            content=f"chunk {i}",
+            source="test.md",
+            heading="",
+            heading_level=0,
+            start_line=i,
+            end_line=i,
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batching_splits_large_requests(mem_with_fake):
+    ms, fake = mem_with_fake
+    chunks = _make_chunks(10)  # 10 chunks, batch size 4
+    n = await ms._embed_and_store(chunks)
+    assert n == 10
+    # Should have been split into 3 batches: 4 + 4 + 2
+    assert fake.call_sizes == [4, 4, 2]
+
+
+@pytest.mark.asyncio
+async def test_batching_single_batch_under_limit(mem_with_fake):
+    ms, fake = mem_with_fake
+    chunks = _make_chunks(3)  # 3 chunks, batch size 4
+    n = await ms._embed_and_store(chunks)
+    assert n == 3
+    assert fake.call_sizes == [3]
+
+
+@pytest.mark.asyncio
+async def test_batching_exact_batch_size(mem_with_fake):
+    ms, fake = mem_with_fake
+    chunks = _make_chunks(4)  # exactly batch size
+    n = await ms._embed_and_store(chunks)
+    assert n == 4
+    assert fake.call_sizes == [4]
+
+
+@pytest.mark.asyncio
+async def test_batching_empty_chunks(mem_with_fake):
+    ms, fake = mem_with_fake
+    n = await ms._embed_and_store([])
+    assert n == 0
+    assert fake.call_sizes == []


### PR DESCRIPTION
## Summary

- Adds `max_batch_size` property to `EmbeddingProvider` Protocol and all 5 provider implementations (Google: 100, Voyage: 128, OpenAI: 2048, Ollama: 512, Local: 512)
- Modifies `_embed_and_store()` in `core.py` to batch embedding requests according to each provider's limit instead of sending all chunks in a single API call
- Adds tests for batching logic in `tests/test_embed_batching.py`

Fixes #72 

## Test plan

- [x] `uv run python -m pytest tests/test_embed_batching.py` — 4 tests pass
- [x] Manual test with Google Gemini provider on a file producing >100 chunks