### PR TITLE
chore: bump memsearch to 0.2.3 and Claude Code plugin to 0.3.4

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.2.2"
+version = "0.2.3"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bumps for new release.

**memsearch 0.2.3 (PyPI):**
- fix: force `encoding_format=float` for OpenAI-compatible endpoints (#302)
- fix: validate compact prompt templates (#233)
- fix: consolidate double `stat()` call in `index_file` (#292)
- fix: force split long paragraphs without blank lines in chunker (#267)

**Claude Code plugin 0.3.4 (Marketplace):**
- fix: use portable stdin timeout on macOS in plugin hooks (#288)