### PR TITLE
feat(ccplugin): per-project collection isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,14 @@ The plugin is a first-class component of memsearch — it's the primary real-wor
 ```
 ccplugin/
 ├── hooks/
-│   ├── common.sh                # Shared setup: PATH, memsearch detection, watch PID management
+│   ├── common.sh                # Shared setup: PATH, memsearch detection, collection name, watch PID
 │   ├── session-start.sh         # SessionStart: start watch, write session heading, inject recent memories
 │   ├── user-prompt-submit.sh    # UserPromptSubmit: lightweight hint reminding Claude about memory skill
 │   ├── stop.sh                  # Stop: parse transcript → haiku summarize → append to daily .md (async)
 │   ├── session-end.sh           # SessionEnd: stop watch process
 │   └── parse-transcript.sh      # Deterministic JSONL-to-text parser (used by stop.sh)
+├── scripts/
+│   └── derive-collection.sh     # Derive per-project collection name from project path
 └── skills/
     └── memory-recall/
         └── SKILL.md             # Skill (context: fork): search → expand → transcript in subagent
@@ -88,7 +90,7 @@ ccplugin/
 
 When modifying hooks/skills, keep in mind:
 - All hooks output JSON to stdout (`additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}`)
-- `common.sh` is sourced by every hook — changes there affect all hooks
+- `common.sh` is sourced by every hook — changes there affect all hooks. It derives a per-project `COLLECTION_NAME` via `derive-collection.sh` and passes `--collection` automatically through `run_memsearch()` and `start_watch()`
 - The watch process uses a PID file (`.memsearch/.watch.pid`) for singleton behavior
 - `stop.sh` has a recursion guard (`stop_hook_active`) since it calls `claude -p` internally
 - The `memory-recall` skill uses `context: fork` — the subagent has its own context window and does not see main conversation history

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -54,7 +54,11 @@ fi
 
 # Build status line: version | provider/model | milvus | optional update/error
 VERSION_TAG="${VERSION:+ v${VERSION}}"
-status="[memsearch${VERSION_TAG}] embedding: ${PROVIDER}/${MODEL:-unknown} | milvus: ${MILVUS_URI:-unknown}${UPDATE_HINT}"
+COLLECTION_HINT=""
+if [ -n "$COLLECTION_NAME" ]; then
+  COLLECTION_HINT=" | collection: ${COLLECTION_NAME}"
+fi
+status="[memsearch${VERSION_TAG}] embedding: ${PROVIDER}/${MODEL:-unknown} | milvus: ${MILVUS_URI:-unknown}${COLLECTION_HINT}${UPDATE_HINT}"
 if [ "$KEY_MISSING" = true ]; then
   status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
 fi

--- a/ccplugin/scripts/derive-collection.sh
+++ b/ccplugin/scripts/derive-collection.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Derive a unique Milvus collection name from a project directory path.
+# Used by hooks (via common.sh) and skill (via SKILL.md ! syntax).
+#
+# Usage: derive-collection.sh [project_dir]
+#   If no argument given, uses pwd.
+#
+# Output: ms_<sanitized_basename>_<8char_sha256>
+#   e.g. /home/user/my-app → ms_my_app_a1b2c3d4
+
+set -euo pipefail
+
+PROJECT_DIR="${1:-$(pwd)}"
+
+# Resolve to absolute path (realpath preferred, cd fallback, raw last resort)
+if command -v realpath &>/dev/null; then
+  PROJECT_DIR="$(realpath -m "$PROJECT_DIR")"
+elif [ -d "$PROJECT_DIR" ]; then
+  PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+else
+  # If directory doesn't exist and no realpath, ensure it starts with /
+  case "$PROJECT_DIR" in
+    /*) ;; # already absolute
+    *)  PROJECT_DIR="$(pwd)/$PROJECT_DIR" ;;
+  esac
+fi
+
+# Extract basename and sanitize:
+# - lowercase
+# - replace non-alphanumeric with underscore
+# - collapse consecutive underscores
+# - trim leading/trailing underscores
+# - truncate to 40 chars
+sanitized=$(basename "$PROJECT_DIR" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9]/_/g' \
+  | sed 's/__*/_/g' \
+  | sed 's/^_//;s/_$//' \
+  | cut -c1-40)
+
+# Compute 8-char SHA-256 hash of the full absolute path
+if command -v sha256sum &>/dev/null; then
+  hash=$(printf '%s' "$PROJECT_DIR" | sha256sum | cut -c1-8)
+elif command -v shasum &>/dev/null; then
+  hash=$(printf '%s' "$PROJECT_DIR" | shasum -a 256 | cut -c1-8)
+else
+  hash=$(python3 -c "import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:8])" "$PROJECT_DIR")
+fi
+
+echo "ms_${sanitized}_${hash}"

--- a/ccplugin/skills/memory-recall/SKILL.md
+++ b/ccplugin/skills/memory-recall/SKILL.md
@@ -7,19 +7,23 @@ allowed-tools: Bash
 
 You are a memory retrieval agent for memsearch. Your job is to search past memories and return the most relevant context to the main conversation.
 
+## Project Collection
+
+Collection: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh`
+
 ## Your Task
 
 Search for memories relevant to: $ARGUMENTS
 
 ## Steps
 
