### PR TITLE
Feat/custom OpenAI endpoint for compact

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -41,6 +41,8 @@ _PARAM_MAP = {
     "llm_provider": "compact.llm_provider",
     "llm_model": "compact.llm_model",
     "prompt_file": "compact.prompt_file",
+    "llm_base_url": "compact.base_url",
+    "llm_api_key": "compact.api_key",
     "max_chunk_size": "chunking.max_chunk_size",
     "overlap_lines": "chunking.overlap_lines",
     "debounce_ms": "watch.debounce_ms",
@@ -454,6 +456,8 @@ def watch(
 @click.option("--output-dir", "-o", default=None, type=click.Path(), help="Directory to write the compact summary into.")
 @click.option("--llm-provider", default=None, help="LLM for summarization.")
 @click.option("--llm-model", default=None, help="Override LLM model.")
+@click.option("--llm-base-url", default=None, help="OpenAI-compatible base URL for the LLM.")
+@click.option("--llm-api-key", default=None, help="API key for the LLM provider.")
 @click.option("--prompt", default=None, help="Custom prompt template (must contain {chunks}).")
 @click.option("--prompt-file", default=None, type=click.Path(exists=True), help="Read prompt template from file.")
 @_common_options
@@ -462,6 +466,8 @@ def compact(
     output_dir: str | None,
     llm_provider: str | None,
     llm_model: str | None,
+    llm_base_url: str | None,
+    llm_api_key: str | None,
     prompt: str | None,
     prompt_file: str | None,
     provider: str | None,
@@ -483,6 +489,7 @@ def compact(
         milvus_uri=milvus_uri, milvus_token=milvus_token,
         llm_provider=llm_provider, llm_model=llm_model,
         prompt_file=prompt_file,
+        llm_base_url=llm_base_url, llm_api_key=llm_api_key,
     ))
 
     prompt_template = prompt
@@ -497,6 +504,8 @@ def compact(
             llm_model=cfg.compact.llm_model or None,
             prompt_template=prompt_template,
             output_dir=output_dir,
+            llm_base_url=cfg.compact.base_url or None,
+            llm_api_key=cfg.compact.api_key or None,
         ))
         if summary:
             click.echo("Compact complete. Summary:\n")

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from .config import resolve_env_ref
+
 COMPACT_PROMPT = """\
 You are a knowledge compression assistant. Given the following chunks of text \
 from a knowledge base, create a concise but comprehensive summary that preserves \
@@ -30,6 +32,8 @@ async def compact_chunks(
     llm_provider: str = "openai",
     model: str | None = None,
     prompt_template: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> str:
     """Compress *chunks* into a summary using an LLM.
 
@@ -44,6 +48,12 @@ async def compact_chunks(
     prompt_template:
         Custom prompt template.  Must contain ``{chunks}`` placeholder.
         Defaults to the built-in ``COMPACT_PROMPT``.
+    base_url:
+        Custom base URL for OpenAI-compatible API endpoints.  Only used
+        when *llm_provider* is ``"openai"``.
+    api_key:
+        API key for the LLM provider.  Only used when *llm_provider* is
+        ``"openai"``.
 
     Returns
     -------
@@ -57,7 +67,7 @@ async def compact_chunks(
     prompt = template.format(chunks=combined)
 
     if llm_provider == "openai":
-        return await _compact_openai(prompt, model or "gpt-4o-mini")
+        return await _compact_openai(prompt, model or "gpt-4o-mini", base_url=base_url, api_key=api_key)
     elif llm_provider == "anthropic":
         return await _compact_anthropic(prompt, model or "claude-sonnet-4-5-20250929")
     elif llm_provider == "gemini":
@@ -69,13 +79,15 @@ async def compact_chunks(
         )
 
 
-async def _compact_openai(prompt: str, model: str) -> str:
+async def _compact_openai(prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None) -> str:
     import openai
 
     kwargs: dict = {}
-    base_url = os.environ.get("OPENAI_BASE_URL")
-    if base_url:
-        kwargs["base_url"] = base_url
+    resolved_base_url = resolve_env_ref(base_url) if base_url else os.environ.get("OPENAI_BASE_URL")
+    if resolved_base_url:
+        kwargs["base_url"] = resolved_base_url
+    if api_key:
+        kwargs["api_key"] = resolve_env_ref(api_key)
 
     client = openai.AsyncOpenAI(**kwargs)
     resp = await client.chat.completions.create(

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -50,6 +50,8 @@ class CompactConfig:
     llm_provider: str = "openai"
     llm_model: str = ""
     prompt_file: str = ""
+    base_url: str = ""  # OpenAI-compatible endpoint URL
+    api_key: str = ""  # API key (supports "env:VAR_NAME" syntax)
 
 
 @dataclass

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -213,6 +213,8 @@ class MemSearch:
         llm_model: str | None = None,
         prompt_template: str | None = None,
         output_dir: str | Path | None = None,
+        llm_base_url: str | None = None,
+        llm_api_key: str | None = None,
     ) -> str:
         """Compress indexed chunks into a summary and append to a daily log.
 
@@ -235,6 +237,12 @@ class MemSearch:
         output_dir:
             Directory to write the compact file into.  Defaults to the
             first entry in *paths*.
+        llm_base_url:
+            Custom base URL for OpenAI-compatible API endpoints.  Only
+            used when *llm_provider* is ``"openai"``.
+        llm_api_key:
+            API key for the LLM provider.  Only used when *llm_provider*
+            is ``"openai"``.
 
         Returns
         -------
@@ -250,6 +258,7 @@ class MemSearch:
         summary = await compact_chunks(
             all_chunks, llm_provider=llm_provider, model=llm_model,
             prompt_template=prompt_template,
+            base_url=llm_base_url, api_key=llm_api_key,
         )
 
         # Write summary to memory/YYYY-MM-DD.md (append)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,3 +186,44 @@ def test_embedding_config_new_fields():
     cfg = EmbeddingConfig()
     assert cfg.base_url == ""
     assert cfg.api_key == ""
+
+
+def test_compact_config_new_fields():
+    """CompactConfig should have base_url and api_key fields with empty defaults."""
+    from memsearch.config import CompactConfig
+    cfg = CompactConfig()
+    assert cfg.base_url == ""
+    assert cfg.api_key == ""
+
+
+def test_compact_config_env_ref_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """resolve_config should resolve env: references in compact.api_key and compact.base_url."""
+    monkeypatch.setenv("TEST_LLM_KEY", "sk-llm-from-env")
+
+    cfg_file = tmp_path / "config.toml"
+    save_config({
+        "compact": {
+            "api_key": "env:TEST_LLM_KEY",
+            "base_url": "https://my-llm-endpoint.com",
+        },
+    }, cfg_file)
+
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    cfg = resolve_config()
+    assert cfg.compact.api_key == "sk-llm-from-env"
+    assert cfg.compact.base_url == "https://my-llm-endpoint.com"
+
+
+def test_compact_config_set_get_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """set_config_value + get_config_value should work for compact.base_url and compact.api_key."""
+    cfg_path = tmp_path / "config.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    set_config_value("compact.base_url", "https://custom-llm.example.com")
+    set_config_value("compact.api_key", "sk-custom-123")
+    cfg = resolve_config()
+    assert get_config_value("compact.base_url", cfg) == "https://custom-llm.example.com"
+    assert get_config_value("compact.api_key", cfg) == "sk-custom-123"


### PR DESCRIPTION
This pull request adds support for configuring a custom base URL and API key for OpenAI-compatible LLM providers in the compact summarization workflow, enabling easy conversion to cloud-hosted open source LLMs and enhancing symmetry of the configuration.

These new options can be set via CLI, configuration files, or environment variables, and are passed through all relevant layers of the application. The changes also include tests to ensure the new configuration fields work as expected.

**CLI and configuration enhancements:**

* Added `--llm-base-url` and `--llm-api-key` options to the CLI, allowing users to specify a custom OpenAI-compatible endpoint and API key for summarization tasks. These options are also mapped in the config key mapping and passed through all function layers (`cli.py`, `core.py`, `compact.py`). 

* Updated the `CompactConfig` dataclass to include `base_url` and `api_key` fields with empty string defaults, and ensured these fields are properly resolved from environment variables if specified using the `env:` syntax. 

**Core logic and API changes:**

* Modified the summarization logic to pass the new configuration options (`base_url`, `api_key`) down to the OpenAI client, resolving environment references where necessary. The OpenAI client is now initialized with these values if provided.

Testing improvements:

* Added tests to verify that the new `base_url` and `api_key` fields are present in `CompactConfig`, that environment references are resolved correctly, and that config set/get roundtrips work for these fields.

These changes make it easier to use custom or cloud-hosted OpenAI-compatible LLM endpoints for summarization, improving flexibility and security for users who need to specify their own API credentials or endpoints.