### PR TITLE
chore: bump memsearch to 0.1.19 and ccplugin to 0.2.9

### DIFF
--- a/ccplugin/.claude-plugin/plugin.json
+++ b/ccplugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.1.18"
+version = "0.1.19"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

**memsearch 0.1.19** (PyPI):
- fix: normalize compact --source paths in CLI (#213)

**ccplugin 0.2.9** (Claude Code plugin):
- fix: remove literal quotes from uvx memsearch command (#213, fixes #211)