### PR TITLE
feat: add date-range filtering to search

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -169,6 +169,18 @@ def index(
     type=click.Path(),
     help="Only search chunks whose source path starts with this prefix.",
 )
+@click.option(
+    "--date-after",
+    default=None,
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Only include results from this date onward (YYYY-MM-DD).",
+)
+@click.option(
+    "--date-before",
+    default=None,
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Only include results up to this date (YYYY-MM-DD).",
+)
 @_common_options
 @click.option("--reranker-model", default=None, help="Cross-encoder model for reranking (empty string disables).")
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
@@ -176,6 +188,8 @@ def search(
     query: str,
     top_k: int | None,
     source_prefix: str | None,
+    date_after,
+    date_before,
     provider: str | None,
     model: str | None,
     batch_size: int | None,
@@ -205,7 +219,15 @@ def search(
     )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
+        results = _run(
+            ms.search(
+                query,
+                top_k=top_k or 5,
+                source_prefix=source_prefix,
+                date_after=date_after.date() if date_after else None,
+                date_before=date_before.date() if date_before else None,
+            )
+        )
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
         else:

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -173,13 +173,13 @@ def index(
     "--date-after",
     default=None,
     type=click.DateTime(formats=["%Y-%m-%d"]),
-    help="Only include results from this date onward (YYYY-MM-DD).",
+    help="Only include results from this date onward. Matches files named YYYY-MM-DD.md (ISO format).",
 )
 @click.option(
     "--date-before",
     default=None,
     type=click.DateTime(formats=["%Y-%m-%d"]),
-    help="Only include results up to this date (YYYY-MM-DD).",
+    help="Only include results up to this date. Matches files named YYYY-MM-DD.md (ISO format).",
 )
 @_common_options
 @click.option("--reranker-model", default=None, help="Cross-encoder model for reranking (empty string disables).")

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +19,36 @@ from .scanner import ScannedFile, scan_paths
 from .store import MilvusStore
 
 logger = logging.getLogger(__name__)
+
+
+def _build_date_filter(date_after: date | None, date_before: date | None) -> str:
+    """Build Milvus filter for date range using source filename patterns.
+
+    Generates ``source like "%YYYY-MM-DD.md"`` clauses for each day in the
+    range.  When a full calendar month falls within the range, a single
+    ``source like "%YYYY-MM-%.md"`` wildcard replaces 28-31 per-day clauses.
+    """
+    if date_after is None and date_before is None:
+        return ""
+    start = date_after or date(2000, 1, 1)
+    end = date_before or date.today()
+    if start > end:
+        msg = f"date_after ({start}) must be before date_before ({end})"
+        raise ValueError(msg)
+
+    clauses: list[str] = []
+    current = start
+    while current <= end:
+        # If at day 1 and the entire month fits, use a month wildcard
+        month_end = (current.replace(day=28) + timedelta(days=4)).replace(day=1) - timedelta(days=1)
+        if current.day == 1 and month_end <= end:
+            clauses.append(f'source like "%{current.strftime("%Y-%m-")}%.md"')
+            current = month_end + timedelta(days=1)
+        else:
+            clauses.append(f'source like "%{current.isoformat()}.md"')
+            current += timedelta(days=1)
+
+    return "(" + " or ".join(clauses) + ")"
 
 
 class MemSearch:
@@ -202,6 +232,8 @@ class MemSearch:
         *,
         top_k: int = 10,
         source_prefix: str | Path | None = None,
+        date_after: date | None = None,
+        date_before: date | None = None,
     ) -> list[dict[str, Any]]:
         """Semantic search across indexed chunks.
 
@@ -214,6 +246,12 @@ class MemSearch:
         source_prefix:
             Optional path prefix to scope results. Only chunks whose
             ``source`` starts with this prefix are returned.
+        date_after:
+            Only include results from this date onward (based on
+            ``YYYY-MM-DD`` pattern in source filename).
+        date_before:
+            Only include results up to this date (based on
+            ``YYYY-MM-DD`` pattern in source filename).
 
         Returns
         -------
@@ -221,11 +259,17 @@ class MemSearch:
             Each dict contains ``content``, ``source``, ``heading``,
             ``score``, and other metadata.
         """
-        filter_expr = ""
+        filters: list[str] = []
         if source_prefix is not None:
             prefix = str(Path(source_prefix).expanduser().resolve())
             escaped = prefix.replace("\\", "\\\\").replace('"', '\\"')
