### PR TITLE
ci(test): add coverage reporting with pytest-cov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run tests
-        run: uv run python -m pytest
+      - name: Run tests with coverage
+        run: uv run python -m pytest --cov=memsearch --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,16 @@ packages = ["src/memsearch"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
+[tool.coverage.run]
+branch = true
+source = ["memsearch"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "ruff>=0.9"]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",


### PR DESCRIPTION
## Summary
- add pytest-cov (>=6.0) to dev dependencies in pyproject
- add coverage run/report config sections for consistent output
- update CI test workflow to run pytest with coverage and missing-line report

## Validation
- PYTHONPATH=src python -m pytest tests/test_config.py --cov=memsearch --cov-report=term-missing -q

Closes #112