### PR TITLE
ci: add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Run pytest across Python 3.10–3.12 on every push/PR to main
+# Run pytest across Python 3.10–3.13 on every push/PR to main
 
 name: Test
 
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add Python 3.13 to the test matrix in `test.yml`
- The `pyproject.toml` classifiers already include 3.13, but CI was only testing 3.10–3.12

Supersedes #103 — that PR was opened before `test.yml` existed on `main` and is now outdated (creates the file from scratch with older action versions and no coverage). This PR applies the same idea (adding 3.13) cleanly on top of the current `main`.

## Test plan

- [x] Workflow syntax validated
- [x] Python 3.13 classifier already present in `pyproject.toml`