### PR TITLE
docs: add Zilliz Cloud comparison table, decision guide, and signup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,9 +392,22 @@ memsearch supports three deployment modes — just change `milvus_uri`:
 |------|-------------|----------|
 | **Milvus Lite** (default) | `~/.memsearch/milvus.db` | Personal use, dev — zero config ⚠️ *not available on Windows* |
 | **Milvus Server** | `http://localhost:19530` | Multi-agent, team environments |
-| **Zilliz Cloud** | `https://in03-xxx.api.gcp-us-west1.zillizcloud.com` | Production, fully managed |
+| ⭐ **Zilliz Cloud** | `https://in03-xxx.api.gcp-us-west1.zillizcloud.com` | Production, fully managed — [free tier available](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-readme) |
 
-> 📖 Code examples and setup details → [Getting Started — Milvus Backends](https://zilliztech.github.io/memsearch/getting-started/#milvus-backends)
+> **Recommended:** [Zilliz Cloud](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-readme) gives you zero-config, zero-ops Milvus with concurrent access and real-time indexing — no Docker needed. Perfect for the Claude Code plugin's `watch` mode.
+
+<details>
+<summary>Sign up for a free Zilliz Cloud cluster 👈</summary>
+
+You can [sign up](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-readme) on Zilliz Cloud to get a free cluster and API key.
+
+![Sign up and get API key](https://raw.githubusercontent.com/zilliztech/CodeIndexer/master/assets/signup_and_get_apikey.png)
+
+Copy your Personal Key to use as `--milvus-token` in the CLI or `milvus_token` in the Python API.
+
+</details>
+
+> 📖 Comparison table and setup details → [Getting Started — Which backend should I choose?](https://zilliztech.github.io/memsearch/getting-started/#which-backend-should-i-choose)
 
 ## 🔗 Integrations
 

--- a/ccplugin/README.md
+++ b/ccplugin/README.md
@@ -685,7 +685,16 @@ pgrep -f "memsearch watch" && echo "found orphans" || echo "clean"
 
 The watch process is started by `SessionStart` and stopped by `SessionEnd`. If Claude Code crashes or is killed with SIGKILL, the `SessionEnd` hook won't fire and the process may become orphaned. The next `SessionStart` always stops any existing watch before starting a new one.
 
-> **Note:** Milvus Lite does not support concurrent access, so the plugin falls back to one-time indexing at session start instead of a persistent watcher. For real-time indexing, use [Milvus Server or Zilliz Cloud](https://zilliztech.github.io/memsearch/getting-started/#milvus-backend).
+> **Note:** Milvus Lite does not support concurrent access, so the plugin falls back to one-time indexing at session start instead of a persistent watcher.
+>
+> **Want real-time indexing?** Switch to [Zilliz Cloud](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-ccplugin) — no Docker, no ops, free tier available. Just set your URI and token:
+>
+> ```bash
+> memsearch config set milvus.uri "https://in03-xxx.api.gcp-us-west1.zillizcloud.com"
+> memsearch config set milvus.token "your-api-key"
+> ```
+>
+> The next Claude Code session will automatically use real-time `watch` indexing. See the [backend comparison](https://zilliztech.github.io/memsearch/getting-started/#which-backend-should-i-choose) for details.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -379,11 +379,22 @@ Deploy Milvus via Docker or Kubernetes. Multiple agents and users can share the 
         milvusdb/milvus:latest milvus run standalone
     ```
 
-### Zilliz Cloud (fully managed)
+### Zilliz Cloud (fully managed) :star: Recommended
 
-Zero-ops, auto-scaling managed Milvus. Get a free cluster at [cloud.zilliz.com](https://cloud.zilliz.com).
+Zero-ops, auto-scaling managed Milvus. **[Get a free cluster →](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs)**
 
-**Best for:** production deployments, teams that do not want to manage infrastructure.
+**Best for:** production deployments, teams that do not want to manage infrastructure, anyone who wants real-time indexing without running Docker.
+
+<details>
+<summary>Sign up for a free Zilliz Cloud cluster 👈</summary>
+
+You can [sign up](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) on Zilliz Cloud to get a free cluster and API key.
+
+![Sign up and get API key](https://raw.githubusercontent.com/zilliztech/CodeIndexer/master/assets/signup_and_get_apikey.png)
+
+Copy your Personal Key to use as `milvus_token` in the examples below.
+
+</details>
 
 === "Python"
 
@@ -402,6 +413,37 @@ Zero-ops, auto-scaling managed Milvus. Get a free cluster at [cloud.zilliz.com](
         --milvus-uri "https://in03-xxx.api.gcp-us-west1.zillizcloud.com" \
         --milvus-token "your-api-key"
     ```
+
+!!! tip "Why Zilliz Cloud?"
+    Zilliz Cloud removes all the operational overhead of running Milvus yourself — no Docker, no port management, no upgrades, no backup scripts. You get a production-ready endpoint in under 2 minutes, with a generous [free tier](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) that covers most personal and small-team use cases.
+
+### Which backend should I choose?
+
+| | Milvus Lite | Milvus Server | Zilliz Cloud |
+|---|:---:|:---:|:---:|
+| Setup complexity | Zero config | Docker required | Zero config |
+| Concurrent access | :material-close: | :material-check: | :material-check: |
+| Real-time `watch` indexing | :material-close: | :material-check: | :material-check: |
+| Multi-machine / team sharing | :material-close: | Manual networking | Built-in |
+| Ops burden | None | Self-managed | Fully managed |
+| Auto-scaling | :material-close: | Manual | Automatic |
+| Free tier | Unlimited (local) | Self-hosted cost | :material-check: [Free cluster](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) |
+
+```mermaid
+graph TD
+    Q1{"Just trying memsearch<br>or single-user dev?"}
+    Q1 -->|Yes| LITE["✅ Milvus Lite<br>(default, zero config)"]
+    Q1 -->|No| Q2{"Want to manage<br>your own server?"}
+    Q2 -->|Yes| SERVER["✅ Milvus Server<br>(Docker / K8s)"]
+    Q2 -->|No| CLOUD["⭐ Zilliz Cloud<br>(recommended)"]
+
+    style CLOUD fill:#1a5276,stroke:#e0976b,color:#f0f0f0
+    style LITE fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
+    style SERVER fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
+```
+
+!!! note "Upgrade anytime"
+    Starting with Milvus Lite? You can switch to Zilliz Cloud later by changing a single config value — your data will be re-indexed automatically from the source markdown files.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a **backend comparison table** (7 dimensions: setup complexity, concurrent access, real-time watch indexing, team sharing, ops burden, auto-scaling, free tier) and a **decision flowchart** to `getting-started.md`
- Add **collapsible signup guide** with step-by-step screenshot (referencing the image from `zilliztech/CodeIndexer`) in both `README.md` and `getting-started.md`
- Add **recommended badge** and concrete **upgrade path** (2 config commands) in `ccplugin/README.md` for switching from Milvus Lite to Zilliz Cloud
- Unify UTM parameters (`utm_source=github&utm_medium=referral`) across all Zilliz Cloud signup links

## Files Changed

- `README.md` — recommended label, signup details block, UTM links
- `docs/getting-started.md` — comparison table, decision flowchart, signup details block, "Why Zilliz Cloud" tip
- `ccplugin/README.md` — expanded Milvus Lite note with upgrade instructions