### PR TITLE
fix(ccplugin): add role labels to transcript parser to prevent summarizer role confusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ ccplugin/
 │   ├── user-prompt-submit.sh    # UserPromptSubmit: lightweight hint reminding Claude about memory skill
 │   ├── stop.sh                  # Stop: extract last turn → haiku summarize (third-person) → append to daily .md (async)
 │   ├── session-end.sh           # SessionEnd: stop watch process
-│   └── parse-transcript.sh      # Last-turn extractor: finds last user question → EOF, formats for LLM (Python 3, no jq)
+│   └── parse-transcript.sh      # Last-turn extractor: finds last user question → EOF, formats with role labels for LLM (Python 3, no jq)
 ├── scripts/
 │   └── derive-collection.sh     # Derive per-project collection name from project path
 └── skills/

--- a/ccplugin/.claude-plugin/plugin.json
+++ b/ccplugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -174,8 +174,8 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
 
 1. **Guards against recursion.** Checks `stop_hook_active` to prevent infinite loops (since the hook itself calls `claude -p`).
 2. **Validates the transcript.** Skips if the transcript file is missing or has fewer than 3 lines.
-3. **Extracts the last turn.** Calls `parse-transcript.sh` (Python3 inline, no `jq` dependency), which finds the last real user message and extracts everything from there to EOF. Skips progress, `file-history-snapshot`, system, and thinking blocks. Tool results are truncated to 1000 characters (configurable via `MEMSEARCH_MAX_RESULT_CHARS`).
-4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with a third-person note-taker system prompt requesting 2-6 bullet points in the same language as the user's message.
+3. **Extracts the last turn.** Calls `parse-transcript.sh` (Python3 inline, no `jq` dependency), which finds the last real user message and extracts everything from there to EOF. Skips progress, `file-history-snapshot`, system, and thinking blocks. Formats output with clear role labels (`[Human]`, `[Claude Code]`, `[Claude Code calls tool]`, `[Tool output]`/`[Tool error]`) so the summarizer treats the content as a third-party transcript. Tool results are truncated to 1000 characters (configurable via `MEMSEARCH_MAX_RESULT_CHARS`).
+4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with an external-observer system prompt requesting 2-6 third-person bullet points in the same language as the user's message.
 5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. Then runs `memsearch index` to ensure immediate indexing.
 
 #### SessionEnd
@@ -427,7 +427,7 @@ ccplugin/
 │   ├── session-start.sh         # Start watch + write session heading + inject cold-start context
 │   ├── user-prompt-submit.sh    # Lightweight systemMessage hint ("[memsearch] Memory available")
 │   ├── stop.sh                  # Extract last turn → haiku summary (third-person) → append to daily .md
-│   ├── parse-transcript.sh      # Extract last turn from JSONL transcript (Python3, no jq)
+│   ├── parse-transcript.sh      # Extract last turn from JSONL, format with role labels (Python3, no jq)
 │   └── session-end.sh           # Stop watch process (cleanup)
 └── skills/
     └── memory-recall/

--- a/ccplugin/hooks/parse-transcript.sh
+++ b/ccplugin/hooks/parse-transcript.sh
@@ -53,7 +53,7 @@ def find_last_turn_start(lines):
 
 def format_turn(lines):
     """Format a turn into structured text for LLM summarization."""
-    output = []
+    output = ["=== Transcript of a conversation between a human and Claude Code ==="]
     for raw_line in lines:
         try:
             obj = json.loads(raw_line)
@@ -69,7 +69,7 @@ def format_turn(lines):
         if msg_type == "user":
             content = obj.get("message", {}).get("content")
             if isinstance(content, str) and content.strip():
-                output.append(f"USER: {content.strip()}")
+                output.append(f"[Human]: {content.strip()}")
             elif isinstance(content, list):
                 for block in content:
                     if not isinstance(block, dict):
@@ -85,7 +85,8 @@ def format_turn(lines):
                         result = truncate(str(result), MAX_RESULT_CHARS)
                         is_error = block.get("is_error", False)
                         prefix = "ERROR" if is_error else "RESULT"
-                        output.append(f"{prefix}: {result}")
+                        label = "[Tool error]" if is_error else "[Tool output]"
+                        output.append(f"{label}: {result}")
 
         elif msg_type == "assistant":
             content = obj.get("message", {}).get("content", [])
@@ -97,7 +98,7 @@ def format_turn(lines):
                 if block_type == "text":
                     text = block.get("text", "").strip()
                     if text:
-                        output.append(f"ASSISTANT: {text}")
+                        output.append(f"[Claude Code]: {text}")
 
                 elif block_type == "tool_use":
                     name = block.get("name", "unknown")
@@ -112,7 +113,7 @@ def format_turn(lines):
                     input_summary = ", ".join(parts)
                     if len(input_summary) > 400:
                         input_summary = input_summary[:400] + "..."
-                    output.append(f"TOOL: {name}({input_summary})")
+                    output.append(f"[Claude Code calls tool]: {name}({input_summary})")
 
                 # Skip thinking blocks — internal reasoning, not useful for memory
 

--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -84,18 +84,27 @@ if command -v claude &>/dev/null; then
     --model haiku \
     --no-session-persistence \
     --no-chrome \
