### PR TITLE
fix: add Windows support guard for milvus-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ memsearch supports three deployment modes — just change `milvus_uri`:
 
 | Mode | `milvus_uri` | Best for |
 |------|-------------|----------|
-| **Milvus Lite** (default) | `~/.memsearch/milvus.db` | Personal use, dev — zero config |
+| **Milvus Lite** (default) | `~/.memsearch/milvus.db` | Personal use, dev — zero config ⚠️ *not available on Windows* |
 | **Milvus Server** | `http://localhost:19530` | Multi-agent, team environments |
 | **Zilliz Cloud** | `https://in03-xxx.api.gcp-us-west1.zillizcloud.com` | Production, fully managed |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -328,6 +328,9 @@ Data is stored in a single local `.db` file. No server to install, no ports to o
 
 **Best for:** personal use, single-agent setups, prototyping, development.
 
+!!! warning "Windows not supported"
+    Milvus Lite does not provide Windows binaries ([milvus-lite#176](https://github.com/milvus-io/milvus-lite/issues/176)). On Windows, use **Milvus Server** (Docker) or **Zilliz Cloud** instead. Alternatively, run memsearch inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
+
 === "Python"
 
     ```python

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -39,7 +39,7 @@ MemSearch(
 | `paths` | `list[str \| Path]` | `[]` | Directories or files to index |
 | `embedding_provider` | `str` | `"openai"` | Embedding backend (`"openai"`, `"google"`, `"voyage"`, `"ollama"`, `"local"`) |
 | `embedding_model` | `str \| None` | `None` | Override the default model for the chosen provider |
-| `milvus_uri` | `str` | `"~/.memsearch/milvus.db"` | Milvus connection URI — local `.db` path for Milvus Lite, `http://host:port` for Milvus Server, or `https://*.zillizcloud.com` for Zilliz Cloud |
+| `milvus_uri` | `str` | `"~/.memsearch/milvus.db"` | Milvus connection URI — local `.db` path for Milvus Lite (Linux/macOS only), `http://host:port` for Milvus Server, or `https://*.zillizcloud.com` for Zilliz Cloud |
 | `milvus_token` | `str \| None` | `None` | Auth token for Milvus Server or Zilliz Cloud |
 | `collection` | `str` | `"memsearch_chunks"` | Milvus collection name. Use different names to isolate agents sharing the same backend |
 | `max_chunk_size` | `int` | `1500` | Maximum chunk size in characters |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "pymilvus[milvus_lite]>=2.5.0",
+    "pymilvus>=2.5.0",
+    "milvus-lite>=2.5.0; sys_platform != 'win32'",
     "click>=8.1",
     "watchdog>=4.0",
     "setuptools<75",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
@@ -1253,8 +1253,9 @@ version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
     { name = "openai" },
-    { name = "pymilvus", extra = ["milvus-lite"] },
+    { name = "pymilvus" },
     { name = "setuptools" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomli-w" },
@@ -1302,9 +1303,10 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.0" },
     { name = "memsearch", extras = ["google", "voyage", "ollama", "local", "anthropic"], marker = "extra == 'all'" },
+    { name = "milvus-lite", marker = "sys_platform != 'win32'", specifier = ">=2.5.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
     { name = "openai", specifier = ">=1.0" },
-    { name = "pymilvus", extras = ["milvus-lite"], specifier = ">=2.5.0" },
+    { name = "pymilvus", specifier = ">=2.5.0" },
     { name = "sentence-transformers", marker = "extra == 'local'", specifier = ">=3.0" },
     { name = "setuptools", specifier = "<75" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
@@ -2632,11 +2634,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/68/9b8bac2267af60035d65fb5a4247c5ac8da175d66ec794d84d9cd3486524/pymilvus-2.6.8.tar.gz", hash = "sha256:15232f5f66805bf2f50b30bbad59637b62f5258d9343f7615353ce1221fab6b5", size = 1421303, upload-time = "2026-01-29T07:32:16.519Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/27/3af2199afaabd48791584fa5da5929f08d1a3c8c37a2ef12c15fc9309111/pymilvus-2.6.8-py3-none-any.whl", hash = "sha256:c4c413ffdef2599064301fd831de6f9839a753abe27c68c6148707629711d069", size = 300995, upload-time = "2026-01-29T07:32:14.199Z" },
-]
-
-[package.optional-dependencies]
-milvus-lite = [
-    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `milvus-lite` does not publish Windows wheels on PyPI ([milvus-lite#176](https://github.com/milvus-io/milvus-lite/issues/176)) — only Linux and macOS binaries are available. This causes two problems for Windows users:

  1. `pip install memsearch` **fails at install time** because `pymilvus[milvus_lite]` is a hard dependency that pulls `milvus-lite`, which has no `win32`/`win64` wheels on PyPI

  2. Even if a user installs `pymilvus` manually without the extra, using the default local URI (`~/.memsearch/milvus.db`) produces a **confusing `ConnectionConfigException`** from deep inside pymilvus internals, with no actionable guidance

- Made `milvus-lite` a **conditional dependency** (`sys_platform != 'win32'`) so `pip install memsearch` succeeds on Windows. Users can then connect to a remote Milvus server or Zilliz Cloud

- Added an **early `RuntimeError`** in `MilvusStore.__init__()` when detecting Windows + local URI, with clear instructions for Docker, WSL2, and Zilliz Cloud workarounds

- Updated docs (README, getting-started, python-api) with Windows limitation notes

Closes #89

## Test plan

- [x] Run existing test suite (`uv run python -m pytest`) — all 34 tests pass
- [x] Verify `pip install memsearch` succeeds on Windows (installs `pymilvus` without `milvus-lite`)
- [x] Verify `MemSearch(milvus_uri="~/.memsearch/milvus.db")` on Windows raises clear `RuntimeError` with workaround instructions
- [x] Verify `MemSearch(milvus_uri="http://localhost:19530")` on Windows works normally with a Docker Milvus instance