### PR TITLE
fix: prevent duplicate session headers in daily memory files

### DIFF
--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -83,7 +83,9 @@ ensure_memory_dir
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
 MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
-echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
+if [ ! -f "$MEMORY_FILE" ] || ! grep -qF "## Session $NOW" "$MEMORY_FILE"; then
+  echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
+fi
 
 # If API key is missing, show status and exit early (watch/search would fail)
 if [ "$KEY_MISSING" = true ]; then


### PR DESCRIPTION
## Problem

When `SessionStart` fires multiple times in the same minute (hook double-fire, rapid session restarts), the unconditional append in `session-start.sh` creates duplicate `## Session HH:MM` headers in the daily memory file.

## Fix

Guard the header append with a `grep -qF` check so it's only written once per unique timestamp:

```bash
# Before (unconditional)
echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"

# After (idempotent)
if [ ! -f "$MEMORY_FILE" ] || ! grep -qF "## Session $NOW" "$MEMORY_FILE"; then
  echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
fi
```

## Test plan

- Start two sessions in the same minute
- Verify only one `## Session HH:MM` header appears in the daily memory file
- Verify normal single-session behavior is unchanged