### PR TITLE
fix: prevent single file failure from blocking entire index

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -90,11 +90,16 @@ class MemSearch:
         """
         files = scan_paths(self._paths)
         total = 0
+        failed = 0
         active_sources: set[str] = set()
         for f in files:
             active_sources.add(str(f.path))
-            n = await self._index_file(f, force=force)
-            total += n
+            try:
+                n = await self._index_file(f, force=force)
+                total += n
+            except Exception:
+                failed += 1
+                logger.exception("Failed to index %s, skipping", f.path)
 
         # Clean up chunks for files that no longer exist
         indexed_sources = self._store.indexed_sources()
@@ -103,7 +108,10 @@ class MemSearch:
                 self._store.delete_by_source(source)
                 logger.info("Removed stale chunks for deleted file: %s", source)
 
-        logger.info("Indexed %d chunks from %d files", total, len(files))
+        if failed:
+            logger.warning("Indexed %d chunks from %d files (%d files failed)", total, len(files) - failed, failed)
+        else:
+            logger.info("Indexed %d chunks from %d files", total, len(files))
         return total
 
     async def index_file(self, path: str | Path) -> int:

--- a/src/memsearch/embeddings/utils.py
+++ b/src/memsearch/embeddings/utils.py
@@ -4,11 +4,53 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 
+# OpenAI embedding API limit is 300,000 tokens per request.
+# Use a conservative default (reserving headroom for tokenization variance).
+_DEFAULT_MAX_TOKENS_PER_BATCH = 250_000
+
+# Rough estimate: 1 token per 4 characters for cl100k_base.
+_CHARS_PER_TOKEN = 4
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from character length (conservative)."""
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def _split_into_batches(
+    texts: list[str],
+    batch_size: int,
+    max_tokens: int,
+) -> list[list[str]]:
+    """Split texts into batches respecting both item count and token budget."""
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_tokens = 0
+
+    for text in texts:
+        text_tokens = _estimate_tokens(text)
+        would_exceed_tokens = current and (current_tokens + text_tokens > max_tokens)
+        would_exceed_items = len(current) >= batch_size
+
+        if would_exceed_tokens or would_exceed_items:
+            batches.append(current)
+            current = []
+            current_tokens = 0
+
+        current.append(text)
+        current_tokens += text_tokens
+
+    if current:
+        batches.append(current)
+
+    return batches
+
 
 async def batched_embed(
     texts: list[str],
     embed_fn: Callable[[list[str]], Awaitable[list[list[float]]]],
     batch_size: int,
+    max_tokens: int = _DEFAULT_MAX_TOKENS_PER_BATCH,
 ) -> list[list[float]]:
     """Split *texts* into batches and call *embed_fn* on each.
 
@@ -20,14 +62,21 @@ async def batched_embed(
         An async callable that embeds a single batch of texts.
     batch_size:
         Maximum number of texts per batch.  Must be >= 1.
+    max_tokens:
+        Maximum estimated tokens per batch.  Prevents exceeding
+        provider API limits when many texts are small enough to
+        fit under *batch_size* but collectively exceed the token cap.
     """
     if not texts:
         return []
     if batch_size <= 0:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
-    if len(texts) <= batch_size:
+
+    total_tokens = sum(_estimate_tokens(t) for t in texts)
+    if len(texts) <= batch_size and total_tokens <= max_tokens:
         return await embed_fn(texts)
+
     results: list[list[float]] = []
-    for i in range(0, len(texts), batch_size):
-        results.extend(await embed_fn(texts[i : i + batch_size]))
+    for batch in _split_into_batches(texts, batch_size, max_tokens):
+        results.extend(await embed_fn(batch))
     return results

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -12,7 +12,7 @@ import pytest
 
 from memsearch.chunker import Chunk
 from memsearch.core import MemSearch
-from memsearch.embeddings.utils import batched_embed
+from memsearch.embeddings.utils import _estimate_tokens, _split_into_batches, batched_embed
 from memsearch.store import MilvusStore
 
 # -- batched_embed utility tests --
@@ -68,6 +68,53 @@ async def test_batched_embed_invalid_batch_size():
     rec = _Recorder()
     with pytest.raises(ValueError, match="batch_size must be >= 1"):
         await batched_embed(["a"], rec, batch_size=0)
