### PR TITLE
fix: deduplicate stop-hook summaries with deferred summarization

### DIFF
--- a/ccplugin/hooks/common.sh
+++ b/ccplugin/hooks/common.sh
@@ -1,26 +1,31 @@
 #!/usr/bin/env bash
-# Shared setup for memsearch command hooks.
-# Sourced by all hook scripts — not executed directly.
+# common.sh — shared utilities for all memsearch hooks.
+# Sourced (not executed) by every hook script.
 
 set -euo pipefail
 
-# Read stdin JSON into $INPUT
+# shellcheck disable=SC2034  # INPUT is read by scripts that source this file.
 INPUT="$(cat)"
 
-# Ensure common user bin paths are in PATH (hooks may run in a minimal env)
+# Hooks may run in a minimal environment; ensure common bin paths are available.
 for p in "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/bin" "/usr/local/bin"; do
   [[ -d "$p" ]] && [[ ":$PATH:" != *":$p:"* ]] && export PATH="$p:$PATH"
 done
 
-# Hooks directory (where this file lives)
-HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
 
-# Memory directory and memsearch state directory are project-scoped
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MEMSEARCH_DIR="${CLAUDE_PROJECT_DIR:-.}/.memsearch"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 PENDING_DIR="$MEMSEARCH_DIR/.pending"
+WATCH_PIDFILE="$MEMSEARCH_DIR/.watch.pid"
 
-# Find memsearch binary: prefer PATH, fallback to uvx
+# ---------------------------------------------------------------------------
+# memsearch binary detection
+# ---------------------------------------------------------------------------
+
 _detect_memsearch() {
   MEMSEARCH_CMD=""
   if command -v memsearch &>/dev/null; then
@@ -31,20 +36,21 @@ _detect_memsearch() {
 }
 _detect_memsearch
 
-# Short command prefix for injected instructions (falls back to "memsearch" even if unavailable)
+# Used in injected instructions even when the binary is absent.
+# shellcheck disable=SC2034
 MEMSEARCH_CMD_PREFIX="${MEMSEARCH_CMD:-memsearch}"
 
-# --- JSON helpers (jq preferred, python3 fallback) ---
+# ---------------------------------------------------------------------------
+# JSON helpers  (prefer jq, fall back to python3)
+# ---------------------------------------------------------------------------
 
-# _json_val <json_string> <dotted_key> [default]
-# Extract a value from JSON. Key supports dotted notation (e.g. "info.version").
-# Returns the default (or empty string) if the key is missing or extraction fails.
+# _json_val <json> <dotted.key> [default]
+# Extract a scalar value. Returns default (or "") on missing key / parse error.
 _json_val() {
   local json="$1" key="$2" default="${3:-}"
   local result=""
 
   if command -v jq &>/dev/null; then
-    # Build jq filter from dotted key: "info.version" → ".info.version"
     result=$(printf '%s' "$json" | jq -r ".${key} // empty" 2>/dev/null) || true
   else
     result=$(python3 -c "
@@ -65,41 +71,34 @@ except Exception:
 " "$json" "$key" 2>/dev/null) || true
   fi
 
-  if [ -z "$result" ]; then
-    printf '%s' "$default"
-  else
-    printf '%s' "$result"
-  fi
+  printf '%s' "${result:-$default}"
   return 0
 }
 
 # _json_encode_str <string>
-# Encode a string as a JSON string (with surrounding quotes).
+# Return a JSON-encoded string (with surrounding quotes).
 _json_encode_str() {
   local str="$1"
   if command -v jq &>/dev/null; then
     printf '%s' "$str" | jq -Rs . 2>/dev/null && return 0
   fi
   printf '%s' "$str" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null && return 0
-  # Last resort: simple quoting (no special char escaping)
   printf '"%s"' "$str"
   return 0
 }
 
-# Helper: ensure memory directory exists
-ensure_memory_dir() {
-  mkdir -p "$MEMORY_DIR"
-}
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
 
-# Helper: run memsearch with arguments, silently fail if not available
+ensure_memory_dir() { mkdir -p "$MEMORY_DIR"; }
+
+# Run memsearch silently; no-op when the binary is unavailable.
 run_memsearch() {
-  if [ -n "$MEMSEARCH_CMD" ]; then
-    $MEMSEARCH_CMD "$@" 2>/dev/null || true
-  fi
+  [ -n "$MEMSEARCH_CMD" ] && $MEMSEARCH_CMD "$@" 2>/dev/null || true
 }
 
-# Helper: check if the embedding provider's API key is set.
-# Returns 0 (true) if key is present or not required, 1 (false) if missing.
+# Return 0 if the configured embedding provider's API key is set (or not required).
 _check_embedding_key() {
   local provider
   provider=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "openai")
@@ -108,92 +107,77 @@ _check_embedding_key() {
     openai) req_key="OPENAI_API_KEY" ;;
     google) req_key="GOOGLE_API_KEY" ;;
     voyage) req_key="VOYAGE_API_KEY" ;;
