### PR TITLE
ci: use uv across all workflows and tighten permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,14 +12,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -27,7 +32,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install mkdocs-material mkdocs-terminal pymdown-extensions
+        run: uv sync --group docs
 
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to PyPI
@@ -25,19 +28,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: python -m pip install build
-
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.13
 
       - name: Publish GitHub Release
         uses: release-drafter/release-drafter@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **docs.yml**: Replace `pip install mkdocs-material ...` with `uv sync --group docs` — pip installs latest unpinned versions which can break unexpectedly, while `uv sync` resolves from `uv.lock` for reproducible builds
- **release.yml**: Replace `python -m pip install build` + `python -m build` with `uv build` — removes the need for an extra dependency and keeps the build tool consistent with local development. Update `pypa/gh-action-pypi-publish` from `release/v1` to `v1.13`
- **lint.yml, test.yml**: Add explicit `permissions: contents: read` at workflow level for least-privilege security

### Why uv over pip in CI?

The project uses `uv` + `pyproject.toml` everywhere — local development, CONTRIBUTING.md ("never pip install directly"), and most workflows already use `uv sync`. The two remaining workflows (`docs.yml`, `release.yml`) still used raw `pip install`, which:

1. **Bypasses the lockfile** — `pip install mkdocs-material` grabs latest, which may differ from what's in `uv.lock`
2. **Inconsistent with project conventions** — contributors are told to use `uv`, but CI doesn't follow its own rules
3. **Adds unnecessary dependencies** — `uv build` replaces both `pip install build` and `python -m build` in one step

### Permissions model

All workflows now follow the same pattern established in `release-drafter.yml`:
- Workflow level: `permissions: contents: read` (minimal default)
- Job level: only the permissions that job actually needs (e.g. `contents: write` for deploy)

## Test plan

- [x] Workflow syntax validated
- [x] All existing CI checks (lint, test) unaffected — changes are additive
- [x] Permission model consistent across all 5 workflows