### PR TITLE
feat: make RRF k-parameter configurable

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -46,6 +46,7 @@ _PARAM_MAP = {
     "overlap_lines": "chunking.overlap_lines",
     "debounce_ms": "watch.debounce_ms",
     "reranker_model": "reranker.model",
+    "rrf_k": "search.rrf_k",
 }
 
 
@@ -78,6 +79,7 @@ def _cfg_to_memsearch_kwargs(cfg: MemSearchConfig) -> dict:
         "max_chunk_size": cfg.chunking.max_chunk_size,
         "overlap_lines": cfg.chunking.overlap_lines,
         "reranker_model": cfg.reranker.model,
+        "rrf_k": cfg.search.rrf_k,
     }
 
 
@@ -171,6 +173,7 @@ def index(
 )
 @_common_options
 @click.option("--reranker-model", default=None, help="Cross-encoder model for reranking (empty string disables).")
+@click.option("--rrf-k", default=None, type=int, help="RRF fusion constant (default 60). Lower favors top-ranked results.")
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
 def search(
     query: str,
@@ -185,6 +188,7 @@ def search(
     milvus_uri: str | None,
     milvus_token: str | None,
     reranker_model: str | None,
+    rrf_k: int | None,
     json_output: bool,
 ) -> None:
     """Search indexed memory for QUERY."""
@@ -201,6 +205,7 @@ def search(
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
             reranker_model=reranker_model,
+            rrf_k=rrf_k,
         )
     )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -26,7 +26,7 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size"}
+_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "rrf_k"}
 
 
 @dataclass
@@ -55,6 +55,11 @@ class CompactConfig:
 
 
 @dataclass
+class SearchConfig:
+    rrf_k: int = 60  # RRF fusion constant; lower = top-ranked results weighted more
+
+
+@dataclass
 class ChunkingConfig:
     max_chunk_size: int = 1500
     overlap_lines: int = 2
@@ -75,6 +80,7 @@ class MemSearchConfig:
     milvus: MilvusConfig = field(default_factory=MilvusConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
     compact: CompactConfig = field(default_factory=CompactConfig)
+    search: SearchConfig = field(default_factory=SearchConfig)
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
@@ -85,6 +91,7 @@ _SECTION_CLASSES: dict[str, type] = {
     "milvus": MilvusConfig,
     "embedding": EmbeddingConfig,
     "compact": CompactConfig,
+    "search": SearchConfig,
     "chunking": ChunkingConfig,
     "watch": WatchConfig,
     "reranker": RerankerConfig,

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -60,6 +60,7 @@ class MemSearch:
         max_chunk_size: int = 1500,
         overlap_lines: int = 2,
         reranker_model: str = "",
+        rrf_k: int = 60,
     ) -> None:
         self._paths = [str(p) for p in (paths or [])]
         self._max_chunk_size = max_chunk_size
@@ -77,6 +78,7 @@ class MemSearch:
             collection=collection,
             dimension=self._embedder.dimension,
             description=description,
+            rrf_k=rrf_k,
         )
         self._reranker_model = reranker_model
 

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -32,6 +32,7 @@ class MilvusStore:
         collection: str = DEFAULT_COLLECTION,
         dimension: int | None = 1536,
         description: str = "",
+        rrf_k: int = 60,
     ) -> None:
         from pymilvus import MilvusClient
 
@@ -57,6 +58,7 @@ class MilvusStore:
         self._collection = collection
         self._dimension = dimension
         self._description = description
+        self._rrf_k = rrf_k
         self._ensure_collection()
 
     def _ensure_collection(self) -> None:
@@ -170,7 +172,7 @@ class MilvusStore:
         results = self._client.hybrid_search(
             collection_name=self._collection,
             reqs=[dense_req, bm25_req],
-            ranker=RRFRanker(k=60),
+            ranker=RRFRanker(k=self._rrf_k),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,
         )

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -84,4 +84,5 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
         "max_chunk_size": 1800,
         "overlap_lines": 4,
         "reranker_model": "",
+        "rrf_k": 60,
     }


### PR DESCRIPTION
## Summary
- Expose `RRFRanker(k=...)` as `--rrf-k` CLI flag and `[search] rrf_k` config option
- Default unchanged at 60 for backward compatibility
- Allows tuning dense vs. BM25 balance for different workloads

## Test plan
- [ ] `uv run python -m pytest` passes
- [ ] `memsearch search "topic" --rrf-k 30` works (stricter ranking)
- [ ] Default behavior unchanged when flag not specified