### PR TITLE
ci: add ruff linting and formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Ruff lint
+        run: uv run ruff check src/ tests/
+
+      - name: Ruff format
+        run: uv run ruff format --check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,39 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9"]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",
     "mkdocs-terminal>=4.8.0",
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E", "W",  # pycodestyle
+    "F",       # pyflakes
+    "I",       # isort
+    "UP",      # pyupgrade
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "SIM",     # flake8-simplify
+    "PIE",     # flake8-pie
+    "PGH",     # pygrep-hooks
+    "RUF",     # ruff-specific
+    "T20",     # flake8-print
+    "PERF",    # perflint
+]
+ignore = [
+    "E501",    # line length handled by formatter
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["memsearch"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["T20"]  # allow print in tests

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -70,11 +70,7 @@ def chunk_markdown(
         sections.append((0, end, "", 0))
 
     for idx, (line_idx, level, title) in enumerate(heading_positions):
-        next_start = (
-            heading_positions[idx + 1][0]
-            if idx + 1 < len(heading_positions)
-            else len(lines)
-        )
+        next_start = heading_positions[idx + 1][0] if idx + 1 < len(heading_positions) else len(lines)
         sections.append((line_idx, next_start, title, level))
 
     chunks: list[Chunk] = []

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import click
 
 from .config import (
+    GLOBAL_CONFIG_PATH,
+    PROJECT_CONFIG_PATH,
     MemSearchConfig,
     config_to_dict,
     get_config_value,
@@ -17,9 +19,6 @@ from .config import (
     resolve_config,
     save_config,
     set_config_value,
-    GLOBAL_CONFIG_PATH,
-    PROJECT_CONFIG_PATH,
-    _SECTION_CLASSES,
 )
 
 
@@ -82,6 +81,7 @@ def _cfg_to_memsearch_kwargs(cfg: MemSearchConfig) -> dict:
 
 # -- Common CLI options --
 
+
 def _common_options(f):
     """Shared options for commands that create a MemSearch instance."""
     f = click.option("--provider", "-p", default=None, help="Embedding provider.")(f)
@@ -122,12 +122,18 @@ def index(
     """Index markdown files from PATHS."""
     from .core import MemSearch
 
-    cfg = resolve_config(_build_cli_overrides(
-        provider=provider, model=model, batch_size=batch_size,
-        base_url=base_url, api_key=api_key,
-        collection=collection,
-        milvus_uri=milvus_uri, milvus_token=milvus_token,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
     try:
         n = _run(ms.index(force=force))
@@ -157,12 +163,18 @@ def search(
     """Search indexed memory for QUERY."""
     from .core import MemSearch
 
-    cfg = resolve_config(_build_cli_overrides(
-        provider=provider, model=model, batch_size=batch_size,
-        base_url=base_url, api_key=api_key,
-        collection=collection,
-        milvus_uri=milvus_uri, milvus_token=milvus_token,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
         results = _run(ms.search(query, top_k=top_k or 5))
@@ -237,12 +249,18 @@ def expand(
     """
     from .store import MilvusStore
 
-    cfg = resolve_config(_build_cli_overrides(
-        provider=provider, model=model, batch_size=batch_size,
-        base_url=base_url, api_key=api_key,
-        collection=collection,
-        milvus_uri=milvus_uri, milvus_token=milvus_token,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
     store = MilvusStore(
         uri=cfg.milvus.uri,
         token=cfg.milvus.token or None,
@@ -279,11 +297,14 @@ def expand(
         else:
             # Show full section under the same heading
             expanded, expanded_start, expanded_end = _extract_section(
-                all_lines, start_line, heading_level,
+                all_lines,
+                start_line,
+                heading_level,
             )
 
         # Parse any anchor comments in the expanded text
         import re
+
         anchor_match = re.search(
             r"<!--\s*session:(\S+)\s+turn:(\S+)\s+transcript:(\S+)\s*-->",
             expanded,
@@ -321,7 +342,9 @@ def expand(
 
 
 def _extract_section(
-    all_lines: list[str], start_line: int, heading_level: int,
+    all_lines: list[str],
+    start_line: int,
+    heading_level: int,
 ) -> tuple[str, int, int]:
     """Extract the full section containing the chunk.
 
@@ -374,10 +397,10 @@ def transcript(
     Part of the progressive disclosure workflow (search -> expand -> transcript).
     """
     from .transcript import (
-        parse_transcript,
         find_turn_context,
-        format_turns,
         format_turn_index,
+        format_turns,
+        parse_transcript,
         turns_to_dicts,
     )
 
@@ -425,13 +448,19 @@ def watch(
     """Watch PATHS for markdown changes and auto-index."""
     from .core import MemSearch
 
-    cfg = resolve_config(_build_cli_overrides(
-        provider=provider, model=model, batch_size=batch_size,
-        base_url=base_url, api_key=api_key,
-        collection=collection,
-        milvus_uri=milvus_uri, milvus_token=milvus_token,
-        debounce_ms=debounce_ms,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+            debounce_ms=debounce_ms,
+        )
+    )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
 
     # Initial index: ensure existing files are indexed before watching
@@ -447,6 +476,7 @@ def watch(
     try:
         while True:
             import time
+
             time.sleep(1)
     except KeyboardInterrupt:
         click.echo("\nStopping watcher.")
@@ -457,7 +487,9 @@ def watch(
 
 @cli.command()
 @click.option("--source", "-s", default=None, help="Only compact chunks from this source.")
-@click.option("--output-dir", "-o", default=None, type=click.Path(), help="Directory to write the compact summary into.")
+@click.option(
+    "--output-dir", "-o", default=None, type=click.Path(), help="Directory to write the compact summary into."
+)
 @click.option("--llm-provider", default=None, help="LLM for summarization.")
 @click.option("--llm-model", default=None, help="Override LLM model.")
 @click.option("--llm-base-url", default=None, help="OpenAI-compatible base URL for the LLM.")
@@ -486,15 +518,23 @@ def compact(
     """Compress stored memories into a summary."""
     from .core import MemSearch
 
-    cfg = resolve_config(_build_cli_overrides(
-        provider=provider, model=model, batch_size=batch_size,
-        base_url=base_url, api_key=api_key,
-        collection=collection,
-        milvus_uri=milvus_uri, milvus_token=milvus_token,
-        llm_provider=llm_provider, llm_model=llm_model,
-        prompt_file=prompt_file,
-        llm_base_url=llm_base_url, llm_api_key=llm_api_key,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            prompt_file=prompt_file,
+            llm_base_url=llm_base_url,
+            llm_api_key=llm_api_key,
+        )
+    )
 
     prompt_template = prompt
     if cfg.compact.prompt_file and not prompt_template:
@@ -502,15 +542,17 @@ def compact(
 
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        summary = _run(ms.compact(
-            source=source,
-            llm_provider=cfg.compact.llm_provider,
-            llm_model=cfg.compact.llm_model or None,
-            prompt_template=prompt_template,
-            output_dir=output_dir,
-            llm_base_url=cfg.compact.base_url or None,
-            llm_api_key=cfg.compact.api_key or None,
-        ))
+        summary = _run(
+            ms.compact(
+                source=source,
+                llm_provider=cfg.compact.llm_provider,
+                llm_model=cfg.compact.llm_model or None,
+                prompt_template=prompt_template,
+                output_dir=output_dir,
+                llm_base_url=cfg.compact.base_url or None,
+                llm_api_key=cfg.compact.api_key or None,
+            )
+        )
         if summary:
             click.echo("Compact complete. Summary:\n")
             click.echo(summary)
@@ -532,9 +574,13 @@ def stats(
     """Show statistics about the index."""
     from .store import MilvusStore
 
-    cfg = resolve_config(_build_cli_overrides(
-        collection=collection, milvus_uri=milvus_uri, milvus_token=milvus_token,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
     store = MilvusStore(
         uri=cfg.milvus.uri,
         token=cfg.milvus.token or None,
@@ -561,9 +607,13 @@ def reset(
     """Drop all indexed data."""
     from .store import MilvusStore
 
-    cfg = resolve_config(_build_cli_overrides(
-        collection=collection, milvus_uri=milvus_uri, milvus_token=milvus_token,
-    ))
+    cfg = resolve_config(
+        _build_cli_overrides(
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
     store = MilvusStore(
         uri=cfg.milvus.uri,
         token=cfg.milvus.token or None,
@@ -581,6 +631,7 @@ def reset(
 # Config command group
 # ======================================================================
 
+
 @cli.group("config")
 def config_group() -> None:
     """Manage memsearch configuration."""
@@ -590,28 +641,30 @@ def config_group() -> None:
 @click.option("--project", is_flag=True, help="Write to .memsearch.toml (project-level) instead of global.")
 def config_init(project: bool) -> None:
     """Interactive configuration wizard."""
-    from dataclasses import fields as dc_fields
 
     target = PROJECT_CONFIG_PATH if project else GLOBAL_CONFIG_PATH
-    existing = load_config_file(target)
+    load_config_file(target)
     current = resolve_config()
 
     result: dict = {}
 
-    click.echo(f"memsearch configuration wizard")
+    click.echo("memsearch configuration wizard")
     click.echo(f"Writing to: {target}\n")
 
     # Milvus
     click.echo("── Milvus ──")
     result["milvus"] = {}
     result["milvus"]["uri"] = click.prompt(
-        "  Milvus URI", default=current.milvus.uri,
+        "  Milvus URI",
+        default=current.milvus.uri,
     )
     result["milvus"]["token"] = click.prompt(
-        "  Milvus token (empty for none)", default=current.milvus.token,
+        "  Milvus token (empty for none)",
+        default=current.milvus.token,
     )
     result["milvus"]["collection"] = click.prompt(
-        "  Collection name", default=current.milvus.collection,
+        "  Collection name",
+        default=current.milvus.collection,
     )
 
     # Embedding
@@ -631,7 +684,8 @@ def config_init(project: bool) -> None:
     _emb_provider = result["embedding"]["provider"]
     _emb_model_default = current.embedding.model or _embedding_defaults.get(_emb_provider, "")
     result["embedding"]["model"] = click.prompt(
-        "  Model", default=_emb_model_default,
+        "  Model",
+        default=_emb_model_default,
     )
     result["embedding"]["base_url"] = click.prompt(
         "  Base URL (empty for default, or env:VAR_NAME)",
@@ -646,17 +700,23 @@ def config_init(project: bool) -> None:
     click.echo("\n── Chunking ──")
     result["chunking"] = {}
     result["chunking"]["max_chunk_size"] = click.prompt(
-        "  Max chunk size (chars)", default=current.chunking.max_chunk_size, type=int,
+        "  Max chunk size (chars)",
+        default=current.chunking.max_chunk_size,
+        type=int,
     )
     result["chunking"]["overlap_lines"] = click.prompt(
-        "  Overlap lines", default=current.chunking.overlap_lines, type=int,
+        "  Overlap lines",
+        default=current.chunking.overlap_lines,
+        type=int,
     )
 
     # Watch
     click.echo("\n── Watch ──")
     result["watch"] = {}
     result["watch"]["debounce_ms"] = click.prompt(
-        "  Debounce (ms)", default=current.watch.debounce_ms, type=int,
+        "  Debounce (ms)",
+        default=current.watch.debounce_ms,
+        type=int,
     )
 
     # Compact
@@ -668,15 +728,18 @@ def config_init(project: bool) -> None:
     }
     result["compact"] = {}
     result["compact"]["llm_provider"] = click.prompt(
-        "  LLM provider (openai/anthropic/gemini)", default=current.compact.llm_provider,
+        "  LLM provider (openai/anthropic/gemini)",
+        default=current.compact.llm_provider,
     )
     _compact_provider = result["compact"]["llm_provider"]
     _compact_model_default = current.compact.llm_model or _compact_defaults.get(_compact_provider, "")
     result["compact"]["llm_model"] = click.prompt(
-        "  LLM model", default=_compact_model_default,
+        "  LLM model",
+        default=_compact_model_default,
     )
     result["compact"]["prompt_file"] = click.prompt(
-        "  Prompt file path (empty for built-in)", default=current.compact.prompt_file,
+        "  Prompt file path (empty for built-in)",
+        default=current.compact.prompt_file,
     )
 
     save_config(result, target)

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -73,10 +73,7 @@ async def compact_chunks(
     elif llm_provider == "gemini":
         return await _compact_gemini(prompt, model or "gemini-2.0-flash")
     else:
-        raise ValueError(
-            f"Unknown LLM provider {llm_provider!r}. "
-            f"Available: openai, anthropic, gemini"
-        )
+        raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
 
 
 async def _compact_openai(prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None) -> str:

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -96,13 +96,10 @@ def resolve_env_ref(value: str) -> str:
     """
     if not isinstance(value, str) or not value.startswith(_ENV_PREFIX):
         return value
-    var_name = value[len(_ENV_PREFIX):]
+    var_name = value[len(_ENV_PREFIX) :]
     env_val = os.environ.get(var_name)
     if env_val is None:
-        raise KeyError(
-            f"Environment variable {var_name!r} referenced in config "
-            f"(via {value!r}) is not set"
-        )
+        raise KeyError(f"Environment variable {var_name!r} referenced in config (via {value!r}) is not set")
     return env_val
 
 
@@ -131,7 +128,6 @@ def load_config_file(path: Path | str) -> dict[str, Any]:
         return {}
     with open(p, "rb") as f:
         return tomllib.load(f)
-
 
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .watcher import FileWatcher
 
 from .chunker import Chunk, chunk_markdown, compute_chunk_id
-from .embeddings import EmbeddingProvider, get_provider
 from .compact import compact_chunks
+from .embeddings import EmbeddingProvider, get_provider
 from .scanner import ScannedFile, scan_paths
 from .store import MilvusStore
 
@@ -70,8 +71,11 @@ class MemSearch:
             api_key=embedding_api_key,
         )
         self._store = MilvusStore(
-            uri=milvus_uri, token=milvus_token, collection=collection,
-            dimension=self._embedder.dimension, description=description,
+            uri=milvus_uri,
+            token=milvus_token,
+            collection=collection,
+            dimension=self._embedder.dimension,
+            description=description,
         )
 
     # ------------------------------------------------------------------
@@ -112,17 +116,15 @@ class MemSearch:
         source = str(f.path)
         text = f.path.read_text(encoding="utf-8")
         chunks = chunk_markdown(
-            text, source=source,
+            text,
+            source=source,
             max_chunk_size=self._max_chunk_size,
             overlap_lines=self._overlap_lines,
         )
         model = self._embedder.model_name
 
         # Compute composite chunk IDs (matching OpenClaw format)
-        chunk_ids = {
-            compute_chunk_id(c.source, c.start_line, c.end_line, c.content_hash, model)
-            for c in chunks
-        }
+        chunk_ids = {compute_chunk_id(c.source, c.start_line, c.end_line, c.content_hash, model) for c in chunks}
         old_ids = self._store.hashes_by_source(source)
 
         # Delete stale chunks that are no longer in the file
@@ -136,9 +138,9 @@ class MemSearch:
         if not force:
             # Only embed chunks whose ID doesn't already exist
             chunks = [
-                c for c in chunks
-                if compute_chunk_id(c.source, c.start_line, c.end_line, c.content_hash, model)
-                not in old_ids
+                c
+                for c in chunks
+                if compute_chunk_id(c.source, c.start_line, c.end_line, c.content_hash, model) not in old_ids
             ]
             if not chunks:
                 return 0
@@ -156,8 +158,11 @@ class MemSearch:
         records: list[dict[str, Any]] = []
         for i, chunk in enumerate(chunks):
             chunk_id = compute_chunk_id(
-                chunk.source, chunk.start_line, chunk.end_line,
-                chunk.content_hash, model,
+                chunk.source,
+                chunk.start_line,
+                chunk.end_line,
+                chunk.content_hash,
+                model,
             )
             records.append(
                 {
@@ -251,15 +256,19 @@ class MemSearch:
             The generated summary markdown.
         """
         from .store import _escape_filter_value
+
         filter_expr = f'source == "{_escape_filter_value(source)}"' if source else ""
         all_chunks = self._store.query(filter_expr=filter_expr)
         if not all_chunks:
             return ""
 
         summary = await compact_chunks(
-            all_chunks, llm_provider=llm_provider, model=llm_model,
+            all_chunks,
+            llm_provider=llm_provider,
+            model=llm_model,
             prompt_template=prompt_template,
-            base_url=llm_base_url, api_key=llm_api_key,
+            base_url=llm_base_url,
+            api_key=llm_api_key,
         )
 
         # Write summary to memory/YYYY-MM-DD.md (append)
@@ -267,7 +276,7 @@ class MemSearch:
         memory_dir = base / "memory"
         memory_dir.mkdir(parents=True, exist_ok=True)
         compact_file = memory_dir / f"{date.today()}.md"
-        compact_heading = f"\n\n## Memory Compact\n\n"
+        compact_heading = "\n\n## Memory Compact\n\n"
         with open(compact_file, "a", encoding="utf-8") as f:
             if compact_file.stat().st_size == 0:
                 f.write(f"# {date.today()}\n")

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -38,7 +38,7 @@ DEFAULT_MODELS: dict[str, str] = {
 }
 
 _INSTALL_HINTS: dict[str, str] = {
-    "openai": 'pip install memsearch  (or: uv add memsearch)',
+    "openai": "pip install memsearch  (or: uv add memsearch)",
     "google": 'pip install "memsearch[google]"  (or: uv add "memsearch[google]")',
     "voyage": 'pip install "memsearch[voyage]"  (or: uv add "memsearch[voyage]")',
     "ollama": 'pip install "memsearch[ollama]"  (or: uv add "memsearch[ollama]")',
@@ -71,10 +71,7 @@ def get_provider(
         Override the API key (currently only used by the openai provider).
     """
     if name not in _PROVIDERS:
-        raise ValueError(
-            f"Unknown embedding provider {name!r}. "
-            f"Available: {', '.join(sorted(_PROVIDERS))}"
-        )
+        raise ValueError(f"Unknown embedding provider {name!r}. Available: {', '.join(sorted(_PROVIDERS))}")
 
     module_path, class_name = _PROVIDERS[name]
     try:
@@ -83,10 +80,7 @@ def get_provider(
         mod = importlib.import_module(module_path)
     except ImportError as exc:
         hint = _INSTALL_HINTS.get(name, "")
-        raise ImportError(
-            f"Embedding provider {name!r} requires extra dependencies. "
-            f"Install with: {hint}"
-        ) from exc
+        raise ImportError(f"Embedding provider {name!r} requires extra dependencies. Install with: {hint}") from exc
 
     cls = getattr(mod, class_name)
     kwargs: dict = {}

--- a/src/memsearch/embeddings/google.py
+++ b/src/memsearch/embeddings/google.py
@@ -7,7 +7,6 @@ Environment variables:
 
 from __future__ import annotations
 
-
 # Known dimensions for common Google embedding models.
 # gemini-embedding-001 natively outputs 3072, but 768 is the recommended
 # default for most use cases (Matryoshka truncation, saves storage).
@@ -23,7 +22,10 @@ class GoogleEmbedding:
     _DEFAULT_BATCH_SIZE = 100
 
     def __init__(
-        self, model: str = "gemini-embedding-001", *, batch_size: int = 0,
+        self,
+        model: str = "gemini-embedding-001",
+        *,
+        batch_size: int = 0,
     ) -> None:
         from google import genai
 

--- a/src/memsearch/embeddings/local.py
+++ b/src/memsearch/embeddings/local.py
@@ -16,7 +16,10 @@ class LocalEmbedding:
     _DEFAULT_BATCH_SIZE = 512
 
     def __init__(
-        self, model: str = "all-MiniLM-L6-v2", *, batch_size: int = 0,
+        self,
+        model: str = "all-MiniLM-L6-v2",
+        *,
+        batch_size: int = 0,
     ) -> None:
         import io
         import os

--- a/src/memsearch/embeddings/ollama.py
+++ b/src/memsearch/embeddings/ollama.py
@@ -14,7 +14,10 @@ class OllamaEmbedding:
     _DEFAULT_BATCH_SIZE = 512
 
     def __init__(
-        self, model: str = "nomic-embed-text", *, batch_size: int = 0,
+        self,
+        model: str = "nomic-embed-text",
+        *,
+        batch_size: int = 0,
     ) -> None:
         import ollama
 

--- a/src/memsearch/embeddings/utils.py
+++ b/src/memsearch/embeddings/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 
 async def batched_embed(

--- a/src/memsearch/embeddings/voyage.py
+++ b/src/memsearch/embeddings/voyage.py
@@ -14,7 +14,10 @@ class VoyageEmbedding:
     _DEFAULT_BATCH_SIZE = 128
 
     def __init__(
-        self, model: str = "voyage-3-lite", *, batch_size: int = 0,
+        self,
+        model: str = "voyage-3-lite",
+        *,
+        batch_size: int = 0,
     ) -> None:
         import voyageai
 

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -80,12 +80,14 @@ class MilvusStore:
         schema.add_field(field_name="heading_level", datatype=DataType.INT64)
         schema.add_field(field_name="start_line", datatype=DataType.INT64)
         schema.add_field(field_name="end_line", datatype=DataType.INT64)
-        schema.add_function(Function(
-            name="bm25_fn",
-            function_type=FunctionType.BM25,
-            input_field_names=["content"],
-            output_field_names=["sparse_vector"],
-        ))
+        schema.add_function(
+            Function(
+                name="bm25_fn",
+                function_type=FunctionType.BM25,
+                input_field_names=["content"],
+                output_field_names=["sparse_vector"],
+            )
+        )
 
         index_params = self._client.prepare_index_params()
         index_params.add_index(field_name="embedding", index_type="FLAT", metric_type="COSINE")
@@ -185,14 +187,16 @@ class MilvusStore:
 
         if not results or not results[0]:
             return []
-        return [
-            {**hit["entity"], "score": hit["distance"]}
-            for hit in results[0]
-        ]
+        return [{**hit["entity"], "score": hit["distance"]} for hit in results[0]]
 
-    _QUERY_FIELDS = [
-        "content", "source", "heading", "chunk_hash",
-        "heading_level", "start_line", "end_line",
+    _QUERY_FIELDS: ClassVar[list[str]] = [
+        "content",
+        "source",
+        "heading",
+        "chunk_hash",
+        "heading_level",
+        "start_line",
+        "end_line",
     ]
 
     def query(self, *, filter_expr: str = "") -> list[dict[str, Any]]:
@@ -200,7 +204,7 @@ class MilvusStore:
         kwargs: dict[str, Any] = {
             "collection_name": self._collection,
             "output_fields": self._QUERY_FIELDS,
-            "filter": filter_expr if filter_expr else 'chunk_hash != ""',
+            "filter": filter_expr or 'chunk_hash != ""',
         }
         return self._client.query(**kwargs)
 

--- a/src/memsearch/transcript.py
+++ b/src/memsearch/transcript.py
@@ -55,10 +55,13 @@ def parse_transcript(path: str | Path) -> list[Turn]:
             content = msg.get("content", "")
 
             # Skip tool results — they are part of the previous assistant turn
-            if isinstance(content, list):
-                # Check if it's a tool_result array
-                if content and isinstance(content[0], dict) and content[0].get("type") == "tool_result":
-                    continue
+            if (
+                isinstance(content, list)
+                and content
+                and isinstance(content[0], dict)
+                and content[0].get("type") == "tool_result"
+            ):
+                continue
 
             # Real user message
             if isinstance(content, str) and content.strip():
@@ -180,6 +183,7 @@ def turns_to_dicts(turns: list[Turn]) -> list[dict[str, Any]]:
 def _strip_hook_tags(text: str) -> str:
     """Remove hook-injected XML tags from user messages."""
     import re
+
     # Remove <system-reminder>...</system-reminder>, <local-command-*>...</local-command-*>, etc.
     text = re.sub(r"<system-reminder>.*?</system-reminder>", "", text, flags=re.DOTALL)
     text = re.sub(r"<local-command-\w+>.*?</local-command-\w+>", "", text, flags=re.DOTALL)

--- a/src/memsearch/watcher.py
+++ b/src/memsearch/watcher.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,6 +1,6 @@
 """Tests for the markdown chunker."""
 
-from memsearch.chunker import Chunk, chunk_markdown
+from memsearch.chunker import chunk_markdown
 
 
 def test_simple_heading_split():
@@ -48,7 +48,7 @@ def test_content_hash_is_deterministic():
 
 def test_large_section_splitting():
     # Create a section larger than max_chunk_size
-    paragraphs = ["Paragraph %d. " % i + "x" * 200 for i in range(20)]
+    paragraphs = [f"Paragraph {i}. " + "x" * 200 for i in range(20)]
     md = "# Big Section\n\n" + "\n\n".join(paragraphs)
     chunks = chunk_markdown(md, source="test.md", max_chunk_size=500)
     assert len(chunks) > 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,9 +8,8 @@ import pytest
 import tomli_w
 
 from memsearch.config import (
-    MemSearchConfig,
-    MilvusConfig,
     EmbeddingConfig,
+    MemSearchConfig,
     deep_merge,
     get_config_value,
     load_config_file,
@@ -53,7 +52,6 @@ def test_load_missing_file(tmp_path: Path):
     """load_config_file should return {} for a missing file."""
     result = load_config_file(tmp_path / "nonexistent.toml")
     assert result == {}
-
 
 
 def test_deep_merge_basic():
@@ -152,6 +150,7 @@ def test_resolve_env_ref_env_prefix(monkeypatch: pytest.MonkeyPatch):
 def test_resolve_env_ref_missing_var():
     """env:VAR_NAME should raise KeyError if the variable is not set."""
     import os
+
     # Ensure the var doesn't exist
     os.environ.pop("NONEXISTENT_MEMSEARCH_VAR", None)
     with pytest.raises(KeyError, match="NONEXISTENT_MEMSEARCH_VAR"):
@@ -164,13 +163,16 @@ def test_resolve_env_refs_in_config(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("TEST_MILVUS_TOKEN", "token-from-env")
 
     cfg_file = tmp_path / "config.toml"
-    save_config({
-        "embedding": {
-            "api_key": "env:TEST_API_KEY",
-            "base_url": "https://my-endpoint.com",
+    save_config(
+        {
+            "embedding": {
+                "api_key": "env:TEST_API_KEY",
+                "base_url": "https://my-endpoint.com",
+            },
+            "milvus": {"token": "env:TEST_MILVUS_TOKEN"},
         },
-        "milvus": {"token": "env:TEST_MILVUS_TOKEN"},
-    }, cfg_file)
+        cfg_file,
+    )
 
     monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_file)
     monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
@@ -191,6 +193,7 @@ def test_embedding_config_new_fields():
 def test_compact_config_new_fields():
     """CompactConfig should have base_url and api_key fields with empty defaults."""
     from memsearch.config import CompactConfig
+
     cfg = CompactConfig()
     assert cfg.base_url == ""
     assert cfg.api_key == ""
@@ -201,12 +204,15 @@ def test_compact_config_env_ref_resolved(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setenv("TEST_LLM_KEY", "sk-llm-from-env")
 
     cfg_file = tmp_path / "config.toml"
-    save_config({
-        "compact": {
-            "api_key": "env:TEST_LLM_KEY",
-            "base_url": "https://my-llm-endpoint.com",
+    save_config(
+        {
+            "compact": {
+                "api_key": "env:TEST_LLM_KEY",
+                "base_url": "https://my-llm-endpoint.com",
+            },
         },
-    }, cfg_file)
+        cfg_file,
+    )
 
     monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_file)
     monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -15,7 +15,6 @@ from memsearch.core import MemSearch
 from memsearch.embeddings.utils import batched_embed
 from memsearch.store import MilvusStore
 
-
 # -- batched_embed utility tests --
 
 

--- a/tests/test_embeddings_openai.py
+++ b/tests/test_embeddings_openai.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture
 def provider():
     from memsearch.embeddings.openai import OpenAIEmbedding
+
     return OpenAIEmbedding()
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,6 +1,5 @@
 """Tests for the file scanner."""
 
-import os
 from pathlib import Path
 
 from memsearch.scanner import scan_paths

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1290,6 +1290,7 @@ voyage = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1320,6 +1321,7 @@ provides-extras = ["google", "voyage", "ollama", "local", "anthropic", "all"]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.9" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
@@ -2932,6 +2934,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add **ruff** as linter and formatter with industry-standard rule set (`E`, `W`, `F`, `I`, `UP`, `B`, `C4`, `SIM`, `PIE`, `PGH`, `RUF`, `T20`, `PERF`) — same conventions used by ruff, pydantic, and fastapi
- Add `lint.yml` CI workflow running `ruff check` + `ruff format --check` on every push/PR to main
- Fix 20 existing lint errors: unused imports, deprecated `typing.Callable` → `collections.abc.Callable`, empty f-strings, unsorted imports, mutable class attribute without `ClassVar`
- Format all source and test files with `ruff format`

Closes #109

## Test plan

- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — all files formatted
- [x] `uv run python -m pytest` — 44 passed, 7 skipped (unchanged)