### PR TITLE
fix: add empty chunks guard in compact_chunks()

### DIFF
--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -50,6 +50,8 @@ async def compact_chunks(
     str
         The compressed summary markdown.
     """
+    if not chunks:
+        return ""
     combined = "\n\n---\n\n".join(c["content"] for c in chunks)
     template = prompt_template or COMPACT_PROMPT
     prompt = template.format(chunks=combined)


### PR DESCRIPTION
## Summary

Add early return guard for empty chunks list in compact_chunks() function.

## Changes Made

- Return early with empty string when chunks list is empty
- Prevents unnecessary LLM API calls
- Handles edge case gracefully

## Testing

- Empty list now returns empty string immediately
- No functional changes for non-empty lists

## Checklist

- [x] Code follows project style
- [x] Edge case handled properly
- [x] Self-reviewed