### PR TITLE
docs(readme): add helpful tip after stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ memsearch stats                          # show total indexed chunk count
 memsearch reset                          # drop all indexed data (with confirmation)
 ```
 
+> 💡 **Tip:** Run `memsearch stats` after indexing to verify your content was processed successfully.
+
 > 📖 Full command reference with all flags and examples → [CLI Reference](https://zilliztech.github.io/memsearch/cli/)
 
 ## 🔍 How It Works


### PR DESCRIPTION
Adds a small tip to help users verify successful indexing after running stats command.