### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.1.11"
+version = "0.1.12"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.11 to 0.1.12

Includes fixes merged since 0.1.11:
- #71: escape backslashes in Milvus filter expressions for Windows paths
- #76: use persistent event loop in watcher to prevent loop-closed crash
- #81: proper watch lifecycle for Server and Lite backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)