### PR TITLE
fix: handle Milvus connection errors gracefully in CLI

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 import click
-from pymilvus.exceptions import MilvusException
 
 from .config import (
     GLOBAL_CONFIG_PATH,
@@ -21,6 +20,11 @@ from .config import (
     save_config,
     set_config_value,
 )
+
+try:
+    from pymilvus.exceptions import MilvusException
+except ImportError:
+    MilvusException = Exception
 
 
 def _run(coro):

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import click
+from pymilvus.exceptions import MilvusException
 
 from .config import (
     GLOBAL_CONFIG_PATH,
@@ -152,12 +153,17 @@ def index(
             milvus_token=milvus_token,
         )
     )
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
+    ms = None
     try:
+        ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
         n = _run(ms.index(force=force))
         click.echo(f"Indexed {n} chunks.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -203,8 +209,9 @@ def search(
             reranker_model=reranker_model,
         )
     )
-    ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
+    ms = None
     try:
+        ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
         results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
@@ -227,8 +234,12 @@ def search(
                     click.echo(f"  ... [truncated, run 'memsearch expand {chunk_hash}' for full content]")
                 else:
                     click.echo(content)
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 # ======================================================================
@@ -285,13 +296,14 @@ def expand(
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         chunks = store.query(filter_expr=f'chunk_hash == "{chunk_hash}"')
         if not chunks:
             click.echo(f"Chunk not found: {chunk_hash}", err=True)
@@ -361,8 +373,12 @@ def expand(
                 click.echo(f"Session: {anchor['session']}  Turn: {anchor['turn']}")
                 click.echo(f"Transcript: {anchor['transcript']}")
             click.echo(f"\n{expanded}")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 def _extract_section(
@@ -435,28 +451,35 @@ def watch(
             debounce_ms=debounce_ms,
         )
     )
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
-
-    # Initial index: ensure existing files are indexed before watching
-    n = _run(ms.index())
-    if n:
-        click.echo(f"Indexed {n} chunks.")
-
-    def _on_event(event_type: str, summary: str, file_path) -> None:
-        click.echo(summary)
-
-    click.echo(f"Watching {len(paths)} path(s) for changes... (Ctrl+C to stop)")
-    watcher = ms.watch(on_event=_on_event, debounce_ms=cfg.watch.debounce_ms)
+    ms = None
+    watcher = None
     try:
+        ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
+
+        # Initial index: ensure existing files are indexed before watching
+        n = _run(ms.index())
+        if n:
+            click.echo(f"Indexed {n} chunks.")
+
+        def _on_event(event_type: str, summary: str, file_path) -> None:
+            click.echo(summary)
+
+        click.echo(f"Watching {len(paths)} path(s) for changes... (Ctrl+C to stop)")
+        watcher = ms.watch(on_event=_on_event, debounce_ms=cfg.watch.debounce_ms)
         while True:
             import time
 
             time.sleep(1)
     except KeyboardInterrupt:
         click.echo("\nStopping watcher.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        watcher.stop()
-        ms.close()
+        if watcher is not None:
+            watcher.stop()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -516,8 +539,9 @@ def compact(
 
     normalized_source = _normalize_compact_source(source)
 
-    ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
+    ms = None
     try:
+        ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
         summary = _run(
             ms.compact(
                 source=normalized_source,
@@ -536,8 +560,12 @@ def compact(
             click.echo(f"No chunks matched source: {normalized_source}")
         else:
             click.echo("No chunks to compact.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -559,17 +587,22 @@ def stats(
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         count = store.count()
         click.echo(f"Total indexed chunks: {count}")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 @cli.command()
@@ -592,17 +625,22 @@ def reset(
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         store.drop()
         click.echo("Dropped collection.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 # ======================================================================

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -370,15 +370,20 @@ class MemSearch:
         loop = asyncio.new_event_loop()
 
         def _on_change(event_type: str, file_path: Path) -> None:
-            if event_type == "deleted":
-                self._store.delete_by_source(str(file_path))
-                summary = f"Removed chunks for {file_path}"
-            else:
-                n = loop.run_until_complete(self.index_file(file_path))
-                summary = f"Indexed {n} chunks from {file_path}"
-            logger.info(summary)
-            if on_event is not None:
-                on_event(event_type, summary, file_path)
+            from pymilvus.exceptions import MilvusException
+
+            try:
+                if event_type == "deleted":
+                    self._store.delete_by_source(str(file_path))
+                    summary = f"Removed chunks for {file_path}"
+                else:
+                    n = loop.run_until_complete(self.index_file(file_path))
+                    summary = f"Indexed {n} chunks from {file_path}"
+                logger.info(summary)
+                if on_event is not None:
+                    on_event(event_type, summary, file_path)
+            except MilvusException as e:
+                logger.warning("Milvus error during watch callback: %s", e)
 
         fw_kwargs: dict[str, Any] = {}
         if debounce_ms is not None:


### PR DESCRIPTION
## Summary
- Catch `MilvusException` in all CLI commands, emit clean error message to stderr
- Wrap watch callback to log Milvus errors instead of crashing the background thread
- Prevents raw pymilvus tracebacks when Milvus is unreachable

## Test plan
- [ ] `uv run python -m pytest` passes
- [ ] Manually tested: stop Milvus, run `memsearch search "test"` -- shows clean error
- [ ] Watch mode: stop Milvus during watch -- process continues, logs warning