### PR TITLE
fix: isolate index errors per file and reduce OpenAI default batch size

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -90,11 +90,16 @@ class MemSearch:
         """
         files = scan_paths(self._paths)
         total = 0
+        failed = 0
         active_sources: set[str] = set()
         for f in files:
             active_sources.add(str(f.path))
-            n = await self._index_file(f, force=force)
-            total += n
+            try:
+                n = await self._index_file(f, force=force)
+                total += n
+            except Exception:
+                failed += 1
+                logger.exception("Failed to index %s, skipping", f.path)
 
         # Clean up chunks for files that no longer exist
         indexed_sources = self._store.indexed_sources()
@@ -103,7 +108,10 @@ class MemSearch:
                 self._store.delete_by_source(source)
                 logger.info("Removed stale chunks for deleted file: %s", source)
 
-        logger.info("Indexed %d chunks from %d files", total, len(files))
+        if failed:
+            logger.warning("Indexed %d chunks from %d files (%d files failed)", total, len(files) - failed, failed)
+        else:
+            logger.info("Indexed %d chunks from %d files", total, len(files))
         return total
 
     async def index_file(self, path: str | Path) -> int:

--- a/src/memsearch/embeddings/openai.py
+++ b/src/memsearch/embeddings/openai.py
@@ -14,7 +14,9 @@ import os
 class OpenAIEmbedding:
     """OpenAI text-embedding provider."""
 
-    _DEFAULT_BATCH_SIZE = 2048
+    # OpenAI limits total tokens per embedding request to 300K.
+    # A lower batch size avoids hitting that limit with large chunks.
+    _DEFAULT_BATCH_SIZE = 256
 
     def __init__(
         self,

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -152,3 +152,41 @@ async def test_embed_and_store_empty(mem_with_fake):
     n = await ms._embed_and_store([])
     assert n == 0
     assert fake.call_sizes == []
+
+
+# -- Error isolation tests --
+
+
+@pytest.mark.asyncio
+async def test_index_continues_after_file_failure(tmp_path: Path):
+    """A file that fails to index should not prevent other files from indexing."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "aaa_good.md").write_text("# Good\n\nThis file is fine.\n")
+    (docs / "bbb_bad.md").write_text("# Bad\n\nThis file will fail.\n")
+    (docs / "ccc_good.md").write_text("# Also Good\n\nThis file is fine too.\n")
+
+    fake = FakeEmbedder(batch_size=100, dim=4)
+    ms = MemSearch.__new__(MemSearch)
+    ms._paths = [str(docs)]
+    ms._max_chunk_size = 1500
+    ms._overlap_lines = 2
+    ms._embedder = fake
+    ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
+
+    # Patch _index_file to fail on the bad file
+    original_index_file = ms._index_file
+
+    async def _patched_index_file(f, *, force=False):
+        if "bbb_bad" in str(f.path):
+            raise RuntimeError("Simulated embedding API failure")
+        return await original_index_file(f, force=force)
+
+    ms._index_file = _patched_index_file
+
+    n = await ms.index()
+    ms.close()
+
+    # Both good files should have been indexed despite the middle file failing
+    assert n > 0
+    assert len(fake.call_sizes) >= 2


### PR DESCRIPTION
## Summary

- **Error isolation**: Wrap `_index_file()` in try/except during bulk `index()` so one file failing doesn't prevent subsequent files from being indexed. Failed files are logged with full traceback and skipped.
- **Reduce OpenAI batch size**: Lower `OpenAIEmbedding._DEFAULT_BATCH_SIZE` from 2048 to 256 to stay safely under OpenAI's 300K token-per-request limit when indexing files with many large chunks.

### The problem

If any markdown file produces chunks whose total tokens exceed OpenAI's 300K-token-per-request embedding limit, `_index_file()` raises a `400 BadRequestError`. With no error handling in the `index()` loop, this kills the entire indexing process — all files after the failing one are never indexed.

### Approach

Instead of adding token estimation logic coupled to OpenAI's specific limit (as proposed in #208), this takes a simpler approach:

1. **Error isolation in `core.py`**: try/except around each file so failures are contained
2. **Lower default batch size in `openai.py`**: 256 items per batch means ~256 × 500 avg tokens ≈ 128K tokens per request, well under the 300K limit. Users with smaller chunks can still override via `--batch-size` config.

This keeps `batched_embed()` provider-agnostic (no OpenAI-specific token constants in shared utils) while solving the same real-world problem.

Credit to @samlevan (#208) for identifying the issue and the error isolation approach.

## Test plan

- [x] New test: `test_index_continues_after_file_failure` — verifies `index()` continues past a failing file
- [x] All 9 batching tests pass
- [x] Full test suite passes