### PR TITLE
fix: support Vertex AI for Google embeddings

### DIFF
--- a/src/memsearch/embeddings/google.py
+++ b/src/memsearch/embeddings/google.py
@@ -2,10 +2,13 @@
 
 Requires: ``pip install 'memsearch[google]'`` or ``uv add 'memsearch[google]'``
 Environment variables:
-    GOOGLE_API_KEY — required
+    GOOGLE_API_KEY — required unless using Vertex AI credentials
+    GOOGLE_GENAI_USE_VERTEXAI — optional, set to "true" to use Vertex AI auth
 """
 
 from __future__ import annotations
+
+import os
 
 # Known dimensions for common Google embedding models.
 # gemini-embedding-001 natively outputs 3072, but 768 is the recommended
@@ -29,7 +32,8 @@ class GoogleEmbedding:
     ) -> None:
         from google import genai
 
-        self._client = genai.Client()  # reads GOOGLE_API_KEY
+        use_vertex_ai = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").strip().lower() == "true"
+        self._client = genai.Client(vertexai=use_vertex_ai)  # reads GOOGLE_API_KEY or Vertex AI env vars
         self._model = model
         self._dimension = _detect_dimension(self._client, model)
         self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE

--- a/tests/test_embeddings_google.py
+++ b/tests/test_embeddings_google.py
@@ -1,0 +1,61 @@
+"""Unit tests for the Google embedding provider."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _install_fake_google_genai(monkeypatch, *, record: dict):
+    google_module = types.ModuleType("google")
+    genai_module = types.ModuleType("google.genai")
+
+    class FakeClient:
+        def __init__(self, *, vertexai: bool = False):
+            record["vertexai"] = vertexai
+            self.models = types.SimpleNamespace(embed_content=self.embed_content)
+
+        def embed_content(self, *, model: str, contents: list[str]):
+            record["model"] = model
+            record["contents"] = contents
+            return types.SimpleNamespace(
+                embeddings=[types.SimpleNamespace(values=[0.1, 0.2, 0.3])]
+            )
+
+    genai_module.Client = FakeClient
+    google_module.genai = genai_module
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_module)
+
+
+def _load_google_embedding_module():
+    sys.modules.pop("memsearch.embeddings.google", None)
+    return importlib.import_module("memsearch.embeddings.google")
+
+
+def test_google_embedding_uses_vertex_ai_when_env_var_is_true(monkeypatch):
+    record: dict = {}
+    _install_fake_google_genai(monkeypatch, record=record)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+
+    GoogleEmbedding = _load_google_embedding_module().GoogleEmbedding
+
+    provider = GoogleEmbedding(model="custom-vertex-model")
+
+    assert record["vertexai"] is True
+    assert provider.dimension == 3
+
+
+def test_google_embedding_defaults_to_api_key_mode(monkeypatch):
+    record: dict = {}
+    _install_fake_google_genai(monkeypatch, record=record)
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+
+    GoogleEmbedding = _load_google_embedding_module().GoogleEmbedding
+
+    provider = GoogleEmbedding(model="custom-api-key-model")
+
+    assert record["vertexai"] is False
+    assert provider.dimension == 3


### PR DESCRIPTION
$## Summary\n- support Vertex AI credentials for the Google embedding provider via `GOOGLE_GENAI_USE_VERTEXAI=true`\n- keep the existing API-key flow unchanged when the env var is unset\n- add unit coverage for both Vertex AI mode and the default API-key mode\n\n## Testing\n- `PYTHONPATH=src python -m pytest tests/test_embeddings_google.py`\n- `python -m ruff check src/memsearch/embeddings/google.py tests/test_embeddings_google.py`\n\nCloses #194