### PR TITLE
fix: remove dead code — unused method, import, and dataclass field

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -19,7 +19,6 @@ from .config import (
     set_config_value,
     GLOBAL_CONFIG_PATH,
     PROJECT_CONFIG_PATH,
-    _SECTION_CLASSES,
 )
 
 

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -113,18 +113,6 @@ class MilvusStore:
                     )
                 break
 
-    def existing_hashes(self, hashes: list[str]) -> set[str]:
-        """Return the subset of *hashes* that already exist in the collection."""
-        if not hashes:
-            return set()
-        hash_list = ", ".join(f'"{h}"' for h in hashes)
-        results = self._client.query(
-            collection_name=self._collection,
-            filter=f"chunk_hash in [{hash_list}]",
-            output_fields=["chunk_hash"],
-        )
-        return {r["chunk_hash"] for r in results}
-
     def upsert(self, chunks: list[dict[str, Any]]) -> int:
         """Insert or update chunks (keyed by ``chunk_hash`` primary key).
 

--- a/src/memsearch/transcript.py
+++ b/src/memsearch/transcript.py
@@ -17,7 +17,6 @@ class Turn:
     role: str  # "user" or "assistant"
     content: str  # rendered text content
     tool_calls: list[str] = field(default_factory=list)  # ["Bash(command=ls)", ...]
-    line_index: int = 0  # line number in JSONL file
 
 
 def parse_transcript(path: str | Path) -> list[Turn]:
@@ -33,13 +32,12 @@ def parse_transcript(path: str | Path) -> list[Turn]:
 
     entries: list[dict[str, Any]] = []
     with open(path, encoding="utf-8") as f:
-        for i, line in enumerate(f):
+        for line in f:
             line = line.strip()
             if not line:
                 continue
             try:
                 obj = json.loads(line)
-                obj["_line_index"] = i
                 entries.append(obj)
             except json.JSONDecodeError:
                 continue
@@ -74,7 +72,6 @@ def parse_transcript(path: str | Path) -> list[Turn]:
                     timestamp=entry.get("timestamp", ""),
                     role="user",
                     content=clean,
-                    line_index=entry.get("_line_index", 0),
                 )
 
         elif entry_type == "assistant" and current_turn is not None:


### PR DESCRIPTION
## Summary

- Remove `MilvusStore.existing_hashes()` — defined but never called; upsert by PK handles dedup automatically
- Remove unused `_SECTION_CLASSES` import from `cli.py` (only used internally in `config.py`)
- Remove `Turn.line_index` field and `_line_index` bookkeeping from transcript parser — assigned but never read

**Breaking change:** `MilvusStore.existing_hashes()` was a public method. External users importing `MilvusStore` directly and calling this method will need to update their code. Acceptable at 0.x per semver.

Closes #107

## Test plan

- [x] All existing tests pass (`uv run python -m pytest` — 42 passed, 7 skipped)
- [x] Verified no remaining references to removed code via grep