### PR TITLE
fix: resolve compact source paths before filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Compress indexed chunks into a condensed markdown summary using an LLM:
 
 ```bash
 memsearch compact
-memsearch compact --llm-provider anthropic --source ./memory/old-notes.md
+memsearch compact --llm-provider anthropic --source /absolute/path/to/memory/old-notes.md
 ```
 
 ### Utilities — `stats` / `reset`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -442,12 +442,15 @@ Compact complete. Summary:
 Compact only chunks from a specific source file:
 
 ```bash
-$ memsearch compact --source ./memory/old-notes.md
+$ memsearch compact --source /absolute/path/to/memory/old-notes.md
 Compact complete. Summary:
 
 ## Old Notes Summary
 - Initial architecture decisions from January meeting...
 ```
+
+`--source` is matched against the absolute path stored during indexing. Relative paths are
+resolved to absolute form by the CLI before querying the store.
 
 Use Anthropic Claude for summarization:
 

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -540,11 +540,13 @@ def compact(
     if cfg.compact.prompt_file and not prompt_template:
         prompt_template = Path(cfg.compact.prompt_file).read_text(encoding="utf-8")
 
+    resolved_source = str(Path(source).expanduser().resolve()) if source else None
+
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
         summary = _run(
             ms.compact(
-                source=source,
+                source=resolved_source,
                 llm_provider=cfg.compact.llm_provider,
                 llm_model=cfg.compact.llm_model or None,
                 prompt_template=prompt_template,

--- a/tests/test_cli_compact.py
+++ b/tests/test_cli_compact.py
@@ -1,0 +1,40 @@
+"""Tests for the compact CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+
+
+class _FakeMemSearch:
+    last_source: str | None = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    async def compact(self, **kwargs):
+        _FakeMemSearch.last_source = kwargs.get("source")
+        return ""
+
+    def close(self):
+        return None
+
+
+def test_compact_resolves_relative_source_to_absolute_path(tmp_path: Path, monkeypatch):
+    source_file = tmp_path / "memory" / "old-notes.md"
+    source_file.parent.mkdir()
+    source_file.write_text("# Old notes\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("memsearch.core.MemSearch", _FakeMemSearch)
+    _FakeMemSearch.last_source = None
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["compact", "--source", "memory/old-notes.md"])
+
+    assert result.exit_code == 0
+    assert _FakeMemSearch.last_source == str(source_file.resolve())
+    assert "No chunks to compact." in result.output


### PR DESCRIPTION
$## Summary\n- resolve `compact --source` paths with `expanduser().resolve()` before building the source filter\n- update CLI docs and README examples to show the absolute-path behavior clearly\n- add a CLI regression test covering relative-path resolution\n\n## Testing\n- `uv run python -m pytest tests/test_cli_compact.py -q`\n- `uv run ruff check src/memsearch/cli.py tests/test_cli_compact.py`\n- `uv run ruff format --check src/memsearch/cli.py tests/test_cli_compact.py`\n- `git diff --check`\n\nCloses #174