-1. **Search**: Run `memsearch search "<query>" --top-k 5 --json-output` to find relevant chunks.
+1. **Search**: Run `memsearch search "<query>" --top-k 5 --json-output --collection <collection name above>` to find relevant chunks.
    - If `memsearch` is not found, try `uvx memsearch` instead.
    - Choose a search query that captures the core intent of the user's question.
 
 2. **Evaluate**: Look at the search results. Skip chunks that are clearly irrelevant or too generic.
 
-3. **Expand**: For each relevant result, run `memsearch expand <chunk_hash>` to get the full markdown section with surrounding context.
+3. **Expand**: For each relevant result, run `memsearch expand <chunk_hash> --collection <collection name above>` to get the full markdown section with surrounding context.
 
 4. **Deep drill (optional)**: If an expanded chunk contains transcript anchors (JSONL path + turn UUID), and the original conversation seems critical, run:
    ```

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -148,7 +148,7 @@ Fires once when a Claude Code session begins. This hook:
 3. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
 4. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
 5. **Checks for updates.** Queries PyPI (2s timeout) and compares with the installed version. If a newer version is available, appends an `UPDATE` hint to the status line.
-6. **Displays config status.** Every exit path returns a `systemMessage` showing the active configuration, e.g. `[memsearch v0.1.10] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db` (with `| UPDATE: v0.1.12 available` when outdated).
+6. **Displays config status.** Every exit path returns a `systemMessage` showing the active configuration, e.g. `[memsearch v0.1.10] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db | collection: ms_my_app_a1b2c3d4` (with `| UPDATE: v0.1.12 available` when outdated).
 
 #### UserPromptSubmit
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ def get_user_memory(user_id: str) -> MemSearch:
 
 Each user gets a physically separate database file. This is the simplest model when you don't need cross-user search.
 
-The [Claude Code plugin](claude-plugin.md) happens to use a per-project layout because that matches its use case (developer working on a codebase). But the underlying memsearch library has no such constraint — a consumer chat app can instantiate one `MemSearch` per user and get clean isolation.
+The [Claude Code plugin](claude-plugin.md) uses per-project isolation — each project automatically gets its own Milvus collection (e.g. `ms_my_app_a1b2c3d4`) derived from the project path, so searches never leak across projects. But the underlying memsearch library has no such constraint — a consumer chat app can instantiate one `MemSearch` per user and get clean isolation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `ccplugin/scripts/derive-collection.sh` to derive unique Milvus collection names per project (format: `ms_<basename>_<8char_sha256>`)
- Update `common.sh` to auto-derive `COLLECTION_NAME` and pass `--collection` via `run_memsearch()` and `start_watch()`
- Update `session-start.sh` status line to display the active collection name
- Update `memory-recall` skill to inject collection name via `!` preprocessor syntax

## Details

Previously all projects shared the default `memsearch_chunks` collection, causing cross-project search leakage. Now each project directory gets a unique collection name derived from its absolute path.

**Pure ccplugin change** — no modifications to Python API, CLI, or config layers. Backward compatible: old data in `memsearch_chunks` stays untouched; `memsearch watch` will re-index markdown files into the new collection on next session start.

## Test plan
- [x] `derive-collection.sh` is idempotent (same path → same output)
- [x] Different paths produce different collection names
- [x] Same basename with different parents produce different hashes (collision prevention)
- [x] Special characters in path names are properly sanitized
- [x] Script works without arguments (uses `pwd` — for skill `!` syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)