### PR TITLE
test: cover compact prompt-file CLI path

### DIFF
--- a/tests/test_compact_cli.py
+++ b/tests/test_compact_cli.py
@@ -11,9 +11,11 @@ from memsearch.cli import cli
 
 class DummyMemSearch:
     last_source = None
+    last_prompt_template = None
 
     async def compact(self, **kwargs):
         DummyMemSearch.last_source = kwargs["source"]
+        DummyMemSearch.last_prompt_template = kwargs["prompt_template"]
         return ""
 
     def close(self) -> None:
@@ -48,3 +50,19 @@ def test_compact_shows_matched_source_when_no_chunks(monkeypatch, tmp_path: Path
     assert result.exit_code == 0
     assert DummyMemSearch.last_source == str(note.resolve())
     assert f"No chunks matched source: {note.resolve()}" in result.output
+
+
+def test_compact_reads_prompt_file_and_passes_template(monkeypatch, tmp_path: Path):
+    note = tmp_path / "memory" / "old-notes.md"
+    note.parent.mkdir()
+    note.write_text("# note\n")
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("Summarize carefully:\n{chunks}\n", encoding="utf-8")
+
+    monkeypatch.setattr("memsearch.core.MemSearch", lambda **kwargs: DummyMemSearch())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["compact", "--source", str(note), "--prompt-file", str(prompt_file)])
+
+    assert result.exit_code == 0
+    assert DummyMemSearch.last_prompt_template == "Summarize carefully:\n{chunks}\n"


### PR DESCRIPTION
## What
- add CLI coverage for `compact --prompt-file`
- verify the prompt file contents are read and passed through as `prompt_template`
- keep the patch scoped to the compact CLI smoke path

## Why
Follow-up coverage for #114.

`compact` already accepted `--prompt-file`, but there was no direct test proving the file contents were actually loaded and forwarded into `MemSearch.compact()`. This patch locks down that CLI behavior without touching external APIs.

## Testing
- `uv run python -m pytest tests/test_compact_cli.py -q`
- `uv run ruff check tests/test_compact_cli.py`
- `uv run ruff format --check tests/test_compact_cli.py`
