### PR TITLE
ci: add pre-commit hooks for ruff lint and format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,12 @@ Questions or ideas? Join the [Discord](https://discord.com/invite/FG6hMJStWu).
 git clone https://github.com/zilliztech/memsearch.git
 cd memsearch
 uv sync --all-extras
+uv run pre-commit install
 ```
 
 > **Dependency management:** Use `uv` and `pyproject.toml` — never `pip install` directly.
+>
+> **Pre-commit hooks:** The `pre-commit install` step registers Git hooks that run `ruff check --fix` and `ruff format` on staged files before each commit.
 
 ## Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9", "pytest-cov>=6.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9", "pytest-cov>=6.0", "pre-commit>=4.0"]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with `ruff-check` (with `--fix`) and `ruff-format` hooks, pinned to v0.15.4 (matches current dev dependency)
- Add `pre-commit>=4.0` to dev dependency group
- Document `uv run pre-commit install` in CONTRIBUTING.md Getting Started

## Why
Closes #125 — lets contributors catch lint/format issues locally before pushing, consistent with existing CI ruff checks.

## Test plan
- [ ] `uv sync --all-extras && uv run pre-commit install`
- [ ] `uv run pre-commit run --all-files` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)