### PR TITLE
chore: bump ccplugin version to 0.2.5

### DIFF
--- a/ccplugin/.claude-plugin/plugin.json
+++ b/ccplugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }


### PR DESCRIPTION
## Summary

- Bump ccplugin version from 0.2.4 to 0.2.5
- Includes fix for array-format user message content in parse-transcript.sh (#197)