### PR TITLE
fix(ccplugin): proper watch lifecycle for Server and Lite backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ ccplugin/
 When modifying hooks/skills, keep in mind:
 - All hooks output JSON to stdout (`additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}`)
 - `common.sh` is sourced by every hook — changes there affect all hooks. It derives a per-project `COLLECTION_NAME` via `derive-collection.sh` and passes `--collection` automatically through `run_memsearch()` and `start_watch()`
-- The watch process uses a PID file (`.memsearch/.watch.pid`) for singleton behavior
-- `stop.sh` has a recursion guard (`stop_hook_active`) since it calls `claude -p` internally
+- The watch process uses a PID file (`.memsearch/.watch.pid`) for singleton behavior. Milvus Lite falls back to one-time `index()` at session start
+- `stop.sh` has a recursion guard (`stop_hook_active`) since it calls `claude -p` internally, and sets `MEMSEARCH_NO_WATCH=1` to prevent the child process from interfering with the main session's watch
 - The `memory-recall` skill uses `context: fork` — the subagent has its own context window and does not see main conversation history
 
 ## Key Design Decisions

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -92,7 +92,7 @@ cat .memsearch/memory/$(date +%Y-%m-%d).md
 
 ## How It Works
 
-The plugin hooks into **4 Claude Code lifecycle events** and provides a **memory-recall skill**. A singleton `memsearch watch` process runs in the background, keeping the vector index in sync with markdown files as they change.
+The plugin hooks into **4 Claude Code lifecycle events** and provides a **memory-recall skill**. A singleton `memsearch watch` process runs in the background, keeping the vector index in sync with markdown files as they change. (Milvus Lite falls back to one-time indexing at session start.)
 
 ### Lifecycle Diagram
 
@@ -144,7 +144,7 @@ stateDiagram-v2
 Fires once when a Claude Code session begins. This hook:
 
 1. **Reads config and checks API key.** Runs `memsearch config get` to read the configured embedding provider, model, and Milvus URI. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`; `ollama` and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
-2. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce.
+2. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce. Milvus Lite falls back to a one-time `memsearch index` at session start.
 3. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
 4. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
 5. **Checks for updates.** Queries PyPI (2s timeout) and compares with the installed version. If a newer version is available, appends an `UPDATE` hint to the status line.
@@ -674,6 +674,8 @@ pgrep -f "memsearch watch" && echo "found orphans" || echo "clean"
 ```
 
 The watch process is started by `SessionStart` and stopped by `SessionEnd`. If Claude Code crashes or is killed with SIGKILL, the `SessionEnd` hook won't fire and the process may become orphaned. The next `SessionStart` always stops any existing watch before starting a new one.
+
+> **Note:** Milvus Lite does not support concurrent access, so the plugin falls back to one-time indexing at session start instead of a persistent watcher. For real-time indexing, use [Milvus Server or Zilliz Cloud](https://zilliztech.github.io/memsearch/getting-started/#milvus-backend).
 
 ---
 

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -77,9 +77,14 @@ if [ "$KEY_MISSING" = true ]; then
   exit 0
 fi
 
-# Start memsearch watch as a singleton background process.
-# This is the ONLY place indexing is managed — all other hooks just write .md files.
+# Start memsearch watch (Server mode) or do one-time index (Lite mode).
+# start_watch() skips watch for Lite — file lock prevents concurrent access.
 start_watch
+
+# Lite mode: one-time index since watch is not running
+if [[ "$MILVUS_URI" != http* ]] && [[ "$MILVUS_URI" != tcp* ]]; then
+  run_memsearch index "$MEMORY_DIR" &>/dev/null &
+fi
 
 # Always include status in systemMessage
 json_status=$(_json_encode_str "$status")

--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -80,7 +80,7 @@ print(uuid)
 # --system-prompt: separate role instructions from data (transcript via stdin)
 SUMMARY=""
 if command -v claude &>/dev/null; then
-  SUMMARY=$(printf '%s' "$PARSED" | claude -p \
+  SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 claude -p \
     --model haiku \
     --no-session-persistence \
     --no-chrome \

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.1.4"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1339,7 +1339,7 @@ name = "milvus-lite"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tqdm" },
+    { name = "tqdm", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/b2/acc5024c8e8b6a0b034670b8e8af306ebd633ede777dcbf557eac4785937/milvus_lite-2.5.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6b014453200ba977be37ba660cb2d021030375fa6a35bc53c2e1d92980a0c512", size = 27934713, upload-time = "2025-06-30T04:23:37.028Z" },


### PR DESCRIPTION
## Summary

- **Server mode**: use `setsid` to launch `memsearch watch` in an independent session for persistent real-time indexing
- **Lite mode**: skip watch entirely (file lock prevents concurrent access) and run one-time `memsearch index` at session start instead
- **Stop hook fix**: set `MEMSEARCH_NO_WATCH=1` when calling `claude -p` for summarization, preventing the child process's SessionStart/SessionEnd hooks from killing the main session's watch

## Background

The Stop hook calls `claude -p --model haiku` for transcript summarization. When the memsearch plugin is loaded (globally or via `--plugin-dir`), this child process triggers its own SessionStart → `start_watch()` → kills the main session's watch, then SessionEnd → `stop_watch()` → removes the PID file. This cascade killed the watch after every assistant response.

Additionally, Milvus Lite uses an exclusive file lock on the `.db` file — running `memsearch watch` alongside `memsearch search` causes `"Open .db failed"` errors.

## Changed files

| File | Change |
|------|--------|
| `ccplugin/hooks/common.sh` | `start_watch()`: detect URI type, skip watch for Lite, use `setsid` for Server; add `MEMSEARCH_NO_WATCH` guard to both `start_watch()` and `stop_watch()` |
| `ccplugin/hooks/session-start.sh` | Add one-time background `index()` for Lite mode |
| `ccplugin/hooks/stop.sh` | Prefix `claude -p` with `MEMSEARCH_NO_WATCH=1` |
| `CLAUDE.md`, `ccplugin/README.md`, `docs/claude-plugin.md` | Document Lite fallback behavior |

## Test plan

- [x] Server mode: watch stays alive across multiple prompts
- [x] Server mode: search works concurrently with watch
- [x] Server mode: real-time indexing (new content searchable within 5s)
- [x] Lite mode: no watch process started, no PID file created
- [x] Lite mode: search works without "Open .db failed" errors
- [x] Collection rebuild: watch re-indexes after file change triggered by Stop hook