### PR TITLE
chore: bump memsearch to 0.1.18 and ccplugin to 0.2.8

### DIFF
--- a/ccplugin/.claude-plugin/plugin.json
+++ b/ccplugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.1.17"
+version = "0.1.18"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bumps for recent changes:

**memsearch 0.1.18** (PyPI library):
- fix: isolate index errors per file and reduce OpenAI default batch size (#215)

**ccplugin 0.2.8** (Claude Code plugin):
- fix: prevent session-start.sh hanging indefinitely in WSL 2 (#209)