-            filter_expr = f'source like "{escaped}%"'
+            filters.append(f'source like "{escaped}%"')
+
+        date_filter = _build_date_filter(date_after, date_before)
+        if date_filter:
+            filters.append(date_filter)
+
+        filter_expr = " and ".join(filters)
 
         embeddings = await self._embedder.embed([query])
         fetch_k = top_k * 3 if self._reranker_model else top_k

--- a/tests/test_date_filter.py
+++ b/tests/test_date_filter.py
@@ -1,0 +1,82 @@
+"""Unit tests for _build_date_filter (date-range search filtering)."""
+
+from datetime import date
+
+import pytest
+
+from memsearch.core import _build_date_filter
+
+
+def test_both_none_returns_empty():
+    assert _build_date_filter(None, None) == ""
+
+
+def test_single_day():
+    result = _build_date_filter(date(2026, 4, 5), date(2026, 4, 5))
+    assert result == '(source like "%2026-04-05.md")'
+
+
+def test_partial_month_no_wildcard():
+    result = _build_date_filter(date(2026, 4, 3), date(2026, 4, 5))
+    assert 'source like "%2026-04-03.md"' in result
+    assert 'source like "%2026-04-04.md"' in result
+    assert 'source like "%2026-04-05.md"' in result
+    assert result.startswith("(") and result.endswith(")")
+
+
+def test_full_month_uses_wildcard():
+    result = _build_date_filter(date(2026, 3, 1), date(2026, 3, 31))
+    assert result == '(source like "%2026-03-%.md")'
+
+
+def test_multi_month_range():
+    # Jan 1 - Mar 31: three full months
+    result = _build_date_filter(date(2026, 1, 1), date(2026, 3, 31))
+    assert 'source like "%2026-01-%.md"' in result
+    assert 'source like "%2026-02-%.md"' in result
+    assert 'source like "%2026-03-%.md"' in result
+    # Should have exactly 3 clauses (one per month)
+    assert result.count("source like") == 3
+
+
+def test_mixed_full_and_partial_months():
+    # Jan 15 - Mar 31: partial Jan, full Feb, full Mar
+    result = _build_date_filter(date(2026, 1, 15), date(2026, 3, 31))
+    # Jan should be per-day (15th through 31st = 17 days)
+    assert 'source like "%2026-01-15.md"' in result
+    assert 'source like "%2026-01-31.md"' in result
+    # Feb and Mar should be wildcards
+    assert 'source like "%2026-02-%.md"' in result
+    assert 'source like "%2026-03-%.md"' in result
+
+
+def test_date_after_only():
+    """date_after without date_before uses today as end."""
+    result = _build_date_filter(date(2026, 4, 5), None)
+    # Should produce at least one clause for that date (today)
+    assert 'source like "%2026-04-05.md"' in result
+
+
+def test_date_before_only():
+    """date_before without date_after uses 2000-01-01 as start."""
+    result = _build_date_filter(None, date(2000, 1, 2))
+    assert 'source like "%2000-01-01.md"' in result
+    assert 'source like "%2000-01-02.md"' in result
+
+
+def test_invalid_range_raises():
+    with pytest.raises(ValueError, match=r"date_after.*must be before"):
+        _build_date_filter(date(2026, 5, 1), date(2026, 4, 1))
+
+
+def test_february_leap_year():
+    # Feb 2024 is a leap year (29 days) -- full month wildcard
+    result = _build_date_filter(date(2024, 2, 1), date(2024, 2, 29))
+    assert result == '(source like "%2024-02-%.md")'
+
+
+def test_clauses_joined_with_or():
+    result = _build_date_filter(date(2026, 4, 1), date(2026, 4, 3))
+    # Partial month, 3 days
+    assert " or " in result
+    assert " and " not in result


### PR DESCRIPTION
## Summary
- Add `--date-after` and `--date-before` flags to `memsearch search`
- Filters on YYYY-MM-DD pattern in source filenames using Milvus `like` operator
- Uses month-level wildcards for full months to minimize filter clause count
- No schema migration required

## Test plan
- [x] `uv run python -m pytest` passes
- [ ] `memsearch search "topic" --date-after 2026-04-01` returns only April results
- [ ] `memsearch search "topic" --date-after 2026-01-01 --date-before 2026-04-05` uses month grouping
- [ ] Composes correctly with `--source-prefix`