### PR TITLE
docs: update compact --source examples for path normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ Compress indexed chunks into a condensed markdown summary using an LLM:
 
 ```bash
 memsearch compact
-memsearch compact --llm-provider anthropic --source /Users/me/projects/myproject/.memsearch/memory/old-notes.md
+memsearch compact --llm-provider anthropic --source ./memory/old-notes.md
 ```
 
-`--source` should be the same absolute file path stored during indexing; relative paths and directory paths will not match existing chunks.
+Relative and `~` paths are automatically resolved to the absolute form used at index time.
 
 ### Utilities — `stats` / `reset`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -442,14 +442,14 @@ Compact complete. Summary:
 Compact only chunks from a specific source file:
 
 ```bash
-$ memsearch compact --source /Users/me/projects/myproject/.memsearch/memory/old-notes.md
+$ memsearch compact --source ./memory/old-notes.md
 Compact complete. Summary:
 
 ## Old Notes Summary
 - Initial architecture decisions from January meeting...
 ```
 
-`--source` must match the indexed `source` path exactly. Because memsearch resolves indexed file paths to absolute paths, prefer an absolute file path here rather than a relative path or directory path.
+Relative and `~` paths are automatically resolved to the absolute form used at index time. If no chunks match, memsearch prints the resolved source path to help debug the filter.
 
 Use Anthropic Claude for summarization:
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -187,11 +187,11 @@ print(summary)
 
 # Compact only one file, using Claude
 summary = await mem.compact(
-    source="/Users/me/projects/myproject/.memsearch/memory/old-notes.md",
+    source="./memory/old-notes.md",
     llm_provider="anthropic",
 )
 
-# `source` should match the indexed absolute path for that file.
+# Relative paths are resolved to the absolute form used at index time.
 ```
 
 ---


### PR DESCRIPTION
## Summary

Update docs to reflect the path normalization added in #213. Previously the docs said `--source` required an absolute path — now relative paths work too.

- README.md: simplify compact example to use relative path
- docs/cli.md: update example and explanation
- docs/python-api.md: update example

Follow-up to #213 and #214 (closed due to merge conflict).