### PR TITLE
fix: escape backslashes in Milvus filter expressions for Windows paths

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -234,7 +234,8 @@ class MemSearch:
         str
             The generated summary markdown.
         """
-        filter_expr = f'source == "{source}"' if source else ""
+        from .store import _escape_filter_value
+        filter_expr = f'source == "{_escape_filter_value(source)}"' if source else ""
         all_chunks = self._store.query(filter_expr=filter_expr)
         if not all_chunks:
             return ""


### PR DESCRIPTION
## Summary

- Adds `_escape_filter_value()` helper in `store.py` that escapes backslashes and double quotes before passing values to Milvus filter expressions
- Applies escaping in `hashes_by_source()`, `delete_by_source()`, and `compact()` to prevent `token recognition error` on Windows paths like `D:\temp\mems\`

Fixes #66

## Test plan

- [x] Verify on Windows with paths containing backslashes (e.g. `D:\temp\mems\memory\file.md`)
- [x] Verify paths with double quotes are handled correctly