### PR TITLE
fix: check config file for API key before reporting missing key

### DIFF
--- a/ccplugin/hooks/session-start.sh
+++ b/ccplugin/hooks/session-start.sh
@@ -48,7 +48,14 @@ REQUIRED_KEY=$(_required_env_var "$PROVIDER")
 
 KEY_MISSING=false
 if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
-  KEY_MISSING=true
+  # Env var not set — check if API key is configured in memsearch config file
+  CONFIG_API_KEY=""
+  if [ -n "$MEMSEARCH_CMD" ]; then
+    CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
+  fi
+  if [ -z "$CONFIG_API_KEY" ]; then
+    KEY_MISSING=true
+  fi
 fi
 
 # Check PyPI for newer version (2s timeout, non-blocking on failure)


### PR DESCRIPTION
## Summary
- Fix false "API key missing" error when users configure `embedding.api_key` in memsearch config file (`.memsearch.toml` or `~/.memsearch/config.toml`) instead of setting environment variables
- Before declaring `KEY_MISSING=true`, now checks `memsearch config get embedding.api_key` as a fallback
- No impact on providers that don't require API keys (onnx, ollama, local)

Closes #181