### PR TITLE
feat(search): add source_prefix filter to scope results by directory

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -16,7 +16,7 @@ from .chunker import Chunk, chunk_markdown, compute_chunk_id
 from .compact import compact_chunks
 from .embeddings import EmbeddingProvider, get_provider
 from .scanner import ScannedFile, scan_paths
-from .store import MilvusStore
+from .store import MilvusStore, _escape_filter_value
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +188,7 @@ class MemSearch:
         query: str,
         *,
         top_k: int = 10,
+        source_prefix: str | Path | None = None,
     ) -> list[dict[str, Any]]:
         """Semantic search across indexed chunks.
 
@@ -197,6 +198,9 @@ class MemSearch:
             Natural-language query.
         top_k:
             Maximum results to return.
+        source_prefix:
+            Optional source path prefix. When set, only chunks whose
+            ``source`` starts with this prefix are searched.
 
         Returns
         -------
@@ -204,8 +208,19 @@ class MemSearch:
             Each dict contains ``content``, ``source``, ``heading``,
             ``score``, and other metadata.
         """
+        filter_expr = ""
+        if source_prefix is not None:
+            prefix = str(Path(source_prefix).expanduser().resolve())
+            escaped_prefix = _escape_filter_value(prefix)
+            filter_expr = f'source like "{escaped_prefix}%"'
+
         embeddings = await self._embedder.embed([query])
-        return self._store.search(embeddings[0], query_text=query, top_k=top_k)
+        return self._store.search(
+            embeddings[0],
+            query_text=query,
+            top_k=top_k,
+            filter_expr=filter_expr,
+        )
 
     # ------------------------------------------------------------------
     # Compact (compress memories)

--- a/tests/test_core_search_filters.py
+++ b/tests/test_core_search_filters.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from memsearch.core import MemSearch
+
+
+class _DummyEmbedder:
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        assert len(texts) == 1
+        return [[0.1, 0.2, 0.3]]
+
+
+class _DummyStore:
+    def __init__(self) -> None:
+        self.last_filter_expr = None
+
+    def search(self, query_embedding, *, query_text: str, top_k: int, filter_expr: str = ""):
+        self.last_filter_expr = filter_expr
+        return [{"content": "ok", "source": "x.md", "score": 0.9}]
+
+
+@pytest.mark.asyncio
+async def test_search_applies_source_prefix_filter(tmp_path: Path):
+    mem = object.__new__(MemSearch)
+    mem._embedder = _DummyEmbedder()
+    store = _DummyStore()
+    mem._store = store
+
+    base = (tmp_path / "memory" / "product")
+    base.mkdir(parents=True)
+
+    await mem.search("price", source_prefix=base)
+
+    expected_prefix = str(base.resolve()).replace("\\", "\\\\").replace('"', '\\"')
+    assert store.last_filter_expr == f'source like "{expected_prefix}%"'
+
+
+@pytest.mark.asyncio
+async def test_search_without_source_prefix_keeps_filter_empty():
+    mem = object.__new__(MemSearch)
+    mem._embedder = _DummyEmbedder()
+    store = _DummyStore()
+    mem._store = store
+
+    await mem.search("anything")
+
+    assert store.last_filter_expr == ""


### PR DESCRIPTION
## Summary
- add optional `source_prefix` parameter to `MemSearch.search()`
- convert prefix to an absolute path and apply a Milvus filter (`source like "<prefix>%"`)
- add async unit tests to validate filtered and unfiltered behavior

## Why
This enables searching within a specific subdirectory without creating separate MemSearch instances, matching the request in #178.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/test_core_search_filters.py`

Closes #178
