### PR TITLE
feat: clean chunk content before embedding to improve vector quality

### DIFF
--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -7,6 +7,41 @@ import re
 from dataclasses import dataclass, field
 
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Minimum meaningful text length after stripping metadata noise.
+# Chunks with less useful text than this are dropped during chunking.
+_MIN_MEANINGFUL_LEN = 2
+
+
+def clean_content_for_embedding(text: str) -> str:
+    """Strip metadata noise from chunk content before embedding.
+
+    Removes HTML comments (<!-- ... -->), which often contain session/turn
+    UUIDs and transcript paths that dilute embedding quality.  The original
+    content stored in Milvus is unchanged — this only affects the text
+    sent to the embedding model.
+    """
+    cleaned = _HTML_COMMENT_RE.sub("", text)
+    # Collapse runs of blank lines left behind by removed comments
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _has_meaningful_content(text: str) -> bool:
+    """Return True if *text* has enough substance to be worth indexing.
+
+    Strips HTML comments, heading lines, and whitespace, then checks
+    whether the remaining body text meets the minimum length threshold.
+    A section like ``## Session 03:16`` with no body is rejected, while
+    ``## Title\\nSome real content`` is kept.
+    """
+    # Remove HTML comments first
+    stripped = _HTML_COMMENT_RE.sub("", text)
+    # Remove heading lines — we only care about body text
+    lines = [ln for ln in stripped.splitlines() if not _HEADING_RE.match(ln)]
+    body = "\n".join(lines).strip()
+    return len(body) >= _MIN_MEANINGFUL_LEN
 
 
 @dataclass(frozen=True)
@@ -76,7 +111,7 @@ def chunk_markdown(
     chunks: list[Chunk] = []
     for start, end, heading, level in sections:
         section_text = "\n".join(lines[start:end]).strip()
-        if not section_text:
+        if not section_text or not _has_meaningful_content(section_text):
             continue
 
         if len(section_text) <= max_chunk_size:

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .watcher import FileWatcher
 
-from .chunker import Chunk, chunk_markdown, compute_chunk_id
+from .chunker import Chunk, chunk_markdown, clean_content_for_embedding, compute_chunk_id
 from .compact import compact_chunks
 from .embeddings import EmbeddingProvider, get_provider
 from .scanner import ScannedFile, scan_paths
@@ -152,7 +152,10 @@ class MemSearch:
             return 0
 
         model = self._embedder.model_name
-        contents = [c.content for c in chunks]
+        # Clean content for embedding: strip HTML comments and metadata noise
+        # so the embedding vector captures semantics, not UUIDs/paths.
+        # The original content is preserved in the Milvus record below.
+        contents = [clean_content_for_embedding(c.content) for c in chunks]
         embeddings = await self._embedder.embed(contents)
 
         records: list[dict[str, Any]] = []

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,6 +1,6 @@
 """Tests for the markdown chunker."""
 
-from memsearch.chunker import chunk_markdown
+from memsearch.chunker import chunk_markdown, clean_content_for_embedding
 
 
 def test_simple_heading_split():
@@ -61,3 +61,55 @@ def test_source_and_lines():
     chunks = chunk_markdown(md, source="doc.md")
     assert all(c.source == "doc.md" for c in chunks)
     assert chunks[0].start_line >= 1
+
+
+def test_empty_session_heading_filtered():
+    """Headings with no meaningful body text should be dropped."""
+    md = """\
+## Session 03:16
+
+## Session 03:17
+
+### 03:18
+<!-- session:abc-123 turn:def-456 transcript:/path/to/file.jsonl -->
+- User asked about something important and Claude provided a detailed answer.
+"""
+    chunks = chunk_markdown(md, source="daily.md")
+    # The two empty "## Session" sections should be filtered out
+    assert all("Session 03:16" not in c.heading for c in chunks)
+    assert all("Session 03:17" not in c.heading for c in chunks)
+    # The section with real content should survive
+    assert len(chunks) >= 1
+    assert any("something important" in c.content for c in chunks)
+
+
+def test_html_comment_only_chunk_filtered():
+    """A chunk with only a heading and HTML comment should be dropped."""
+    md = """\
+### 08:00
+<!-- session:aaa-bbb turn:ccc-ddd transcript:/tmp/foo.jsonl -->
+"""
+    chunks = chunk_markdown(md, source="daily.md")
+    assert chunks == []
+
+
+def test_clean_content_for_embedding():
+    """HTML comments should be stripped for embedding but content preserved."""
+    text = (
+        "### 03:18\n"
+        "<!-- session:abc-123 turn:def-456 transcript:/path/to/file.jsonl -->\n"
+        "- User asked about chunking optimization."
+    )
+    cleaned = clean_content_for_embedding(text)
+    assert "session:abc-123" not in cleaned
+    assert "transcript:" not in cleaned
+    assert "chunking optimization" in cleaned
+
+
+def test_clean_content_collapses_blank_lines():
+    """Removing comments should not leave excessive blank lines."""
+    text = "Line one.\n\n<!-- comment -->\n\n\n\nLine two."
+    cleaned = clean_content_for_embedding(text)
+    assert "\n\n\n" not in cleaned
+    assert "Line one." in cleaned
+    assert "Line two." in cleaned


### PR DESCRIPTION
## Summary
- Strip HTML comments (`<!-- session/turn/transcript metadata -->`) from chunk text before embedding, so vectors capture semantics instead of UUIDs and file paths
- Filter out chunks with no meaningful body text (e.g. bare `## Session HH:MM` headings or comment-only sections) during chunking
- Original content stored in Milvus is preserved unchanged — only the text sent to the embedding model is cleaned

## Motivation
Daily memory logs produced by the ccplugin stop hook contain HTML comment metadata (session IDs, turn IDs, transcript paths) and empty session headings. These get embedded as-is, diluting vector quality and wasting storage on meaningless chunks.

## Changes
- `chunker.py`: Add `clean_content_for_embedding()` and `_has_meaningful_content()` functions
- `core.py`: Call `clean_content_for_embedding()` in `_embed_and_store()` before sending to embedding model
- `test_chunker.py`: 4 new tests covering empty session filtering, comment-only filtering, comment stripping, and blank line collapsing

## Test plan
- [x] All 10 chunker tests pass (including 4 new ones)
- [x] Full test suite: 73/74 pass (1 pre-existing flaky `test_embed_deterministic`)
- [ ] Verify with real daily logs: re-index after upgrade and check search quality improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)