-    *) return 0 ;;  # ollama, local — no API key needed
+    *) return 0 ;;
   esac
   [ -z "$req_key" ] || [ -n "${!req_key:-}" ]
 }
 
-# --- Watch singleton management ---
+# ---------------------------------------------------------------------------
+# Watch process management  (singleton per project)
+# ---------------------------------------------------------------------------
 
-WATCH_PIDFILE="$MEMSEARCH_DIR/.watch.pid"
-
-# Kill a process and its entire process group to avoid orphans
 _kill_tree() {
   local pid="$1"
-  # Kill the process group (negative PID) to catch child processes
   kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
 }
 
-# Stop the watch process: pidfile first, then sweep for orphans
 stop_watch() {
-  # 1. Kill the process recorded in pidfile
   if [ -f "$WATCH_PIDFILE" ]; then
     local pid
     pid=$(cat "$WATCH_PIDFILE" 2>/dev/null)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      _kill_tree "$pid"
-    fi
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && _kill_tree "$pid"
     rm -f "$WATCH_PIDFILE"
   fi
-
-  # 2. Sweep for orphaned watch processes targeting this MEMORY_DIR
+  # Sweep for orphaned watchers targeting the same directory.
   local orphans
   orphans=$(pgrep -f "memsearch watch $MEMORY_DIR" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
-    echo "$orphans" | while read -r opid; do
-      kill "$opid" 2>/dev/null || true
-    done
+    echo "$orphans" | while read -r opid; do kill "$opid" 2>/dev/null || true; done
   fi
 }
 
-# Start memsearch watch — always stop-then-start to pick up config changes
+# Always restart to pick up any config changes (uri, provider, etc.).
 start_watch() {
-  if [ -z "$MEMSEARCH_CMD" ]; then
-    return 0
-  fi
+  [ -z "$MEMSEARCH_CMD" ] && return 0
   ensure_memory_dir
-
-  # Always restart: ensures latest config (milvus_uri, etc.) is used
   stop_watch
-
+  # shellcheck disable=SC2086  # Intentional word splitting: MEMSEARCH_CMD may be "uvx memsearch".
   nohup $MEMSEARCH_CMD watch "$MEMORY_DIR" &>/dev/null &
-  echo $! > "$WATCH_PIDFILE"
+  echo $! >"$WATCH_PIDFILE"
 }
 
-# --- Pending session management (stop-hook dedup) ---
+# ---------------------------------------------------------------------------
+# Deferred summarization  (Stop-hook dedup)
 #
-# The Stop hook fires after every assistant turn, but we only want one summary
-# per session. Stop only records the transcript path in a lightweight state file
-# (overwriting each time — last writer wins). The expensive work (parsing +
-# Haiku summarization) happens exactly once in flush_pending(), called by
-# SessionEnd (and by SessionStart as a safety net for crashed sessions).
+# The Stop hook fires after every assistant turn, but we only need one summary
+# per session. Stop records the transcript path in a lightweight state file
+# (overwriting on each turn). The expensive work — parsing + LLM call —
+# runs exactly once via flush_pending(), triggered by SessionEnd (or by
+# SessionStart as a safety net for crashed sessions).
+# ---------------------------------------------------------------------------
 
-# Summarize a single pending session and append to its daily .md file.
-# Args: $1 = pending state file path
+# Summarize one pending session and append the result to its daily .md.
 _summarize_pending() {
   local pending="$1"
   [ -f "$pending" ] || return 0
 
-  # Read state: line 1 = transcript path, line 2 = target date
+  # State file format: line 1 = transcript path, line 2 = target date.
   local transcript_path target_date
   transcript_path=$(sed -n '1p' "$pending")
   target_date=$(sed -n '2p' "$pending")
 
-  # Validate
   if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ] || [ -z "$target_date" ]; then
     rm -f "$pending"
     return 0
   fi
 
-  # Skip empty transcripts (< 3 lines = no real content)
   local line_count
-  line_count=$(wc -l < "$transcript_path" 2>/dev/null || echo "0")
+  line_count=$(wc -l <"$transcript_path" 2>/dev/null || echo "0")
   if [ "$line_count" -lt 3 ]; then
     rm -f "$pending"
     return 0
   fi
 
-  # Parse transcript into concise text
   local parsed
   parsed=$("$HOOKS_DIR/parse-transcript.sh" "$transcript_path" 2>/dev/null || true)
   if [ -z "$parsed" ] || [ "$parsed" = "(empty transcript)" ]; then
@@ -201,7 +185,7 @@ _summarize_pending() {
     return 0
   fi
 
-  # Extract session ID and last user turn UUID for progressive disclosure anchors
+  # Extract metadata for the progressive-disclosure anchor.
   local session_id last_turn_uuid
   session_id=$(basename "$pending")
   last_turn_uuid=$(python3 -c "
@@ -217,7 +201,7 @@ with open(sys.argv[1]) as f:
 print(uuid)
 " "$transcript_path" 2>/dev/null || true)
 
-  # Summarize with claude -p (model configurable via MEMSEARCH_SUMMARY_MODEL)
+  # Model is configurable via env var (default: haiku).
   local summary_model="${MEMSEARCH_SUMMARY_MODEL:-haiku}"
   local summary=""
   if command -v claude &>/dev/null; then
@@ -236,12 +220,9 @@ Rules:
       2>/dev/null || true)
   fi
 
-  # Fallback to raw parsed output if claude unavailable or returned empty
-  if [ -z "$summary" ]; then
-    summary="$parsed"
-  fi
+  # Fall back to raw parsed text when claude is unavailable.
+  [ -z "$summary" ] && summary="$parsed"
 
-  # Append to daily .md
   local now memory_file
   now=$(date +%H:%M)
   memory_file="$MEMORY_DIR/${target_date}.md"
@@ -252,18 +233,16 @@ Rules:
     echo "<!-- session:${session_id} turn:${last_turn_uuid} transcript:${transcript_path} -->"
     echo "$summary"
     echo ""
-  } >> "$memory_file"
+  } >>"$memory_file"
 
   rm -f "$pending"
 }
 
