### PR TITLE
fix(stop-hook): suppress hooks in haiku summarization subprocess

### DIFF
--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -87,7 +87,7 @@ if command -v claude &>/dev/null; then
     --model haiku \
     --no-session-persistence \
     --no-chrome \
-    --settings '{"hooks":{}}' \
+    --settings '{"hooks":{"Stop":[],"UserPromptSubmit":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"SessionStart":[],"SessionEnd":[]}}' \
     --system-prompt "You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human (labeled [Human]) and Claude Code (labeled [Claude Code]). Tool calls are labeled [Tool Call] and their results [Tool RESULT] or [Tool ERROR].
 
 Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT Claude Code, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.


### PR DESCRIPTION
## Problem

When a user has Claude Code hooks configured — notification relays, loggers, or any other hook system registered in `~/.claude/settings.json` — the inner `claude -p` call in `stop.sh` inherits those hooks. The subprocess is treated as a real user session, causing the hook system to fire on the transcript content.

Concretely: hook systems that forward prompts/responses (e.g. to Slack, Telegram, or a logging service) see the summarization call as a new conversation and relay the raw transcript or fire Stop hooks on the haiku response. Users end up with duplicate messages or unintended side effects triggered by every Claude Code turn.

`CLAUDECODE=` is already set to signal non-interactive mode, but hooks are loaded from `settings.json` before hook scripts have a chance to check that env var.

## Fix

Pass `--settings '{"hooks":{}}'` to the `claude -p` invocation. This overrides the hooks configuration for the subprocess only, clearing all registered hooks without affecting the parent session.

```bash
SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
  --model haiku \
  --no-session-persistence \
  --no-chrome \
  --settings '{"hooks":{}}' \   # ← new
  --system-prompt "..."
```

The `--settings` flag accepts inline JSON and merges with (or in this case overrides) the active settings, scoped to the subprocess only. No change to behaviour for users without hooks configured.

## Testing

Reproduced by registering a UserPromptSubmit hook that logs to a file, then verifying the log no longer receives entries from the haiku summarization call after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)