### PR TITLE
fix: handle array-format user message content in parse-transcript.sh

### DIFF
--- a/ccplugin/hooks/parse-transcript.sh
+++ b/ccplugin/hooks/parse-transcript.sh
@@ -39,7 +39,7 @@ def truncate(text, max_chars):
     return text[:max_chars] + "...(truncated)"
 
 def find_last_turn_start(lines):
-    """Find the index of the last real user message (content is a plain string)."""
+    """Find the index of the last real user message (string or array-format content)."""
     for i in range(len(lines) - 1, -1, -1):
         try:
             obj = json.loads(lines[i])
@@ -47,6 +47,10 @@ def find_last_turn_start(lines):
                 content = obj.get("message", {}).get("content")
                 if isinstance(content, str) and content.strip():
                     return i
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text" and block.get("text", "").strip():
+                            return i
         except Exception:
             pass
     return None
@@ -74,7 +78,11 @@ def format_turn(lines):
                 for block in content:
                     if not isinstance(block, dict):
                         continue
-                    if block.get("type") == "tool_result":
+                    if block.get("type") == "text":
+                        text = block.get("text", "").strip()
+                        if text:
+                            output.append(f"[Human]: {text}")
+                    elif block.get("type") == "tool_result":
                         result = block.get("content", "")
                         if isinstance(result, list):
                             texts = []


### PR DESCRIPTION
## Summary

- Fix `parse-transcript.sh` failing to parse user messages when `content` is an array of blocks instead of a plain string
- Claude Code follows the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) format where `content` can be either a string or an array of content blocks (e.g., `[{"type": "text", "text": "..."}]`)
- Update both `find_last_turn_start()` and `format_turn()` to handle both formats

## Root Cause

`find_last_turn_start()` only checked `isinstance(content, str)`, returning `None` for array-format messages. Similarly, `format_turn()` only handled `tool_result` blocks in list content, silently skipping `text` blocks.

This caused `stop.sh` to receive `"(no user message found)"` and skip writing summaries, resulting in empty session memory entries.

## Test Plan

- [x] Verified bug reproduction: array-format JSONL returns `(no user message found)` before fix
- [x] Verified fix: array-format messages correctly parsed after fix
- [x] Verified backward compatibility: string-format messages still work
- [x] Verified mixed format (string + array in same transcript) works
- [x] Verified with real transcript from current session

Closes #196