### PR TITLE
feat(cli): add --source-prefix option to memsearch search

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -145,11 +145,13 @@ def index(
 @cli.command()
 @click.argument("query")
 @click.option("--top-k", "-k", default=None, type=int, help="Number of results.")
+@click.option("--source-prefix", default=None, type=click.Path(path_type=Path), help="Only search chunks whose source path starts with this directory/file prefix.")
 @_common_options
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
 def search(
     query: str,
     top_k: int | None,
+    source_prefix: Path | None,
     provider: str | None,
     model: str | None,
     batch_size: int | None,
@@ -177,7 +179,7 @@ def search(
     )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        results = _run(ms.search(query, top_k=top_k or 5))
+        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
         else:

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -43,6 +43,13 @@ class TestCLIHelp:
         assert result.exit_code == 0
         assert "Usage:" in result.output
 
+    def test_search_help_includes_source_prefix(self):
+        """Search help should include source-prefix option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--help"])
+        assert result.exit_code == 0
+        assert "--source-prefix" in result.output
+
     def test_stats_help(self):
         """Stats command should have help."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- add `--source-prefix` option to `memsearch search`
- pass CLI `--source-prefix` through to `MemSearch.search(..., source_prefix=...)`
- add CLI help test coverage for the new option

## Why
Issue #178 requests directory-scoped search. The API support is in #180; this PR exposes the same capability in the CLI so users can scope search results without writing Python code.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/test_cli_help.py::TestCLIHelp::test_search_help tests/test_cli_help.py::TestCLIHelp::test_search_help_includes_source_prefix`

Related to #178
