### PR TITLE
refine compact config: remove redundant env resolution and improve docs

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -456,8 +456,8 @@ def watch(
 @click.option("--output-dir", "-o", default=None, type=click.Path(), help="Directory to write the compact summary into.")
 @click.option("--llm-provider", default=None, help="LLM for summarization.")
 @click.option("--llm-model", default=None, help="Override LLM model.")
-@click.option("--llm-base-url", default=None, help="OpenAI-compatible base URL for the LLM.")
-@click.option("--llm-api-key", default=None, help="API key for the LLM provider.")
+@click.option("--llm-base-url", default=None, help="OpenAI-compatible base URL for the LLM (OpenAI provider only).")
+@click.option("--llm-api-key", default=None, help="API key for the LLM (OpenAI provider only).")
 @click.option("--prompt", default=None, help="Custom prompt template (must contain {chunks}).")
 @click.option("--prompt-file", default=None, type=click.Path(exists=True), help="Read prompt template from file.")
 @_common_options

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from .config import resolve_env_ref
-
 COMPACT_PROMPT = """\
 You are a knowledge compression assistant. Given the following chunks of text \
 from a knowledge base, create a concise but comprehensive summary that preserves \
@@ -83,11 +81,11 @@ async def _compact_openai(prompt: str, model: str, *, base_url: str | None = Non
     import openai
 
     kwargs: dict = {}
-    resolved_base_url = resolve_env_ref(base_url) if base_url else os.environ.get("OPENAI_BASE_URL")
+    resolved_base_url = base_url or os.environ.get("OPENAI_BASE_URL")
     if resolved_base_url:
         kwargs["base_url"] = resolved_base_url
     if api_key:
-        kwargs["api_key"] = resolve_env_ref(api_key)
+        kwargs["api_key"] = api_key
 
     client = openai.AsyncOpenAI(**kwargs)
     resp = await client.chat.completions.create(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,12 +199,13 @@ def test_compact_config_new_fields():
 def test_compact_config_env_ref_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """resolve_config should resolve env: references in compact.api_key and compact.base_url."""
     monkeypatch.setenv("TEST_LLM_KEY", "sk-llm-from-env")
+    monkeypatch.setenv("TEST_LLM_BASE_URL", "https://my-llm-endpoint.com")
 
     cfg_file = tmp_path / "config.toml"
     save_config({
         "compact": {
             "api_key": "env:TEST_LLM_KEY",
-            "base_url": "https://my-llm-endpoint.com",
+            "base_url": "env:TEST_LLM_BASE_URL",
         },
     }, cfg_file)
 


### PR DESCRIPTION
## Summary
- Remove redundant `resolve_env_ref` calls in `compact.py` — `resolve_config()` already handles `env:` reference resolution before values reach `compact_chunks()`
- Add "(OpenAI provider only)" to `--llm-base-url` / `--llm-api-key` CLI help text to clarify scope
- Fix `test_compact_config_env_ref_resolved` to use `env:` syntax for both `base_url` and `api_key`, matching the test docstring

Follow-up refinements to PR #101.

## Test plan
- [x] All 18 config tests pass (`uv run python -m pytest tests/test_config.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)