-    --system-prompt "You are a third-person note-taker. You will receive a transcript of ONE turn from a coding session between a user and Claude Code. Your job is to record what happened in that turn as factual notes. You are NOT Claude Code — do NOT answer questions, give explanations, or offer help. Just record what occurred.
+    --system-prompt "You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human (labeled [Human]) and Claude Code (labeled [Claude Code]). Tool calls are labeled [Tool Call] and their results [Tool RESULT] or [Tool ERROR].
 
-Output 2-6 bullet points, each starting with '- '. Nothing else.
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT Claude Code, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
 
 Rules:
 - Write in third person: 'User asked...', 'Claude read file X', 'Claude ran command Y'
 - First bullet: what the user asked or wanted (one sentence)
 - Remaining bullets: what Claude did — tools called, files read/edited, commands run, key findings
 - Be specific: mention file names, function names, tool names, and concrete outcomes
-- Do NOT answer the user's question yourself — just note what was discussed
+- Do NOT answer the human's question yourself — just note what was discussed
 - Do NOT add any text before or after the bullet points
-- Write in the same language as the user's message in the transcript" \
+- Write in the same language as the human's message (the [Human] line) in the transcript
+
+The transcript uses these labels:
+- [Human]: what the user said
+- [Claude Code]: what Claude Code said
+- [Claude Code calls tool]: a tool Claude Code invoked
+- [Tool output]: the result returned by a tool
+- [Tool error]: an error returned by a tool" \
     2>/dev/null || true)
 fi
 

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -178,9 +178,9 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
     - Scans backward from EOF to find the last real user message (content is a string, not a `tool_result`)
     - Extracts only the last turn: from that user message to EOF
     - Skips `progress`, `file-history-snapshot`, `system`, and `thinking` blocks
-    - Keeps user/assistant text and tool call summaries; truncates tool results to 1000 characters
-    - Uses Python 3 (no `jq` dependency)
-4. **Summarizes with Haiku.** Pipes the parsed last turn to `claude -p --model haiku --no-session-persistence` with a third-person note-taker system prompt that requests 2-6 bullet points recording what the user asked and what Claude did (tools called, files changed, key findings). The summary language matches the user's language.
+    - Formats output with clear role labels: `[Human]` for user messages, `[Claude Code]` for assistant text, `[Claude Code calls tool]` for tool invocations, `[Tool output]`/`[Tool error]` for tool results — these labels help the summarizer treat the content as a third-party transcript rather than its own conversation
+    - Truncates tool results to 1000 characters; uses Python 3 (no `jq` dependency)
+4. **Summarizes with Haiku.** Pipes the parsed last turn to `claude -p --model haiku --no-session-persistence` with an external-observer system prompt that requests 2-6 third-person bullet points recording what the user asked and what Claude did (tools called, files changed, key findings). The summary language matches the user's language.
 5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. Then explicitly runs `memsearch index` to ensure the new content is indexed immediately, rather than relying on the watcher's debounce timer (which may not fire before SessionEnd kills the watcher).
 
 #### SessionEnd
@@ -589,7 +589,7 @@ ccplugin/
 | `session-start.sh` | SessionStart hook implementation. Starts the watcher, writes the session heading, and reads recent memory files for cold-start context injection. |
 | `user-prompt-submit.sh` | UserPromptSubmit hook implementation. Returns a lightweight `systemMessage` hint to keep Claude aware of the memory system. No search -- retrieval is handled by the memory-recall skill. |
 | `stop.sh` | Stop hook implementation. Extracts the transcript path, validates it, delegates parsing to `parse-transcript.sh`, calls Haiku for summarization (with `CLAUDECODE=` to bypass nested session detection), and appends the result with session anchors to the daily memory file. |
-| `parse-transcript.sh` | Standalone transcript parser. Extracts the last turn (last user question + all responses to EOF) from a JSONL transcript using Python 3. Skips progress, thinking, and file-history-snapshot entries. No `jq` dependency. Used by `stop.sh`. |
+| `parse-transcript.sh` | Standalone transcript parser. Extracts the last turn (last user question + all responses to EOF) from a JSONL transcript using Python 3. Outputs with role labels (`[Human]`, `[Claude Code]`, `[Claude Code calls tool]`, `[Tool output]`/`[Tool error]`) so the summarizer treats it as a third-party transcript. Skips progress, thinking, and file-history-snapshot entries. No `jq` dependency. Used by `stop.sh`. |
 | `session-end.sh` | SessionEnd hook implementation. Calls `stop_watch` to terminate the background watcher and clean up. |
 
 ---


### PR DESCRIPTION
## Summary

The stop hook's Haiku summarizer sometimes responds as an assistant instead of recording third-person notes. Root cause: `parse-transcript.sh` used ambiguous labels (`USER:`, `ASSISTANT:`, `TOOL:`, `RESULT:`) that made Haiku identify with the assistant role.

**Changes:**
- Renamed labels to `[Human]`, `[Claude Code]`, `[Claude Code calls tool]`, `[Tool output]`/`[Tool error]`
- Added a transcript header line to frame the content as a third-party conversation record
- Updated the system prompt to emphasize "external observer" role and explain the label semantics
- Bumped ccplugin version to 0.2.1
- Updated docs (ccplugin README, docs/claude-plugin.md, CLAUDE.md)