### PR TITLE
feat: add /commit skill for conventional commits

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: commit
+description: Create a conventional commit following project conventions
+argument-hint: "[optional message override]"
+disable-model-invocation: true
+allowed-tools: Bash(git *)
+---
+
+Create a commit following this project's conventions.
+
+## Steps
+
+1. Run `git status` to see changed files (never use `-uall`).
+2. Run `git diff` (staged + unstaged) to understand what changed.
+3. Run `git log --oneline -5` to see recent commit style.
+4. Choose the correct conventional commit prefix based on the changes:
+
+   | Prefix     | When to use                                    |
+   |------------|------------------------------------------------|
+   | `feat`     | New feature or capability                      |
+   | `fix`      | Bug fix                                        |
+   | `docs`     | Documentation only                             |
+   | `ci`       | CI/CD workflows, GitHub Actions                |
+   | `chore`    | Dependencies, config, non-code maintenance     |
+   | `refactor` | Code restructuring without behavior change     |
+   | `test`     | Adding or updating tests                       |
+   | `style`    | Formatting, linting fixes (no logic change)    |
+   | `perf`     | Performance improvement                        |
+
+5. If there are no changes to commit, say so and stop.
+6. Stage the relevant files by name — do NOT use `git add -A` or `git add .`.
+7. Write a commit message:
+   - Format: `prefix(scope): short imperative description`
+   - Scope is optional — use it when the change targets a specific component (e.g., `fix(store):`, `ci(lint):`)
+   - Body explains **why**, not what — the diff shows what changed
+   - Do NOT add `Co-Authored-By` lines
+8. Commit using a HEREDOC for the message.
+9. Run `git status` to verify the commit succeeded.
+
+## Rules
+
+- Never commit `.env`, credentials, or secrets
+- Never amend previous commits unless explicitly asked
+- Never push — only commit locally
+- If `$ARGUMENTS` is provided, use it as guidance for the commit message but still follow the format above


### PR DESCRIPTION
## Summary

- Add a project-level Claude Code skill at `.claude/skills/commit/SKILL.md`
- Invoked with `/commit` — creates conventional commits following the project's prefix conventions
- `disable-model-invocation: true` — Claude cannot trigger it automatically, only the user can
- Supports all prefixes from CONTRIBUTING.md: `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`, `style`, `perf`
- Compatible with release-drafter autolabeler regex (handles `prefix:`, `prefix(scope):`, `prefix!:`)

### How it works

The skill instructs Claude to:
1. Check `git status` and `git diff` to understand changes
2. Pick the correct conventional commit prefix
3. Stage files by name (never `git add -A`)
4. Write a commit message with optional scope: `prefix(scope): description`
5. Never push, amend, or commit secrets

### Usage

```
/commit
/commit fix the scanner edge case
```

## Test plan

- [x] Skill file follows [Claude Code skills docs](https://code.claude.com/docs/en/skills): YAML frontmatter, `disable-model-invocation: true`, `allowed-tools`
- [x] All prefixes match release-drafter autolabeler config in #119
- [x] Skill does not auto-trigger — user-only invocation