### PR TITLE
feat: add near-duplicate removal to search results

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -171,6 +171,12 @@ def index(
 )
 @_common_options
 @click.option("--reranker-model", default=None, help="Cross-encoder model for reranking (empty string disables).")
+@click.option(
+    "--dedup-threshold",
+    default=0.0,
+    type=float,
+    help="Jaccard token-overlap threshold (0-1) for removing near-duplicate results. 0 disables.",
+)
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
 def search(
     query: str,
@@ -185,6 +191,7 @@ def search(
     milvus_uri: str | None,
     milvus_token: str | None,
     reranker_model: str | None,
+    dedup_threshold: float,
     json_output: bool,
 ) -> None:
     """Search indexed memory for QUERY."""
@@ -205,7 +212,7 @@ def search(
     )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
+        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix, dedup_threshold=dedup_threshold))
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
         else:

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -21,6 +21,47 @@ from .store import MilvusStore
 logger = logging.getLogger(__name__)
 
 
+# ------------------------------------------------------------------
+# Near-duplicate removal helpers
+# ------------------------------------------------------------------
+
+
+def _token_overlap(text1: str, text2: str) -> float:
+    """Jaccard similarity on whitespace-split lowercased tokens."""
+    tokens1 = set(text1.lower().split())
+    tokens2 = set(text2.lower().split())
+    if not tokens1 or not tokens2:
+        return 0.0
+    return len(tokens1 & tokens2) / len(tokens1 | tokens2)
+
+
+def _deduplicate_results(
+    results: list[dict[str, Any]],
+    threshold: float = 0.85,
+) -> list[dict[str, Any]]:
+    """Remove near-duplicate results based on token overlap.
+
+    For each pair exceeding *threshold*, the lower-scored result is dropped.
+    Runs in O(N^2) on the result list, which is fine for typical top_k (5-20).
+    """
+    if not results or threshold <= 0:
+        return results
+    keep = set(range(len(results)))
+    for i in range(len(results)):
+        if i not in keep:
+            continue
+        for j in range(i + 1, len(results)):
+            if j not in keep:
+                continue
+            if _token_overlap(results[i]["content"], results[j]["content"]) >= threshold:
+                if results[i].get("score", 0) >= results[j].get("score", 0):
+                    keep.discard(j)
+                else:
+                    keep.discard(i)
+                    break
+    return [results[i] for i in sorted(keep)]
+
+
 class MemSearch:
     """High-level API for semantic memory search.
 
@@ -202,6 +243,7 @@ class MemSearch:
         *,
         top_k: int = 10,
         source_prefix: str | Path | None = None,
+        dedup_threshold: float = 0.0,
     ) -> list[dict[str, Any]]:
         """Semantic search across indexed chunks.
 
@@ -214,6 +256,9 @@ class MemSearch:
         source_prefix:
             Optional path prefix to scope results. Only chunks whose
             ``source`` starts with this prefix are returned.
+        dedup_threshold:
+            Jaccard token-overlap threshold (0-1) for removing
+            near-duplicate results.  ``0`` (default) disables dedup.
 
         Returns
         -------
@@ -234,6 +279,8 @@ class MemSearch:
             from .reranker import rerank
 
             results = rerank(query, results, model_name=self._reranker_model, top_k=top_k)
+        if dedup_threshold > 0 and results:
+            results = _deduplicate_results(results, threshold=dedup_threshold)
         return results
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--dedup-threshold` flag to `memsearch search` (default 0 = disabled)
- Uses Jaccard token overlap on content to identify near-duplicates
- Keeps higher-scored result when overlap exceeds threshold
- Runs after reranking, O(N^2) on top_k results (negligible for typical k=5-10)

## Test plan
- [ ] `uv run python -m pytest` passes
- [ ] `memsearch search "topic" --dedup-threshold 0.85` removes near-duplicate results
- [ ] `memsearch search "topic"` (no flag) returns same results as before