-# Flush all pending sessions: summarize each and re-index.
+# Process all pending state files, then re-index.
 flush_pending() {
   [ -d "$PENDING_DIR" ] || return 0
 
-  # Check embedding API key — skip if missing (indexing would fail anyway)
   if ! _check_embedding_key; then
-    # Clean up pending files since we can't process them
     rm -rf "$PENDING_DIR"
     return 0
   fi
@@ -275,11 +254,6 @@ flush_pending() {
     flushed=true
   done
 
-  # Re-index after flushing so memories become searchable immediately
-  if [ "$flushed" = true ]; then
-    run_memsearch index "$MEMORY_DIR"
-  fi
-
-  # Clean up empty pending dir
+  [ "$flushed" = true ] && run_memsearch index "$MEMORY_DIR"
   rmdir "$PENDING_DIR" 2>/dev/null || true
 }

--- a/ccplugin/hooks/parse-transcript.sh
+++ b/ccplugin/hooks/parse-transcript.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
-# Parse a Claude Code JSONL transcript into a concise text summary
-# suitable for AI summarization.
+# parse-transcript.sh — convert a Claude Code JSONL transcript into concise
+# plain text suitable for LLM summarization.
 #
 # Usage: bash parse-transcript.sh <transcript_path>
 #
-# Truncation rules:
-#   - Only process the last MAX_LINES lines (default 200)
-#   - User/assistant text content > MAX_CHARS chars (default 500) is truncated to tail
-#   - Tool calls: only output tool name + truncated input summary
-#   - Tool results: only output a one-line truncated preview
-#   - Skip file-history-snapshot entries entirely
+# Truncation:
+#   - Process only the last MAX_LINES lines  (env MEMSEARCH_MAX_LINES, default 200)
+#   - Text blocks > MAX_CHARS characters      (env MEMSEARCH_MAX_CHARS, default 500)
+#     are tail-truncated with a leading "..."
+#   - Tool calls:    tool name + truncated input summary
+#   - Tool results:  one-line truncated preview
+#   - file-history-snapshot entries are skipped entirely
 
 set -euo pipefail
 
-# parse-transcript requires jq for JSON processing; gracefully degrade if missing
 if ! command -v jq &>/dev/null; then
   echo "(transcript parsing skipped — jq not installed)"
   exit 0
@@ -28,27 +28,30 @@ if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   exit 1
 fi
 
-# Count total lines for context
-TOTAL_LINES=$(wc -l < "$TRANSCRIPT_PATH")
-
+TOTAL_LINES=$(wc -l <"$TRANSCRIPT_PATH")
 if [ "$TOTAL_LINES" -eq 0 ]; then
   echo "(empty transcript)"
   exit 0
 fi
 
-# Helper: truncate text to last N chars
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Keep the last $2 characters of $1; prepend "..." when truncated.
 truncate_tail() {
-  local text="$1"
-  local max="$2"
-  local len=${#text}
-  if [ "$len" -le "$max" ]; then
+  local text="$1" max="$2"
+  if [ "${#text}" -le "$max" ]; then
     printf '%s' "$text"
   else
     printf '...%s' "${text: -$max}"
   fi
 }
 
-# Print header
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
 if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
   echo "=== Transcript (last $MAX_LINES of $TOTAL_LINES lines) ==="
 else
@@ -56,58 +59,42 @@ else
 fi
 echo ""
 
-# Process JSONL — take the last MAX_LINES, parse with jq line by line
 tail -n "$MAX_LINES" "$TRANSCRIPT_PATH" | while IFS= read -r line; do
-  # Extract type
   entry_type=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || continue
-
-  # Skip file snapshots
   [ "$entry_type" = "file-history-snapshot" ] && continue
 
-  # Extract timestamp
+  # Extract HH:MM:SS from ISO timestamp.
   ts=$(printf '%s' "$line" | jq -r '.timestamp // empty' 2>/dev/null)
   ts_short=""
-  if [ -n "$ts" ]; then
-    # Extract HH:MM:SS from ISO timestamp
-    ts_short=$(printf '%s' "$ts" | sed -n 's/.*T\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\).*/\1/p' 2>/dev/null || echo "")
-  fi
+  [ -n "$ts" ] && ts_short=$(printf '%s' "$ts" | sed -n 's/.*T\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\).*/\1/p' 2>/dev/null || echo "")
 
   if [ "$entry_type" = "user" ]; then
-    # Check if it's a tool_result or a normal user message
     content_type=$(printf '%s' "$line" | jq -r '.message.content | if type == "array" then .[0].type // "text" else "text" end' 2>/dev/null) || content_type="text"
 
     if [ "$content_type" = "tool_result" ]; then
-      # Tool result — one-line preview
       result_text=$(printf '%s' "$line" | jq -r '.message.content[0].content // "" | if type == "array" then .[0].text // "" else . end' 2>/dev/null)
-      result_short=$(truncate_tail "$result_text" "$MAX_CHARS")
-      echo "[${ts_short}] TOOL RESULT: ${result_short}"
+      echo "[${ts_short}] TOOL RESULT: $(truncate_tail "$result_text" "$MAX_CHARS")"
     else
-      # Normal user message
       user_text=$(printf '%s' "$line" | jq -r '.message.content // "" | if type == "array" then map(select(.type == "text") | .text) | join("\n") else . end' 2>/dev/null)
-      user_short=$(truncate_tail "$user_text" "$MAX_CHARS")
       echo ""
-      echo "[${ts_short}] USER: ${user_short}"
+      echo "[${ts_short}] USER: $(truncate_tail "$user_text" "$MAX_CHARS")"
     fi
 
   elif [ "$entry_type" = "assistant" ]; then
-    # Process each content block
     num_blocks=$(printf '%s' "$line" | jq -r '.message.content | length' 2>/dev/null) || num_blocks=0
 
-    for (( i=0; i<num_blocks; i++ )); do
+    for ((i = 0; i < num_blocks; i++)); do
       block_type=$(printf '%s' "$line" | jq -r ".message.content[$i].type // empty" 2>/dev/null)
 
       if [ "$block_type" = "text" ]; then
         text=$(printf '%s' "$line" | jq -r ".message.content[$i].text // empty" 2>/dev/null)
         [ -z "$text" ] && continue
-        text_short=$(truncate_tail "$text" "$MAX_CHARS")
-        echo "[${ts_short}] ASSISTANT: ${text_short}"
+        echo "[${ts_short}] ASSISTANT: $(truncate_tail "$text" "$MAX_CHARS")"
 
       elif [ "$block_type" = "tool_use" ]; then
         tool_name=$(printf '%s' "$line" | jq -r ".message.content[$i].name // \"unknown\"" 2>/dev/null)
-        # One-line summary of tool input
-        tool_input_summary=$(printf '%s' "$line" | jq -r ".message.content[$i].input | to_entries | map(\"\(.key)=\(.value | tostring | .[0:80])\") | join(\", \")" 2>/dev/null || echo "")
-        tool_input_short=$(truncate_tail "$tool_input_summary" 200)
-        echo "[${ts_short}] TOOL USE: ${tool_name}(${tool_input_short})"
+        tool_input=$(printf '%s' "$line" | jq -r ".message.content[$i].input | to_entries | map(\"\(.key)=\(.value | tostring | .[0:80])\") | join(\", \")" 2>/dev/null || echo "")
+        echo "[${ts_short}] TOOL USE: ${tool_name}($(truncate_tail "$tool_input" 200))"
       fi
     done
   fi

--- a/ccplugin/hooks/session-end.sh
+++ b/ccplugin/hooks/session-end.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# SessionEnd hook: flush pending summaries and stop the memsearch watch singleton.
+# SessionEnd hook — summarize the session and tear down the watcher.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-# Flush staged stop-hook summaries into daily .md files and re-index.
-# Must happen before stop_watch — the watcher may be killed before debounce fires.
+# Flush before stopping the watcher — it may be killed before its debounce fires.
 flush_pending
-
 stop_watch
 
 exit 0

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -1,38 +1,42 @@
 #!/usr/bin/env bash
-# SessionStart hook: start watch singleton + inject recent memory context.
+# SessionStart hook — bootstrap memsearch, inject recent memory context.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-# Bootstrap: if memsearch not available, install uv and warm up uvx cache
+# --- Auto-install via uvx if memsearch is not on PATH ----------------------
+
 if [ -z "$MEMSEARCH_CMD" ]; then
   if ! command -v uvx &>/dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null
     export PATH="$HOME/.local/bin:$PATH"
   fi
-  # Warm up uvx cache with --upgrade to pull latest version
-  # First run downloads packages (~2s); subsequent runs use cache (<0.3s)
   uvx --upgrade memsearch --version &>/dev/null || true
   _detect_memsearch
 fi
 
-# Read resolved config and version for status display
-PROVIDER="openai"; MODEL=""; MILVUS_URI=""; VERSION=""
+# --- Resolve config for status line ----------------------------------------
+
+PROVIDER="openai"
+MODEL=""
+MILVUS_URI=""
+VERSION=""
 if [ -n "$MEMSEARCH_CMD" ]; then
   PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "openai")
   MODEL=$($MEMSEARCH_CMD config get embedding.model 2>/dev/null || echo "")
   MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")
-  # "memsearch, version 0.1.10" → "0.1.10"
   VERSION=$($MEMSEARCH_CMD --version 2>/dev/null | sed 's/.*version //' || echo "")
 fi
 
-# Determine required API key for the configured provider
+# --- Check required API key ------------------------------------------------
+
 _required_env_var() {
   case "$1" in
     openai) echo "OPENAI_API_KEY" ;;
     google) echo "GOOGLE_API_KEY" ;;
     voyage) echo "VOYAGE_API_KEY" ;;
