### PR TITLE
docs: add pre-commit hooks section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ uv run ruff check src/ tests/      # lint
 uv run ruff format src/ tests/     # format
 ```
 
+### Pre-commit Hooks (Recommended)
+
+Install pre-commit hooks to automatically run Ruff checks before each commit:
+
+```bash
+uv run pre-commit install
+```
+
+This ensures your code passes linting before committing, avoiding CI failures.
+
 - Python 3.10+ with `from __future__ import annotations` for type hints.
 - Code and comments in English.
 - Line length limit: 120 characters.


### PR DESCRIPTION
Adds documentation for the new pre-commit hooks in CONTRIBUTING.md.

Changes:
- Installation instructions for pre-commit hooks
- Benefits explanation for contributors

Relates to #125, part of #114