### PR TITLE
Fix stop.sh to fall back to config file for API key check

### DIFF
--- a/ccplugin/hooks/stop.sh
+++ b/ccplugin/hooks/stop.sh
@@ -24,8 +24,15 @@ _required_env_var() {
 _PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "onnx")
 _REQ_KEY=$(_required_env_var "$_PROVIDER")
 if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
-  echo '{}'
-  exit 0
+  # Env var not set — check if API key is configured in memsearch config file
+  _CONFIG_API_KEY=""
+  if [ -n "$MEMSEARCH_CMD" ]; then
+    _CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
+  fi
+  if [ -z "$_CONFIG_API_KEY" ]; then
+    echo '{}'
+    exit 0
+  fi
 fi
 
 # Extract transcript path from hook input


### PR DESCRIPTION
## Problem

`ccplugin/hooks/stop.sh` checks for the required API key (e.g. `OPENAI_API_KEY`) only via environment variables. If the env var is not set, it exits early — skipping conversation summarization and memory indexing entirely.

However, `session-start.sh` already handles this correctly: it first checks the env var, then falls back to checking `embedding.api_key` from the memsearch config file (set via `memsearch config set embedding.api_key <key>`).

This inconsistency means users who configure their API key through the memsearch config file (rather than environment variables) will:
- See the "key not set" warning from `session-start.sh` (which is also a bug, but separate)
- **Never get conversation summaries saved** because `stop.sh` bails out before summarization

## Fix

Add the same config file fallback to `stop.sh` that `session-start.sh` already has. Before exiting early, check `$MEMSEARCH_CMD config get embedding.api_key` — only bail out if both the env var and the config value are missing.

### Before
```bash
if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
  echo '{}'
  exit 0
fi
```

### After
```bash
if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
  # Env var not set — check if API key is configured in memsearch config file
  _CONFIG_API_KEY=""
  if [ -n "$MEMSEARCH_CMD" ]; then
    _CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
  fi
  if [ -z "$_CONFIG_API_KEY" ]; then
    echo '{}'
    exit 0
  fi
fi
```

This matches the pattern already used in `session-start.sh` (lines 56-63).