### PR TITLE
feat: add configurable OpenAI-compatible embedding endpoints

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,6 +195,9 @@ provider = "openai"
 | `milvus.collection` | string | `memsearch_chunks` | Collection name |
 | `embedding.provider` | string | `openai` | Embedding provider name |
 | `embedding.model` | string | `""` | Override embedding model (empty = provider default) |
+| `embedding.batch_size` | int | `0` | Embedding batch size (0 = provider default) |
+| `embedding.base_url` | string | `""` | OpenAI-compatible API base URL (empty = SDK default) |
+| `embedding.api_key` | string | `""` | API key for embedding provider (supports `env:VAR_NAME` syntax) |
 | `chunking.max_chunk_size` | int | `1500` | Maximum chunk size in characters |
 | `chunking.overlap_lines` | int | `2` | Number of overlapping lines between adjacent chunks |
 | `watch.debounce_ms` | int | `1500` | File watcher debounce delay in milliseconds |
@@ -215,6 +218,8 @@ Scan one or more directories (or files) and index all markdown files (`.md`, `.m
 | `PATHS` | | *(required)* | One or more directories or files to index |
 | `--provider` | `-p` | `openai` | Embedding provider (`openai`, `google`, `voyage`, `ollama`, `local`) |
 | `--model` | `-m` | provider default | Override the embedding model name |
+| `--base-url` | | *(none)* | OpenAI-compatible API base URL |
+| `--api-key` | | *(none)* | API key for the embedding provider |
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token (for server or Zilliz Cloud) |
@@ -277,6 +282,8 @@ Run a semantic search query against indexed chunks. Uses [hybrid search](https:/
 | `--top-k` | `-k` | `5` | Maximum number of results to return |
 | `--provider` | `-p` | `openai` | Embedding provider (must match the provider used at index time) |
 | `--model` | `-m` | provider default | Override the embedding model |
+| `--base-url` | | *(none)* | OpenAI-compatible API base URL |
+| `--api-key` | | *(none)* | API key for the embedding provider |
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
@@ -351,6 +358,8 @@ Start a long-running file watcher that monitors directories for markdown file ch
 | `--debounce-ms` | | `1500` | Debounce delay in milliseconds; multiple rapid changes to the same file within this window are collapsed into a single re-index |
 | `--provider` | `-p` | `openai` | Embedding provider |
 | `--model` | `-m` | provider default | Override the embedding model |
+| `--base-url` | | *(none)* | OpenAI-compatible API base URL |
+| `--api-key` | | *(none)* | API key for the embedding provider |
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
@@ -402,6 +411,8 @@ Use an LLM to compress all indexed chunks (or a subset) into a condensed markdow
 | `--prompt-file` | | *(none)* | Read the prompt template from a file instead |
 | `--provider` | `-p` | `openai` | Embedding provider (used to access the index) |
 | `--model` | `-m` | provider default | Override the embedding model |
+| `--base-url` | | *(none)* | OpenAI-compatible API base URL |
+| `--api-key` | | *(none)* | API key for the embedding provider |
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
@@ -480,6 +491,8 @@ Look up a chunk by its hash in the index and return the surrounding context from
 | `--json-output` | `-j` | `false` | Output as JSON |
 | `--provider` | `-p` | `openai` | Embedding provider |
 | `--model` | `-m` | provider default | Override the embedding model |
+| `--base-url` | | *(none)* | OpenAI-compatible API base URL |
+| `--api-key` | | *(none)* | API key for the embedding provider |
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
@@ -686,7 +699,7 @@ Dropped collection.
 
 ## Environment Variables
 
-memsearch reads API keys from environment variables. These are required by the corresponding embedding and LLM provider SDKs and are **not** stored in memsearch config files.
+memsearch reads API keys from environment variables by default. You can also configure them in TOML config files using the `env:VAR_NAME` reference syntax or the `embedding.api_key` / `embedding.base_url` fields. See [Configuration](getting-started.md#configuration) for details.
 
 ### API Keys
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -414,7 +414,7 @@ memsearch uses a layered configuration system. Settings are resolved in priority
 
 Higher-priority sources override lower ones. This means you can set defaults globally, customize per project, and override on the fly with CLI flags.
 
-> **Note:** API keys for embedding and LLM providers (e.g. `OPENAI_API_KEY`, `GOOGLE_API_KEY`) are read from environment variables by their respective SDKs. They are **not** stored in memsearch config files. See [API Keys](#api-keys) below.
+> **Note:** API keys can be configured via environment variables (e.g. `OPENAI_API_KEY`) or in config files using the `env:` reference syntax (e.g. `api_key = "env:MY_API_KEY"`). See [API Keys](#api-keys) and [Environment Variable References](#environment-variable-references) below.
 
 ### Interactive config wizard
 
@@ -468,6 +468,8 @@ collection = "memsearch_chunks"
 [embedding]
 provider = "openai"
 model = ""
+base_url = ""
+api_key = ""
 
 [chunking]
 max_chunk_size = 1500
@@ -481,6 +483,47 @@ llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
 ```
+
+### Environment variable references
+
+Any string value in the config file can reference an environment variable using the `env:` prefix. This lets you keep secrets out of config files while still configuring them per-project:
+
+```toml
+# .memsearch.toml
+[embedding]
+provider = "openai"
+base_url = "https://my-azure.openai.azure.com"
+api_key = "env:AZURE_OPENAI_API_KEY"       # resolved from $AZURE_OPENAI_API_KEY at runtime
+
+[milvus]
+token = "env:MILVUS_TOKEN"                 # works for any string field
+```
+
+If the referenced environment variable is not set, memsearch raises an error at startup with a clear message. Plain string values (without the `env:` prefix) are used as-is.
+
+### Custom OpenAI-compatible endpoints
+
+The `embedding.base_url` and `embedding.api_key` fields allow using any OpenAI-compatible embedding API (Azure OpenAI, vLLM, LiteLLM, SiliconFlow, NVIDIA, etc.):
+
+```toml
+# .memsearch.toml — Azure OpenAI example
+[embedding]
+provider = "openai"
+model = "text-embedding-3-small"
+base_url = "https://my-resource.openai.azure.com"
+api_key = "env:AZURE_OPENAI_API_KEY"
+```
+
+```toml
+# .memsearch.toml — local vLLM example
+[embedding]
+provider = "openai"
+model = "BAAI/bge-small-en-v1.5"
+base_url = "http://localhost:8000/v1"
+api_key = "dummy"
+```
+
+These settings can also be passed via CLI flags (`--base-url`, `--api-key`) or the Python API (`embedding_base_url`, `embedding_api_key`).
 
 ### Get and set individual values
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -26,6 +26,9 @@ MemSearch(
     *,
     embedding_provider="openai",
     embedding_model=None,
+    embedding_batch_size=0,
+    embedding_base_url=None,
+    embedding_api_key=None,
     milvus_uri="~/.memsearch/milvus.db",
     milvus_token=None,
     collection="memsearch_chunks",
@@ -39,6 +42,9 @@ MemSearch(
 | `paths` | `list[str \| Path]` | `[]` | Directories or files to index |
 | `embedding_provider` | `str` | `"openai"` | Embedding backend (`"openai"`, `"google"`, `"voyage"`, `"ollama"`, `"local"`) |
 | `embedding_model` | `str \| None` | `None` | Override the default model for the chosen provider |
+| `embedding_batch_size` | `int` | `0` | Max texts per embedding API call (0 = provider default) |
+| `embedding_base_url` | `str \| None` | `None` | OpenAI-compatible API base URL. Overrides `OPENAI_BASE_URL` env var |
+| `embedding_api_key` | `str \| None` | `None` | API key for the embedding provider. Overrides `OPENAI_API_KEY` env var |
 | `milvus_uri` | `str` | `"~/.memsearch/milvus.db"` | Milvus connection URI — local `.db` path for Milvus Lite (Linux/macOS only), `http://host:port` for Milvus Server, or `https://*.zillizcloud.com` for Zilliz Cloud |
 | `milvus_token` | `str \| None` | `None` | Auth token for Milvus Server or Zilliz Cloud |
 | `collection` | `str` | `"memsearch_chunks"` | Milvus collection name. Use different names to isolate agents sharing the same backend |

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -33,6 +33,8 @@ _PARAM_MAP = {
     "provider": "embedding.provider",
     "model": "embedding.model",
     "batch_size": "embedding.batch_size",
+    "base_url": "embedding.base_url",
+    "api_key": "embedding.api_key",
     "collection": "milvus.collection",
     "milvus_uri": "milvus.uri",
     "milvus_token": "milvus.token",
@@ -66,6 +68,8 @@ def _cfg_to_memsearch_kwargs(cfg: MemSearchConfig) -> dict:
         "embedding_provider": cfg.embedding.provider,
         "embedding_model": cfg.embedding.model or None,
         "embedding_batch_size": cfg.embedding.batch_size,
+        "embedding_base_url": cfg.embedding.base_url or None,
+        "embedding_api_key": cfg.embedding.api_key or None,
         "milvus_uri": cfg.milvus.uri,
         "milvus_token": cfg.milvus.token or None,
         "collection": cfg.milvus.collection,
@@ -81,6 +85,8 @@ def _common_options(f):
     f = click.option("--provider", "-p", default=None, help="Embedding provider.")(f)
     f = click.option("--model", "-m", default=None, help="Override embedding model.")(f)
     f = click.option("--batch-size", default=None, type=int, help="Embedding batch size (0 = provider default).")(f)
+    f = click.option("--base-url", default=None, help="OpenAI-compatible API base URL.")(f)
+    f = click.option("--api-key", default=None, help="API key for the embedding provider.")(f)
     f = click.option("--collection", "-c", default=None, help="Milvus collection name.")(f)
     f = click.option("--milvus-uri", default=None, help="Milvus connection URI.")(f)
     f = click.option("--milvus-token", default=None, help="Milvus auth token.")(f)
@@ -102,6 +108,8 @@ def index(
     provider: str | None,
     model: str | None,
     batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
     collection: str | None,
     milvus_uri: str | None,
     milvus_token: str | None,
@@ -112,6 +120,7 @@ def index(
 
     cfg = resolve_config(_build_cli_overrides(
         provider=provider, model=model, batch_size=batch_size,
+        base_url=base_url, api_key=api_key,
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
     ))
@@ -134,6 +143,8 @@ def search(
     provider: str | None,
     model: str | None,
     batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
     collection: str | None,
     milvus_uri: str | None,
     milvus_token: str | None,
@@ -144,6 +155,7 @@ def search(
 
     cfg = resolve_config(_build_cli_overrides(
         provider=provider, model=model, batch_size=batch_size,
+        base_url=base_url, api_key=api_key,
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
     ))
@@ -206,6 +218,8 @@ def expand(
     provider: str | None,
     model: str | None,
     batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
     collection: str | None,
     milvus_uri: str | None,
     milvus_token: str | None,
@@ -221,6 +235,7 @@ def expand(
 
     cfg = resolve_config(_build_cli_overrides(
         provider=provider, model=model, batch_size=batch_size,
+        base_url=base_url, api_key=api_key,
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
     ))
@@ -394,6 +409,8 @@ def watch(
     provider: str | None,
     model: str | None,
     batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
     collection: str | None,
     milvus_uri: str | None,
     milvus_token: str | None,
@@ -404,6 +421,7 @@ def watch(
 
     cfg = resolve_config(_build_cli_overrides(
         provider=provider, model=model, batch_size=batch_size,
+        base_url=base_url, api_key=api_key,
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
         debounce_ms=debounce_ms,
@@ -449,6 +467,8 @@ def compact(
     provider: str | None,
     model: str | None,
     batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
     collection: str | None,
     milvus_uri: str | None,
     milvus_token: str | None,
@@ -458,6 +478,7 @@ def compact(
 
     cfg = resolve_config(_build_cli_overrides(
         provider=provider, model=model, batch_size=batch_size,
+        base_url=base_url, api_key=api_key,
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
         llm_provider=llm_provider, llm_model=llm_model,
@@ -598,6 +619,14 @@ def config_init(project: bool) -> None:
     _emb_model_default = current.embedding.model or _embedding_defaults.get(_emb_provider, "")
     result["embedding"]["model"] = click.prompt(
         "  Model", default=_emb_model_default,
+    )
+    result["embedding"]["base_url"] = click.prompt(
+        "  Base URL (empty for default, or env:VAR_NAME)",
+        default=current.embedding.base_url,
+    )
+    result["embedding"]["api_key"] = click.prompt(
+        "  API key (empty for env default, or env:VAR_NAME)",
+        default=current.embedding.api_key,
     )
 
     # Chunking

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -6,6 +6,7 @@ Priority chain (lowest to highest):
 
 from __future__ import annotations
 
+import os
 import sys
 
 if sys.version_info >= (3, 11):
@@ -40,6 +41,8 @@ class EmbeddingConfig:
     provider: str = "openai"
     model: str = ""
     batch_size: int = 0  # 0 = use provider default
+    base_url: str = ""  # OpenAI-compatible endpoint URL
+    api_key: str = ""  # API key (supports "env:VAR_NAME" syntax)
 
 
 @dataclass
@@ -77,6 +80,41 @@ _SECTION_CLASSES: dict[str, type] = {
     "chunking": ChunkingConfig,
     "watch": WatchConfig,
 }
+
+
+_ENV_PREFIX = "env:"
+
+
+def resolve_env_ref(value: str) -> str:
+    """Resolve an ``env:VAR_NAME`` reference to its environment variable value.
+
+    If *value* starts with ``env:``, the remainder is used as an environment
+    variable name.  Returns the variable's value, or raises ``KeyError`` if
+    the variable is not set.  Non-prefixed strings are returned unchanged.
+    """
+    if not isinstance(value, str) or not value.startswith(_ENV_PREFIX):
+        return value
+    var_name = value[len(_ENV_PREFIX):]
+    env_val = os.environ.get(var_name)
+    if env_val is None:
+        raise KeyError(
+            f"Environment variable {var_name!r} referenced in config "
+            f"(via {value!r}) is not set"
+        )
+    return env_val
+
+
+def _resolve_env_refs_in_dict(d: dict[str, Any]) -> dict[str, Any]:
+    """Walk a nested config dict and resolve all ``env:`` references."""
+    resolved = {}
+    for key, val in d.items():
+        if isinstance(val, dict):
+            resolved[key] = _resolve_env_refs_in_dict(val)
+        elif isinstance(val, str) and val.startswith(_ENV_PREFIX):
+            resolved[key] = resolve_env_ref(val)
+        else:
+            resolved[key] = val
+    return resolved
 
 
 def _default_dict() -> dict[str, Any]:
@@ -135,6 +173,7 @@ def resolve_config(cli_overrides: dict[str, Any] | None = None) -> MemSearchConf
     result = deep_merge(result, load_config_file(PROJECT_CONFIG_PATH))
     if cli_overrides:
         result = deep_merge(result, cli_overrides)
+    result = _resolve_env_refs_in_dict(result)
     cfg = _dict_to_config(result)
 
     # Fill in the provider's default model when model is empty

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -50,6 +50,8 @@ class MemSearch:
         embedding_provider: str = "openai",
         embedding_model: str | None = None,
         embedding_batch_size: int = 0,
+        embedding_base_url: str | None = None,
+        embedding_api_key: str | None = None,
         milvus_uri: str = "~/.memsearch/milvus.db",
         milvus_token: str | None = None,
         collection: str = "memsearch_chunks",
@@ -60,7 +62,11 @@ class MemSearch:
         self._max_chunk_size = max_chunk_size
         self._overlap_lines = overlap_lines
         self._embedder: EmbeddingProvider = get_provider(
-            embedding_provider, model=embedding_model, batch_size=embedding_batch_size,
+            embedding_provider,
+            model=embedding_model,
+            batch_size=embedding_batch_size,
+            base_url=embedding_base_url,
+            api_key=embedding_api_key,
         )
         self._store = MilvusStore(
             uri=milvus_uri, token=milvus_token, collection=collection,

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -51,6 +51,8 @@ def get_provider(
     *,
     model: str | None = None,
     batch_size: int = 0,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> EmbeddingProvider:
     """Instantiate an embedding provider by name.
 
@@ -63,6 +65,10 @@ def get_provider(
     batch_size:
         Maximum number of texts per embedding API call.
         ``0`` means use the provider's built-in default.
+    base_url:
+        Override the API base URL (currently only used by the openai provider).
+    api_key:
+        Override the API key (currently only used by the openai provider).
     """
     if name not in _PROVIDERS:
         raise ValueError(
@@ -88,6 +94,11 @@ def get_provider(
         kwargs["model"] = model
     if batch_size > 0:
         kwargs["batch_size"] = batch_size
+    if name == "openai":
+        if base_url:
+            kwargs["base_url"] = base_url
+        if api_key:
+            kwargs["api_key"] = api_key
     return cls(**kwargs)
 
 

--- a/src/memsearch/embeddings/openai.py
+++ b/src/memsearch/embeddings/openai.py
@@ -17,16 +17,26 @@ class OpenAIEmbedding:
     _DEFAULT_BATCH_SIZE = 2048
 
     def __init__(
-        self, model: str = "text-embedding-3-small", *, batch_size: int = 0,
+        self,
+        model: str = "text-embedding-3-small",
+        *,
+        batch_size: int = 0,
+        base_url: str | None = None,
+        api_key: str | None = None,
     ) -> None:
         import openai
 
         kwargs: dict = {}
-        base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url:
-            kwargs["base_url"] = base_url
+        # Explicit params take priority over environment variables.
+        # Env vars (OPENAI_BASE_URL, OPENAI_API_KEY) are still read
+        # automatically by the openai SDK when not overridden here.
+        effective_base_url = base_url or os.environ.get("OPENAI_BASE_URL")
+        if effective_base_url:
+            kwargs["base_url"] = effective_base_url
+        if api_key:
+            kwargs["api_key"] = api_key
 
-        self._client = openai.AsyncOpenAI(**kwargs)  # reads OPENAI_API_KEY
+        self._client = openai.AsyncOpenAI(**kwargs)  # reads OPENAI_API_KEY if not provided
         self._model = model
         self._dimension = _detect_dimension(model, kwargs)
         self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from memsearch.config import (
     get_config_value,
     load_config_file,
     resolve_config,
+    resolve_env_ref,
     save_config,
     set_config_value,
 )
@@ -130,3 +131,58 @@ def test_save_and_load_roundtrip(tmp_path: Path):
     save_config(data, path)
     loaded = load_config_file(path)
     assert loaded == data
+
+
+# -- env: resolver tests --
+
+
+def test_resolve_env_ref_plain():
+    """Non-prefixed strings should pass through unchanged."""
+    assert resolve_env_ref("https://api.openai.com") == "https://api.openai.com"
+    assert resolve_env_ref("") == ""
+    assert resolve_env_ref("sk-test123") == "sk-test123"
+
+
+def test_resolve_env_ref_env_prefix(monkeypatch: pytest.MonkeyPatch):
+    """env:VAR_NAME should resolve to the environment variable value."""
+    monkeypatch.setenv("MY_TEST_KEY", "resolved-value-123")
+    assert resolve_env_ref("env:MY_TEST_KEY") == "resolved-value-123"
+
+
+def test_resolve_env_ref_missing_var():
+    """env:VAR_NAME should raise KeyError if the variable is not set."""
+    import os
+    # Ensure the var doesn't exist
+    os.environ.pop("NONEXISTENT_MEMSEARCH_VAR", None)
+    with pytest.raises(KeyError, match="NONEXISTENT_MEMSEARCH_VAR"):
+        resolve_env_ref("env:NONEXISTENT_MEMSEARCH_VAR")
+
+
+def test_resolve_env_refs_in_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """resolve_config should resolve env: references in TOML values."""
+    monkeypatch.setenv("TEST_API_KEY", "sk-from-env")
+    monkeypatch.setenv("TEST_MILVUS_TOKEN", "token-from-env")
+
+    cfg_file = tmp_path / "config.toml"
+    save_config({
+        "embedding": {
+            "api_key": "env:TEST_API_KEY",
+            "base_url": "https://my-endpoint.com",
+        },
+        "milvus": {"token": "env:TEST_MILVUS_TOKEN"},
+    }, cfg_file)
+
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    cfg = resolve_config()
+    assert cfg.embedding.api_key == "sk-from-env"
+    assert cfg.embedding.base_url == "https://my-endpoint.com"
+    assert cfg.milvus.token == "token-from-env"
+
+
+def test_embedding_config_new_fields():
+    """EmbeddingConfig should have base_url and api_key fields with empty defaults."""
+    cfg = EmbeddingConfig()
+    assert cfg.base_url == ""
+    assert cfg.api_key == ""


### PR DESCRIPTION
## Summary

- Add `embedding.base_url` and `embedding.api_key` config fields to support OpenAI-compatible embedding providers (Azure OpenAI, vLLM, LiteLLM, SiliconFlow, NVIDIA, etc.)
- Introduce `env:` prefix syntax for safe secret references in config files (e.g. `api_key = "env:AZURE_OPENAI_API_KEY"`) — works globally for any string config value
- Add `--base-url` and `--api-key` CLI flags, Python API params (`embedding_base_url`, `embedding_api_key`), and config wizard support
- Fully backward compatible: existing `OPENAI_API_KEY` / `OPENAI_BASE_URL` env vars continue to work

## Config example

```toml
[embedding]
provider = "openai"
model = "text-embedding-3-small"
base_url = "https://my-azure.openai.azure.com"
api_key = "env:AZURE_OPENAI_API_KEY"
```

## Changed files

| File | Change |
|------|--------|
| `config.py` | New `EmbeddingConfig.base_url/api_key` fields + `resolve_env_ref()` utility |
| `embeddings/__init__.py` | Pass `base_url/api_key` through `get_provider()` |
| `embeddings/openai.py` | Accept explicit `base_url/api_key` with env var fallback |
| `core.py` | Pass new params through `MemSearch` constructor |
| `cli.py` | New `--base-url/--api-key` options + config wizard |
| `tests/test_config.py` | 5 new tests for env: resolver and new fields |
| `docs/getting-started.md` | New "Environment variable references" and "Custom endpoints" sections |
| `docs/cli.md` | Updated option tables and config keys |
| `docs/python-api.md` | Updated constructor signature |

## Test plan

- [x] All 46 tests pass (`uv run python -m pytest -v`)
- [x] `env:VAR` resolves correctly, missing var raises clear error
- [x] Plain values (no `env:` prefix) pass through unchanged
- [x] Empty `base_url`/`api_key` defaults preserve existing behavior
- [x] `milvus.token = "env:..."` also works (global resolver)

Closes #88