### PR TITLE
feat(ccplugin): show upgrade command in version update hint

### DIFF
--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -528,7 +528,7 @@ The SessionStart hook also loads the 2 most recent daily logs as `additionalCont
 **Update available:**
 
 ```
-[memsearch v0.1.11] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db | UPDATE: v0.1.12 available
+[memsearch v0.1.11] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db | UPDATE: v0.1.12 available — run: pip install --upgrade memsearch
 ```
 
 #### "ERROR: \<KEY\> not set — memory search disabled"
@@ -557,18 +557,18 @@ To make it permanent, add the export to your `~/.bashrc`, `~/.zshrc`, or equival
 
 #### "UPDATE: v0.x.x available"
 
-The plugin checks PyPI at session start (2s timeout) and shows this hint when a newer version exists. How to upgrade depends on your installation method:
+The plugin checks PyPI at session start (2s timeout) and shows this hint when a newer version exists. The hint now includes the exact upgrade command, auto-detected from your installation method:
 
-```bash
-# If installed via uv tool
-uv tool upgrade memsearch
-
-# If installed via pip
-pip install --upgrade memsearch
-
-# If using uvx (auto-upgraded on each session — you shouldn't see this)
-uvx --upgrade memsearch --version
 ```
+UPDATE: v0.1.15 available — run: pip install --upgrade memsearch
+UPDATE: v0.1.15 available — run: uv tool upgrade memsearch
+```
+
+| Install method | Upgrade command shown |
+|---|---|
+| `pip install memsearch` | `pip install --upgrade memsearch` |
+| `uv tool install memsearch` | `uv tool upgrade memsearch` |
+| `uvx` (auto) | `uvx --upgrade memsearch --version` |
 
 > **Note:** `uvx` users get automatic upgrades — the plugin runs `uvx --upgrade` on every bootstrap. The `UPDATE` hint primarily helps `pip`/`uv tool` users who have no automatic update mechanism.
 

--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -48,7 +48,18 @@ if [ -n "$VERSION" ]; then
   _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
   LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
-    UPDATE_HINT=" | UPDATE: v${LATEST} available"
+    # Detect install method to suggest the right upgrade command
+    if [ "$MEMSEARCH_CMD" = "uvx memsearch" ]; then
+      UPGRADE_CMD="uvx --upgrade memsearch --version"
+    else
+      _MS_PATH=$(command -v memsearch 2>/dev/null || true)
+      if [[ "$_MS_PATH" == *"uv/tools"* ]]; then
+        UPGRADE_CMD="uv tool upgrade memsearch"
+      else
+        UPGRADE_CMD="pip install --upgrade memsearch"
+      fi
+    fi
+    UPDATE_HINT=" | UPDATE: v${LATEST} available — run: ${UPGRADE_CMD}"
   fi
 fi
 

--- a/docs/claude-plugin/troubleshooting.md
+++ b/docs/claude-plugin/troubleshooting.md
@@ -88,18 +88,20 @@ To make it permanent, add the export to your `~/.bashrc`, `~/.zshrc`, or equival
 
 ### "UPDATE: v0.x.x available"
 
-The plugin checks PyPI at session start (2s timeout) and shows this hint when a newer version exists. How to upgrade depends on your installation method:
+The plugin checks PyPI at session start (2s timeout) and shows this hint when a newer version exists. The hint now includes the exact upgrade command for your installation method:
 
-```bash
-# If installed via uv tool
-uv tool upgrade memsearch
-
-# If installed via pip
-pip install --upgrade memsearch
-
-# If using uvx (auto-upgraded on each session -- you shouldn't see this)
-uvx --upgrade memsearch --version
 ```
+UPDATE: v0.1.15 available — run: pip install --upgrade memsearch
+UPDATE: v0.1.15 available — run: uv tool upgrade memsearch
+```
+
+The plugin auto-detects how memsearch was installed:
+
+| Install method | Upgrade command shown |
+|---|---|
+| `pip install memsearch` | `pip install --upgrade memsearch` |
+| `uv tool install memsearch` | `uv tool upgrade memsearch` |
+| `uvx` (auto) | `uvx --upgrade memsearch --version` |
 
 !!! note
     `uvx` users get automatic upgrades -- the plugin runs `uvx --upgrade` on every bootstrap. The `UPDATE` hint primarily helps `pip`/`uv tool` users who have no automatic update mechanism.


### PR DESCRIPTION
## Summary

- Auto-detect memsearch installation method (pip / uv tool / uvx) in the session-start hook
- Include the exact upgrade command in the UPDATE hint so users can copy-paste directly:
  ```
  UPDATE: v0.1.15 available — run: pip install --upgrade memsearch
  ```
- Detection logic: `uvx memsearch` → uvx command; PATH binary in `uv/tools` → uv tool; otherwise → pip
- Update ccplugin/README.md and docs/claude-plugin/troubleshooting.md to reflect the new format

## Test plan

- [ ] Verify with pip-installed memsearch: hint shows `pip install --upgrade memsearch`
- [ ] Verify with `uv tool install`: hint shows `uv tool upgrade memsearch`
- [ ] Verify with uvx fallback: hint shows `uvx --upgrade memsearch --version`
- [ ] Verify no hint when version is up to date