### PR TITLE
docs: remove language convention from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,5 +126,4 @@ They evolve independently — bump only the one that changed. If both changed, b
 - Uses `uv` + `pyproject.toml` for dependency management (not pip).
 - Optional deps via extras: `[google]`, `[voyage]`, `[ollama]`, `[local]`, `[all]`.
 - Docs at `docs/` use mkdocs-material. The `site/` directory is build output — do not commit.
-- Code and comments in English. Respond to the user in Chinese unless they specify otherwise.
 - Always use `uv run python -m pytest` instead of `uv run pytest` to avoid system Python pytest conflicts.


### PR DESCRIPTION
## Summary
- Remove the "respond in Chinese" language convention from project-level CLAUDE.md
- Response language preference is user-specific and should be configured in personal settings, not enforced at the project level

## Test plan
- No code changes, documentation only