### PR TITLE
chore: switch from uv add to uv tool install for CLI availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,16 +322,20 @@ User: "What did we discuss about batch size?"
 # pip
 pip install memsearch
 
-# or uv (recommended)
+# Install as a CLI tool (recommended for most users)
 uv tool install memsearch
+
+# Or add as a project dependency
+uv add memsearch
 ```
 
 <details>
 <summary><b>Optional embedding providers</b></summary>
 
 ```bash
-pip install "memsearch[onnx]"    # Local ONNX (recommended, no API key)
-# or: uv tool install "memsearch[onnx]"
+pip install "memsearch[onnx]"          # Local ONNX (recommended, no API key)
+# uv tool install "memsearch[onnx]"    # CLI with ONNX embedding
+# or: uv add "memsearch[onnx]"         # as project dependency
 
 # Other options: [openai], [google], [voyage], [ollama], [local], [all]
 ```

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ User: "What did we discuss about batch size?"
 pip install memsearch
 
 # or uv (recommended)
-uv add memsearch
+uv tool install memsearch
 ```
 
 <details>
@@ -331,7 +331,7 @@ uv add memsearch
 
 ```bash
 pip install "memsearch[onnx]"    # Local ONNX (recommended, no API key)
-# or: uv add "memsearch[onnx]"
+# or: uv tool install "memsearch[onnx]"
 
 # Other options: [openai], [google], [voyage], [ollama], [local], [all]
 ```


### PR DESCRIPTION


**Title:** chore: switch from `uv add` to `uv tool install` for CLI availability

**Description:**
This PR replaces `uv add` with `uv tool install` for the specified package.

**Reasoning:**
- `uv add` is designed for managing project-specific dependencies within a virtual environment (`pyproject.toml`). It does not make the CLI globally accessible.
- `uv tool install` installs the package in an isolated environment and exposes the executable globally (via PATH), allowing the CLI tool to be run directly from the terminal without activating a specific project environment.

This change ensures the tool is properly installed as a standalone global utility rather than a project dependency.
