### PR TITLE
release: memsearch v0.1.15, ccplugin v0.2.2

### DIFF
--- a/ccplugin/.claude-plugin/plugin.json
+++ b/ccplugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.1.14"
+version = "0.1.15"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump memsearch to v0.1.15
- Bump ccplugin to v0.2.2

## What's new
- Collection description support (`--description` flag for `index`/`watch`)
- ccplugin auto-generates description from project name + embedding info
- Compact config refinements (remove redundant env resolution, improve help text)
- Remove language convention from CLAUDE.md