### PR TITLE
feat: add collection description support

### DIFF
--- a/ccplugin/hooks/common.sh
+++ b/ccplugin/hooks/common.sh
@@ -90,12 +90,15 @@ ensure_memory_dir() {
   mkdir -p "$MEMORY_DIR"
 }
 
+# Collection description (set by session-start.sh, empty by default)
+COLLECTION_DESC=""
+
 # Helper: run memsearch with arguments, silently fail if not available
 run_memsearch() {
   if [ -n "$MEMSEARCH_CMD" ] && [ -n "$COLLECTION_NAME" ]; then
-    $MEMSEARCH_CMD "$@" --collection "$COLLECTION_NAME" 2>/dev/null || true
+    $MEMSEARCH_CMD "$@" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
   elif [ -n "$MEMSEARCH_CMD" ]; then
-    $MEMSEARCH_CMD "$@" 2>/dev/null || true
+    $MEMSEARCH_CMD "$@" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
   fi
 }
 
@@ -164,9 +167,9 @@ start_watch() {
   command -v setsid &>/dev/null && launch_prefix="setsid"
 
   if [ -n "$COLLECTION_NAME" ]; then
-    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" --collection "$COLLECTION_NAME" </dev/null &>/dev/null &
+    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
   else
-    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" </dev/null &>/dev/null &
+    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
   fi
   echo $! > "$WATCH_PIDFILE"
 }

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -63,6 +63,10 @@ if [ "$KEY_MISSING" = true ]; then
   status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
 fi
 
+# Build collection description: "<project_basename> | <provider>/<model>"
+PROJECT_BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-.}")
+COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
+
 # Write session heading to today's memory file
 ensure_memory_dir
 TODAY=$(date +%Y-%m-%d)

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -105,6 +105,7 @@ def cli() -> None:
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--force", is_flag=True, help="Re-index all files.")
+@click.option("--description", default=None, help="Collection description (written on creation only).")
 def index(
     paths: tuple[str, ...],
     provider: str | None,
@@ -116,6 +117,7 @@ def index(
     milvus_uri: str | None,
     milvus_token: str | None,
     force: bool,
+    description: str | None,
 ) -> None:
     """Index markdown files from PATHS."""
     from .core import MemSearch
@@ -126,7 +128,7 @@ def index(
         collection=collection,
         milvus_uri=milvus_uri, milvus_token=milvus_token,
     ))
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg))
+    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
     try:
         n = _run(ms.index(force=force))
         click.echo(f"Indexed {n} chunks.")
@@ -406,6 +408,7 @@ def transcript(
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--debounce-ms", default=None, type=int, help="Debounce delay in ms.")
+@click.option("--description", default=None, help="Collection description (written on creation only).")
 def watch(
     paths: tuple[str, ...],
     provider: str | None,
@@ -417,6 +420,7 @@ def watch(
     milvus_uri: str | None,
     milvus_token: str | None,
     debounce_ms: int | None,
+    description: str | None,
 ) -> None:
     """Watch PATHS for markdown changes and auto-index."""
     from .core import MemSearch
@@ -428,7 +432,7 @@ def watch(
         milvus_uri=milvus_uri, milvus_token=milvus_token,
         debounce_ms=debounce_ms,
     ))
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg))
+    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
 
     # Initial index: ensure existing files are indexed before watching
     n = _run(ms.index())

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -55,6 +55,7 @@ class MemSearch:
         milvus_uri: str = "~/.memsearch/milvus.db",
         milvus_token: str | None = None,
         collection: str = "memsearch_chunks",
+        description: str = "",
         max_chunk_size: int = 1500,
         overlap_lines: int = 2,
     ) -> None:
@@ -70,7 +71,7 @@ class MemSearch:
         )
         self._store = MilvusStore(
             uri=milvus_uri, token=milvus_token, collection=collection,
-            dimension=self._embedder.dimension,
+            dimension=self._embedder.dimension, description=description,
         )
 
     # ------------------------------------------------------------------

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -31,6 +31,7 @@ class MilvusStore:
         token: str | None = None,
         collection: str = DEFAULT_COLLECTION,
         dimension: int | None = 1536,
+        description: str = "",
     ) -> None:
         from pymilvus import MilvusClient
 
@@ -53,6 +54,7 @@ class MilvusStore:
         self._client = MilvusClient(**connect_kwargs)
         self._collection = collection
         self._dimension = dimension
+        self._description = description
         self._ensure_collection()
 
     def _ensure_collection(self) -> None:
@@ -65,7 +67,10 @@ class MilvusStore:
 
         from pymilvus import DataType, Function, FunctionType
 
-        schema = self._client.create_schema(enable_dynamic_field=True)
+        schema = self._client.create_schema(
+            enable_dynamic_field=True,
+            description=self._description,
+        )
         schema.add_field(field_name="chunk_hash", datatype=DataType.VARCHAR, max_length=64, is_primary=True)
         schema.add_field(field_name="embedding", datatype=DataType.FLOAT_VECTOR, dim=self._dimension)
         schema.add_field(field_name="content", datatype=DataType.VARCHAR, max_length=65535, enable_analyzer=True)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -158,3 +158,22 @@ def test_drop(store: MilvusStore):
     store._ensure_collection()
     results = store.search([1.0, 0.0, 0.0, 0.0], top_k=10)
     assert len(results) == 0
+
+
+def test_collection_description(tmp_path: Path):
+    """Collection should store the description when provided."""
+    db = str(tmp_path / "desc_test.db")
+    desc = "myproject | openai/text-embedding-3-small"
+    s = MilvusStore(uri=db, dimension=4, description=desc)
+    info = s._client.describe_collection(s._collection)
+    assert info.get("description") == desc
+    s.close()
+
+
+def test_collection_description_empty_by_default(tmp_path: Path):
+    """Collection should have empty description when not provided."""
+    db = str(tmp_path / "desc_default_test.db")
+    s = MilvusStore(uri=db, dimension=4)
+    info = s._client.describe_collection(s._collection)
+    assert info.get("description") == ""
+    s.close()


### PR DESCRIPTION
## Summary
- Add optional `--description` flag to `index` and `watch` CLI commands
- When a new Milvus collection is created, the description is written to the schema via `create_schema(description=...)`
- Existing collections are not affected — description is only written on creation
- ccplugin automatically generates description from project basename and embedding info (e.g. `memsearch | openai/text-embedding-3-small`)

## Changes
- `store.py`: `MilvusStore.__init__` accepts `description` param, passes to `create_schema`
- `core.py`: `MemSearch.__init__` accepts and forwards `description`
- `cli.py`: `index` and `watch` commands gain `--description` option
- `ccplugin/hooks/common.sh`: `run_memsearch` and `start_watch` pass `--description` when set
- `ccplugin/hooks/session-start.sh`: builds description from `$CLAUDE_PROJECT_DIR` basename + provider/model
- `tests/test_store.py`: 2 new tests for description write and empty default

## Test plan
- [x] All 51 tests pass (`uv run python -m pytest tests/ -v`)