### PR TITLE
fix: remove unreachable UUID prefix-match in transcript parser

### DIFF
--- a/plugins/claude-code/transcript.py
+++ b/plugins/claude-code/transcript.py
@@ -123,7 +123,7 @@ def find_turn_context(
     """
     target_idx = -1
     for i, turn in enumerate(turns):
-        if turn.uuid.startswith(target_uuid) or target_uuid.startswith(turn.uuid[:8]):
+        if turn.uuid.startswith(target_uuid):
             target_idx = i
             break
 


### PR DESCRIPTION
## Summary
- Remove dead `target_uuid.startswith(turn.uuid[:8])` condition in `find_turn_context()`
- All callers pass full UUIDs; the 8-char prefix match is unreachable
- Eliminates theoretical false-positive risk in long transcripts

## Test plan
- [x] Existing transcript tests still pass
- [x] Verified: all HTML comment anchors in memory files contain full UUIDs