### PR TITLE
ci: add pre-commit hooks for ruff lint and format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,12 @@ Questions or ideas? Join the [Discord](https://discord.com/invite/FG6hMJStWu).
 git clone https://github.com/zilliztech/memsearch.git
 cd memsearch
 uv sync --all-extras
+uv run pre-commit install
 ```
 
 > **Dependency management:** Use `uv` and `pyproject.toml` — never `pip install` directly.
+>
+> **Pre-commit hooks:** The `pre-commit install` step registers Git hooks that run `ruff check --fix` and `ruff format` automatically on every commit, so style issues are caught before they reach CI.
 
 ## Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9", "pytest-cov>=6.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9", "pytest-cov>=6.0", "pre-commit>=4.0"]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",


### PR DESCRIPTION
## Summary

Add pre-commit hooks so contributors catch ruff lint and format issues locally before pushing, matching the existing CI lint workflow.

Closes #125

## Changes

- **`.pre-commit-config.yaml`** — new file with `ruff-pre-commit` hooks (`ruff check --fix` + `ruff format`), pinned to v0.9.10 (consistent with `ruff>=0.9` in dev deps)
- **`pyproject.toml`** — add `pre-commit>=4.0` to `[dependency-groups] dev`
- **`CONTRIBUTING.md`** — add `uv run pre-commit install` to Getting Started and explain what the hooks do

## Usage

After cloning:

```bash
uv sync --all-extras
uv run pre-commit install
```

Every `git commit` will now auto-run ruff lint (with `--fix`) and ruff format on staged files. No manual ruff invocation needed for contributors.