### PR TITLE
fix(ccplugin): fix realpath -m incompatibility on macOS

### DIFF
--- a/ccplugin/scripts/derive-collection.sh
+++ b/ccplugin/scripts/derive-collection.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 PROJECT_DIR="${1:-$(pwd)}"
 
 # Resolve to absolute path (realpath preferred, cd fallback, raw last resort)
-if command -v realpath &>/dev/null; then
+if realpath -m "$PROJECT_DIR" &>/dev/null 2>&1; then
   PROJECT_DIR="$(realpath -m "$PROJECT_DIR")"
 elif [ -d "$PROJECT_DIR" ]; then
   PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"


### PR DESCRIPTION
## Summary

- `derive-collection.sh` used `command -v realpath` to check for path resolution support, then unconditionally called `realpath -m` — but macOS ships BSD `realpath` which does **not** support the `-m` flag, causing the hook to crash with `illegal option -- m`
- Replaced the existence check with a functional test: `realpath -m "$PROJECT_DIR" &>/dev/null 2>&1` — this silently fails on macOS (BSD) and falls through to the existing `cd && pwd` fallback, while continuing to work normally on Linux (GNU realpath)
- No behaviour change on Linux or Windows; one-line fix, zero new dependencies

Closes #95

## Test plan

- [x] Verified `realpath -m` exits non-zero on macOS BSD (`illegal option -- m`)
- [x] Ran `derive-collection.sh` on macOS — falls through to `cd` fallback, produces correct collection name
- [x] Tested existing directory, non-existing directory, relative path, path with spaces, path with special characters — all produce stable, deterministic output
- [x] Confirmed relative `.` and equivalent absolute path produce identical collection name (hash stability)
- [x] Linux behaviour unchanged — `realpath -m` test passes and GNU realpath is used as before