### PR TITLE
fix: remove literal quotes from ccplugin uvx command

### DIFF
--- a/ccplugin/hooks/common.sh
+++ b/ccplugin/hooks/common.sh
@@ -22,7 +22,7 @@ _detect_memsearch() {
   if command -v memsearch &>/dev/null; then
     MEMSEARCH_CMD="memsearch"
   elif command -v uvx &>/dev/null; then
-    MEMSEARCH_CMD="uvx --from 'memsearch[onnx]' memsearch"
+    MEMSEARCH_CMD="uvx --from memsearch[onnx] memsearch"
   fi
 }
 _detect_memsearch


### PR DESCRIPTION
## Summary
- remove the literal single quotes from the fallback uvx command in `ccplugin/hooks/common.sh`
- keep the existing command shape while ensuring bash passes `memsearch[onnx]` as a normal package spec
- fixes the session-start status line reading the wrong embedding provider/model when the hook falls back to uvx

## Testing
- reproduced the argv split locally with a temporary fake `uvx` binary and confirmed the old command passed `memsearch[onnx]` literally while the new command passes `memsearch[onnx]` correctly
