### PR TITLE
fix(ccplugin): rewrite stop hook to summarize last turn only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,9 @@ ccplugin/
 │   ├── common.sh                # Shared setup: PATH, memsearch detection, collection name, watch PID
 │   ├── session-start.sh         # SessionStart: start watch, write session heading, inject recent memories
 │   ├── user-prompt-submit.sh    # UserPromptSubmit: lightweight hint reminding Claude about memory skill
-│   ├── stop.sh                  # Stop: parse transcript → haiku summarize → append to daily .md (async)
+│   ├── stop.sh                  # Stop: extract last turn → haiku summarize (third-person) → append to daily .md (async)
 │   ├── session-end.sh           # SessionEnd: stop watch process
-│   └── parse-transcript.sh      # Deterministic JSONL-to-text parser (used by stop.sh)
+│   └── parse-transcript.sh      # Last-turn extractor: finds last user question → EOF, formats for LLM (Python 3, no jq)
 ├── scripts/
 │   └── derive-collection.sh     # Derive per-project collection name from project path
 └── skills/
@@ -86,7 +86,7 @@ ccplugin/
 **Supporting hooks:**
 - `SessionStart` injects cold-start context (recent daily logs) so Claude knows history exists
 - `UserPromptSubmit` returns a lightweight `systemMessage` hint ("[memsearch] Memory available") to increase skill trigger awareness
-- `Stop` hook is async and non-blocking — calls `claude -p --model haiku` to summarize, appends to daily `.md`
+- `Stop` hook is async and non-blocking — extracts last turn only, calls `claude -p --model haiku` (with `CLAUDECODE=` to bypass nested session detection) to summarize as third-person notes, appends to daily `.md`
 
 When modifying hooks/skills, keep in mind:
 - All hooks output JSON to stdout (`additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}`)


### PR DESCRIPTION
## Summary

The stop hook previously parsed the last 200 lines of the **entire session transcript**, causing two issues:

1. **Duplicate summaries**: Each stop event re-summarized all previous turns, producing N overlapping summaries per session
2. **Information loss**: Aggressive 500-char truncation could cut important content mid-sentence

This PR fixes both by extracting only the **last turn** (last user message → EOF) and summarizing just that.

## Changes

### `parse-transcript.sh` (rewritten)
- **bash+jq → Python3 inline** — eliminates `jq` dependency
- Scans backward from EOF to find the last real user message (content is a string, not a `tool_result`)
- Extracts only that turn's messages, skipping `progress`, `file-history-snapshot`, `system`, and `thinking` blocks
- Tool results truncated to 1000 chars (was 500), configurable via `MEMSEARCH_MAX_RESULT_CHARS`

### `stop.sh`
- Added `CLAUDECODE=` to the `claude -p` call to bypass nested session detection
- Rewrote system prompt: "session memory writer" → "third-person note-taker"
- Added explicit rules: third-person voice, language matching, no answering questions
- Changed bullet count from 3-8 to 2-6 (more appropriate for single-turn summaries)
- Added checks for new empty-value sentinels (`(no user message found)`, `(empty turn)`)

### Documentation
- Updated `docs/claude-plugin.md`, `ccplugin/README.md`, and `CLAUDE.md` to reflect all changes

## Test plan

- [x] Tested across 10+ session restarts with varied conversation types
- [x] Verified each stop event produces a unique, non-overlapping summary
- [x] Verified third-person note format ("User asked...", "Claude read file X")
- [x] Verified language matching (Chinese input → Chinese summary, English → English)
- [x] Verified `CLAUDECODE=` fix resolves Haiku empty-return issue
- [x] Verified summaries correctly append to daily `.md` with session/turn anchors