-    *) echo "" ;;  # ollama, local — no API key needed
+    *) echo "" ;;
   esac
 }
 REQUIRED_KEY=$(_required_env_var "$PROVIDER")
@@ -42,7 +46,8 @@ if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
   KEY_MISSING=true
 fi
 
-# Check PyPI for newer version (2s timeout, non-blocking on failure)
+# --- Check for newer version on PyPI (non-blocking, 2 s timeout) ----------
+
 UPDATE_HINT=""
 if [ -n "$VERSION" ]; then
   _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
@@ -52,65 +57,59 @@ if [ -n "$VERSION" ]; then
   fi
 fi
 
-# Build status line: version | provider/model | milvus | optional update/error
+# --- Build status line -----------------------------------------------------
+
 VERSION_TAG="${VERSION:+ v${VERSION}}"
 status="[memsearch${VERSION_TAG}] embedding: ${PROVIDER}/${MODEL:-unknown} | milvus: ${MILVUS_URI:-unknown}${UPDATE_HINT}"
-if [ "$KEY_MISSING" = true ]; then
-  status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
-fi
+[ "$KEY_MISSING" = true ] && status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
 
-# Flush any pending summaries from crashed sessions where SessionEnd didn't fire.
-# Safety net: ensures no staged summaries are lost between sessions.
+# --- Flush pending summaries from previous (possibly crashed) sessions -----
+
 ensure_memory_dir
 flush_pending
 