+
+
+# -- Token-aware batching tests --
+
+
+@pytest.mark.asyncio
+async def test_batched_embed_splits_on_token_limit():
+    """Even if item count is under batch_size, split when tokens exceed limit."""
+    rec = _Recorder()
+    # Each text is 400 chars = ~100 tokens. 3 texts = ~300 tokens.
+    # With max_tokens=200, should split into 2 batches despite batch_size=10.
+    texts = ["x" * 400] * 3
+    result = await batched_embed(texts, rec, batch_size=10, max_tokens=200)
+    assert len(result) == 3
+    assert rec.call_sizes == [2, 1]
+
+
+@pytest.mark.asyncio
+async def test_batched_embed_respects_both_limits():
+    """Token limit and item limit are both enforced."""
+    rec = _Recorder()
+    # 6 short texts, batch_size=3, max_tokens very high -> splits by items only
+    texts = list("abcdef")
+    result = await batched_embed(texts, rec, batch_size=3, max_tokens=999999)
+    assert len(result) == 6
+    assert rec.call_sizes == [3, 3]
+
+
+def test_estimate_tokens():
+    assert _estimate_tokens("") == 1  # minimum 1
+    assert _estimate_tokens("abcd") == 1  # 4 chars = 1 token
+    assert _estimate_tokens("a" * 400) == 100
+
+
+def test_split_into_batches_by_tokens():
+    # 3 texts of 400 chars each (~100 tokens each), max_tokens=150
+    texts = ["x" * 400] * 3
+    batches = _split_into_batches(texts, batch_size=100, max_tokens=150)
+    assert len(batches) == 3  # each text alone is ~100 tokens, 2 would be ~200 > 150
+    assert all(len(b) == 1 for b in batches)
+
+
+def test_split_into_batches_by_items():
+    texts = list("abcdef")
+    batches = _split_into_batches(texts, batch_size=2, max_tokens=999999)
+    assert len(batches) == 3
+    assert [len(b) for b in batches] == [2, 2, 2]
 
 
 # -- Integration test: MemSearch._embed_and_store with fake embedder --
@@ -152,3 +199,41 @@ async def test_embed_and_store_empty(mem_with_fake):
     n = await ms._embed_and_store([])
     assert n == 0
     assert fake.call_sizes == []
+
+
+# -- Error isolation tests --
+
+
+@pytest.mark.asyncio
+async def test_index_continues_after_file_failure(tmp_path: Path):
+    """A file that fails to index should not prevent other files from indexing."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "aaa_good.md").write_text("# Good\n\nThis file is fine.\n")
+    (docs / "bbb_bad.md").write_text("# Bad\n\nThis file will fail.\n")
+    (docs / "ccc_good.md").write_text("# Also Good\n\nThis file is fine too.\n")
+
+    fake = FakeEmbedder(batch_size=100, dim=4)
+    ms = MemSearch.__new__(MemSearch)
+    ms._paths = [str(docs)]
+    ms._max_chunk_size = 1500
+    ms._overlap_lines = 2
+    ms._embedder = fake
+    ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
+
+    # Patch _index_file to fail on the bad file
+    original_index_file = ms._index_file
+
+    async def _patched_index_file(f, *, force=False):
+        if "bbb_bad" in str(f.path):
+            raise RuntimeError("Simulated embedding API failure")
+        return await original_index_file(f, force=force)
+
+    ms._index_file = _patched_index_file
+
+    n = await ms.index()
+    ms.close()
+
+    # Both good files should have been indexed despite the middle file failing
+    assert n > 0
+    assert len(fake.call_sizes) >= 2


### PR DESCRIPTION
## Summary

- **Error isolation**: Wrap `_index_file()` in try/except during bulk `index()` so one file failing doesn't prevent subsequent files from being indexed. Failed files are logged and skipped.
- **Token-aware batching**: Add `max_tokens` budget to `batched_embed()` that splits batches when estimated tokens would exceed the provider's API limit (default 250K, conservative vs OpenAI's 300K cap). Previously, batching only checked item count (default 2,048), so a file with 1,000+ chunks could exceed the token limit in a single API call.

### The problem

If any markdown file produces chunks whose total tokens exceed OpenAI's 300K-token-per-request embedding limit, `_index_file()` raises a `400 BadRequestError`. Since there's no try/except in the `index()` loop, this kills the entire indexing process. All files sorted after the failing one are never indexed.

This is made worse by the error being silently swallowed in the Claude Code plugin hooks (`2>/dev/null`, `|| true`, `&>/dev/null`), so users have no indication their index is incomplete.

### Real-world scenario

A single large memory file (1.7MB, ~1,000 chunks, ~425K tokens) crashed indexing on every run. Because files are processed alphabetically and this was the 2nd file, only 1 of 27 memory files was ever indexed. Search returned irrelevant results because 96% of the corpus was missing from the index.

## Test plan

- [x] New test: `test_batched_embed_splits_on_token_limit` - verifies batches split when tokens exceed limit even if item count is under `batch_size`
- [x] New test: `test_batched_embed_respects_both_limits` - verifies both item and token limits are enforced
- [x] New test: `test_estimate_tokens` - token estimation from character length
- [x] New test: `test_split_into_batches_by_tokens` and `test_split_into_batches_by_items` - batch splitting logic
- [x] New test: `test_index_continues_after_file_failure` - verifies index() continues past a failing file
- [x] All 14 batching tests pass, full suite 77/78 pass (1 pre-existing flaky OpenAI determinism test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)