### PR TITLE
fix(ccplugin): respect config file API key before requiring env variable

### DIFF
--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -39,7 +39,15 @@ REQUIRED_KEY=$(_required_env_var "$PROVIDER")
 
 KEY_MISSING=false
 if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
-  KEY_MISSING=true
+  # Before declaring key missing, check if the config file provides an API key
+  # (supports both literal keys and "env:VAR_NAME" references).
+  CONFIG_API_KEY=""
+  if [ -n "$MEMSEARCH_CMD" ]; then
+    CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || true)
+  fi
+  if [ -z "$CONFIG_API_KEY" ]; then
+    KEY_MISSING=true
+  fi
 fi
 
 # Check PyPI for newer version (2s timeout, non-blocking on failure)


### PR DESCRIPTION
## Problem

The CC plugin `session-start.sh` hook only checks environment variables (e.g. `OPENAI_API_KEY`) to determine whether an API key is available. This causes a false `ERROR: OPENAI_API_KEY not set — memory search disabled` even when the API key is correctly configured in the memsearch config file.

As reported in #181, users who configure their API key via `memsearch.yaml` / `.memsearch.toml` (either as a literal value or using the `env:VAR_NAME` syntax) hit this error because the hook never consults the config.

## Fix

Before declaring the key missing, query `memsearch config get embedding.api_key`. If the config provides a non-empty value, skip the env-var error. This respects the existing priority chain: config file → env variable.

## Changes

- `ccplugin/hooks/session-start.sh`: Added config-file API key check before setting `KEY_MISSING=true`

Fixes #181