### PR TITLE
fix: docs rendering for Zilliz Cloud comparison table and signup block

### DIFF
--- a/docs/claude-plugin/troubleshooting.md
+++ b/docs/claude-plugin/troubleshooting.md
@@ -220,7 +220,7 @@ pgrep -f "memsearch watch" && echo "found orphans" || echo "clean"
 
 The watch process is started by `SessionStart` and stopped by `SessionEnd`. If Claude Code crashes or is killed with SIGKILL, the `SessionEnd` hook won't fire and the process may become orphaned. The next `SessionStart` always stops any existing watch before starting a new one.
 
-> **Note:** Milvus Lite does not support concurrent access, so the plugin falls back to one-time indexing at session start instead of a persistent watcher. For real-time indexing, use [Milvus Server or Zilliz Cloud](../getting-started.md#milvus-backend).
+> **Note:** Milvus Lite does not support concurrent access, so the plugin falls back to one-time indexing at session start instead of a persistent watcher. For real-time indexing, use [Milvus Server or Zilliz Cloud](../getting-started.md#milvus-backends).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -385,7 +385,7 @@ Zero-ops, auto-scaling managed Milvus. **[Get a free cluster →](https://cloud.
 
 **Best for:** production deployments, teams that do not want to manage infrastructure, anyone who wants real-time indexing without running Docker.
 
-<details>
+<details markdown>
 <summary>Sign up for a free Zilliz Cloud cluster 👈</summary>
 
 You can [sign up](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) on Zilliz Cloud to get a free cluster and API key.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - md_in_html
   - toc:


### PR DESCRIPTION
## Summary

- Add `pymdownx.emoji` extension to `mkdocs.yml` so `:material-check:` / `:material-close:` icons render correctly in the backend comparison table
- Add `markdown` attribute to `<details>` tag in `getting-started.md` so the signup screenshot renders inside the collapsible block
- Fix broken anchor `#milvus-backend` → `#milvus-backends` in `troubleshooting.md`

Follow-up to #219.