### PR TITLE
ci: add pytest workflow for push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run python -m pytest


### PR DESCRIPTION
## Summary\n\nAdd a dedicated test workflow to run the project test suite on both pushes and pull requests.\n\n## Changes\n\n- Add \n- Run  for dependency setup\n- Run tests via  (matching CONTRIBUTING guidance)\n- Test matrix: Python 3.10, 3.11, 3.12\n\n## Why\n\nThe repository currently has docs/release workflows but no continuous test workflow for PR validation. This adds fast feedback for contributors and helps prevent regressions before merge.\n