### PR TITLE
feat: make max_chunk_size configurable via CLI

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -123,6 +123,7 @@ def cli() -> None:
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--force", is_flag=True, help="Re-index all files.")
+@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def index(
     paths: tuple[str, ...],
@@ -135,6 +136,7 @@ def index(
     milvus_uri: str | None,
     milvus_token: str | None,
     force: bool,
+    max_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Index markdown files from PATHS."""
@@ -150,6 +152,7 @@ def index(
             collection=collection,
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
+            max_chunk_size=max_chunk_size,
         )
     )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
@@ -405,6 +408,7 @@ def _extract_section(
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--debounce-ms", default=None, type=int, help="Debounce delay in ms.")
+@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def watch(
     paths: tuple[str, ...],
@@ -417,6 +421,7 @@ def watch(
     milvus_uri: str | None,
     milvus_token: str | None,
     debounce_ms: int | None,
+    max_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Watch PATHS for markdown changes and auto-index."""
@@ -433,6 +438,7 @@ def watch(
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
             debounce_ms=debounce_ms,
+            max_chunk_size=max_chunk_size,
         )
     )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")


### PR DESCRIPTION
## Summary
- Add `--max-chunk-size` CLI flag to `index` and `watch` commands
- Config layer and core already supported this; only the CLI option was missing
- Default unchanged at 1500 for backward compatibility
- Smaller values (e.g. 800) keep semantic context tighter for short session notes

## Test plan
- [ ] `uv run python -m pytest` passes
- [ ] `memsearch index . --max-chunk-size 800` produces smaller chunks
- [ ] Default behavior unchanged when flag not specified