-# Write session heading to today's memory file
+# --- Write session heading -------------------------------------------------
+
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
 MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
-echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
+echo -e "\n## Session $NOW\n" >>"$MEMORY_FILE"
 
-# If API key is missing, show status and exit early (watch/search would fail)
+# Early exit when the API key is missing — watch and search would fail.
 if [ "$KEY_MISSING" = true ]; then
   json_status=$(_json_encode_str "$status")
   echo "{\"systemMessage\": $json_status}"
   exit 0
 fi
 
-# Start memsearch watch as a singleton background process.
-# This is the ONLY place indexing is managed — all other hooks just write .md files.
+# --- Start the file watcher ------------------------------------------------
+
 start_watch
 
-# Always include status in systemMessage
+# --- Inject cold-start context (last 2 daily logs) -------------------------
+
 json_status=$(_json_encode_str "$status")
 
-# If memory dir has no .md files (other than the one we just created), nothing to inject
 if [ ! -d "$MEMORY_DIR" ] || ! ls "$MEMORY_DIR"/*.md &>/dev/null; then
   echo "{\"systemMessage\": $json_status}"
   exit 0
 fi
 
 context=""
-
-# Find the 2 most recent daily log files (sorted by filename descending)
 recent_files=$(ls -1 "$MEMORY_DIR"/*.md 2>/dev/null | sort -r | head -2)
-
 if [ -n "$recent_files" ]; then
   context="# Recent Memory\n\n"
   for f in $recent_files; do
-    basename_f=$(basename "$f")
-    # Read last ~30 lines from each file
     content=$(tail -30 "$f" 2>/dev/null || true)
     if [ -n "$content" ]; then
-      context+="## $basename_f\n$content\n\n"
+      context+="## $(basename "$f")\n$content\n\n"
     fi
   done
 fi
 
-# Note: Detailed memory search is handled by the memory-recall skill (pull-based).
-# The cold-start context above gives Claude enough awareness of recent sessions
-# to decide when to invoke the skill for deeper recall.
-
+# Full memory search is handled by the memory-recall skill (pull-based).
+# This cold-start snippet gives Claude enough awareness to decide when
+# to invoke that skill for deeper recall.
 if [ -n "$context" ]; then
   json_context=$(_json_encode_str "$context")
   echo "{\"systemMessage\": $json_status, \"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": $json_context}}"

--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -1,45 +1,37 @@
 #!/usr/bin/env bash
-# Stop hook: record the transcript path for deferred summarization.
+# Stop hook — record the transcript path for deferred summarization.
 #
-# This hook fires after every assistant turn, but summarization is expensive
-# (Haiku API call). Instead of summarizing on every turn, we just save the
-# transcript path to a lightweight state file. The actual summarization
-# happens once in flush_pending() — called by SessionEnd (or SessionStart
-# as a safety net for crashed sessions).
+# Fires after every assistant turn. Instead of running an expensive LLM call
+# each time, we write a lightweight state file that flush_pending() (called
+# once by SessionEnd) will pick up and summarize.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-# Prevent infinite loop: if this Stop was triggered by a claude -p call
-# inside flush_pending, bail out.
-STOP_HOOK_ACTIVE=$(_json_val "$INPUT" "stop_hook_active" "false")
-if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+# Guard against recursion: flush_pending() calls claude -p, which may
+# re-trigger Stop hooks — bail out if that's the case.
+if [ "$(_json_val "$INPUT" "stop_hook_active" "false")" = "true" ]; then
   echo '{}'
   exit 0
 fi
 
-# Skip when the required API key is missing — the session likely only
-# contains the "key not set" warning, and flush would skip anyway.
+# Nothing useful to record when the embedding key is missing.
 if ! _check_embedding_key; then
   echo '{}'
   exit 0
 fi
 
-# Extract and validate transcript path from hook input
 TRANSCRIPT_PATH=$(_json_val "$INPUT" "transcript_path" "")
 if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   echo '{}'
   exit 0
 fi
 
-# Save transcript path to a pending state file.
-# Filename = session ID (derived from transcript). Content = path + date.
-# Each Stop invocation overwrites the same file (last-writer-wins),
-# so only the final transcript state is summarized.
+# Write state: transcript path + date. Overwrites on every turn so only
+# the final (most complete) transcript snapshot is summarized.
 SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl)
-TODAY=$(date +%Y-%m-%d)
-
 mkdir -p "$PENDING_DIR"
-printf '%s\n%s\n' "$TRANSCRIPT_PATH" "$TODAY" > "$PENDING_DIR/$SESSION_ID"
+printf '%s\n%s\n' "$TRANSCRIPT_PATH" "$(date +%Y-%m-%d)" >"$PENDING_DIR/$SESSION_ID"
 
 echo '{}'

--- a/ccplugin/hooks/user-prompt-submit.sh
+++ b/ccplugin/hooks/user-prompt-submit.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: lightweight hint reminding Claude about the memory-recall skill.
-# The actual search + expand is handled by the memory-recall skill (pull-based, context: fork).
+# UserPromptSubmit hook — emit a hint so Claude knows the memory-recall skill
+# is available. The actual search is handled by the skill itself (context: fork).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-# Skip short prompts (greetings, single words, etc.)
+# Ignore trivially short prompts (greetings, single words, etc.).
 PROMPT=$(_json_val "$INPUT" "prompt" "")
 if [ -z "$PROMPT" ] || [ "${#PROMPT}" -lt 10 ]; then
   echo '{}'
   exit 0
 fi
 
-# Need memsearch available
-if [ -z "$MEMSEARCH_CMD" ]; then
+[ -z "$MEMSEARCH_CMD" ] && {
   echo '{}'
   exit 0
-fi
+}
 
 echo '{"systemMessage": "[memsearch] Memory available"}'


### PR DESCRIPTION
## Summary

The `Stop` hook fires after **every assistant turn**, not just at session end. This causes N near-identical summaries to be appended to the daily `.md` file for a single session — polluting both the memory files and the Milvus index with duplicates.

**Example (before):** a session with 3 Claude responses produces 3 almost identical entries:

```markdown
## Session 13:35

### 13:35
- Removed symlinks, copied skill directories, deleted .agents/

### 13:36
- Removed symlinks, copied skill directories, deleted .agents/   ← duplicate
- Created .memsearch.toml

### 13:36
- Removed symlinks, copied skill directories, deleted .agents/   ← duplicate
- Created .memsearch.toml
```

### Changes

This PR introduces **deferred summarization** — the Stop hook becomes a lightweight state recorder, and the actual LLM summarization happens exactly once at session end:

- **`stop.sh`** — stripped down from 120 to 45 lines. Now only saves the transcript path to a pending state file (`.memsearch/.pending/<session_id>`). Each turn overwrites the same file (last-writer-wins). No parsing, no LLM call — instant and free.

- **`common.sh`** — new functions:
  - `_summarize_pending()` — reads transcript path from state file, parses transcript, calls `claude -p` to summarize, appends to daily `.md`
  - `flush_pending()` — iterates pending state files, summarizes each, re-indexes
  - `_check_embedding_key()` — extracted API key validation as a reusable helper

- **`session-end.sh`** — calls `flush_pending()` before `stop_watch` (primary flush path)

- **`session-start.sh`** — calls `flush_pending()` as a safety net for crashed sessions where `SessionEnd` didn't fire

### Benefits

- **No duplicates** — exactly 1 summary per session, by design (not heuristics)
- **N→1 LLM calls** — a session with 10 turns now makes 1 Haiku call instead of 10
- **Faster Stop hook** — writing 2 lines to a file vs. parsing + LLM roundtrip on every turn
- **Crash-safe** — `SessionStart` picks up any unflushed state from previous sessions

Also adds `MEMSEARCH_SUMMARY_MODEL` env var (default: `haiku`) to configure the summarization model (`haiku` | `sonnet` | `opus`).

---

> **Note:** This is a proposal. If there's interest in improving the ccplugin hook logic for Claude Code, I'd be happy to iterate on this approach and develop it further. In my experience this is the most efficient solution for the duplication problem, but I'm open to feedback.

## Test plan

- [x] Run a multi-turn session and verify only 1 summary appears in the daily `.md` after session end
- [x] Kill a session mid-conversation, start a new one, and verify `SessionStart` flushes the orphaned pending file
- [x] Set `MEMSEARCH_SUMMARY_MODEL=sonnet` and verify the summary uses Sonnet
- [x] Verify `.memsearch/.pending/` is cleaned up after flush