### PR TITLE
feat: add indexed memory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ memsearch index ./memory/                          # index markdown files
 memsearch index ./memory/ ./notes/ --force         # re-embed everything
 memsearch search "Redis caching"                   # hybrid search (BM25 + vector)
 memsearch search "auth flow" --top-k 10 --json-output  # JSON for scripting
+memsearch list --limit 20                          # inspect indexed memories without guessing a query
 memsearch expand <chunk_hash>                      # show full section around a chunk
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -346,6 +346,39 @@ $ memsearch search "database migrations" --provider google
 
 ---
 
+## `memsearch list`
+
+List indexed memories without needing a search query first. Results are ordered by source path and line number so you can quickly inspect what is already in the memory index.
+
+### Options
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--source-prefix` | | *(all sources)* | Only list chunks whose source path starts with this prefix |
+| `--limit` | `-n` | *(all matches)* | Maximum number of memories to show |
+| `--json-output` | `-j` | `false` | Emit raw JSON rows instead of formatted text |
+| `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
+| `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
+| `--milvus-token` | | *(none)* | Milvus auth token |
+
+### Examples
+
+Show the first 10 indexed memories:
+
+```bash
+$ memsearch list --limit 10
+```
+
+Scope the listing to a directory and consume it as JSON:
+
+```bash
+$ memsearch list --source-prefix ./memory --json-output
+```
+
+Text output includes the source file, heading, line range, chunk hash, and a short preview so you can decide whether to run `memsearch expand <chunk_hash>` next.
+
+---
+
 ## `memsearch watch`
 
 Start a long-running file watcher that monitors directories for markdown file changes. On startup, all existing markdown files are indexed first (dedup ensures no wasted API calls for unchanged content). Then the watcher monitors for changes: when a `.md` or `.markdown` file is created or modified, it is automatically re-indexed. When a file is deleted, its chunks are removed from the store.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -149,6 +149,29 @@ for r in results:
 
 ---
 
+### `list_memories`
+
+```python
+await mem.list_memories(*, source_prefix=None, limit=None) -> list[dict]
+```
+
+List indexed memories in deterministic source/line order.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `source_prefix` | `str \| Path \| None` | `None` | Only return chunks whose source path starts with this prefix |
+| `limit` | `int \| None` | `None` | Maximum number of memories to return |
+
+**Return value:** Each dict has the same shape as `search()` results, except no relevance `score` is included.
+
+```python
+memories = await mem.list_memories(limit=5)
+for memory in memories:
+    print(memory["source"], memory["heading"], memory["chunk_hash"])
+```
+
+---
+
 ### `compact`
 
 ```python

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -231,6 +231,67 @@ def search(
         ms.close()
 
 
+@cli.command("list")
+@click.option(
+    "--source-prefix",
+    default=None,
+    type=click.Path(),
+    help="Only list chunks whose source path starts with this prefix.",
+)
+@click.option("--limit", "-n", default=None, type=click.IntRange(1), help="Maximum number of memories to show.")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+@click.option("--collection", "-c", default=None, help="Milvus collection name.")
+@click.option("--milvus-uri", default=None, help="Milvus connection URI.")
+@click.option("--milvus-token", default=None, help="Milvus auth token.")
+def list_memories(
+    source_prefix: str | None,
+    limit: int | None,
+    json_output: bool,
+    collection: str | None,
+    milvus_uri: str | None,
+    milvus_token: str | None,
+) -> None:
+    """List indexed memories."""
+    from .store import MilvusStore
+
+    cfg = resolve_config(
+        _build_cli_overrides(
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
+    store = MilvusStore(
+        uri=cfg.milvus.uri,
+        token=cfg.milvus.token or None,
+        collection=cfg.milvus.collection,
+        dimension=None,
+    )
+    try:
+        memories = store.list_memories(source_prefix=source_prefix, limit=limit)
+        if json_output:
+            click.echo(json.dumps(memories, indent=2, ensure_ascii=False))
+            return
+
+        if not memories:
+            click.echo("No memories found.")
+            return
+
+        for i, memory in enumerate(memories, 1):
+            content = " ".join(memory.get("content", "").split())
+            preview = content if len(content) <= 160 else f"{content[:157]}..."
+            click.echo(f"\n--- Memory {i} ---")
+            click.echo(f"Source: {memory.get('source', '?')}")
+            heading = memory.get("heading", "")
+            if heading:
+                click.echo(f"Heading: {heading}")
+            click.echo(f"Lines: {memory.get('start_line', '?')}-{memory.get('end_line', '?')}")
+            click.echo(f"Chunk: {memory.get('chunk_hash', '')}")
+            click.echo(f"Preview: {preview}")
+    finally:
+        store.close()
+
+
 # ======================================================================
 # Expand command (progressive disclosure L2)
 #

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -237,6 +237,15 @@ class MemSearch:
             results = rerank(query, results, model_name=self._reranker_model, top_k=top_k)
         return results
 
+    async def list_memories(
+        self,
+        *,
+        source_prefix: str | Path | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List indexed memories ordered by source path and line number."""
+        return self._store.list_memories(source_prefix=source_prefix, limit=limit)
+
     # ------------------------------------------------------------------
     # Compact (compress memories)
     # ------------------------------------------------------------------

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -198,6 +198,31 @@ class MilvusStore:
         }
         return self._client.query(**kwargs)
 
+    def list_memories(
+        self,
+        *,
+        source_prefix: str | Path | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return indexed memories ordered by source path and line number."""
+        filter_expr = ""
+        if source_prefix is not None:
+            prefix = str(Path(source_prefix).expanduser().resolve())
+            filter_expr = f'source like "{_escape_filter_value(prefix)}%"'
+
+        results = self.query(filter_expr=filter_expr)
+        results.sort(
+            key=lambda row: (
+                row.get("source", ""),
+                row.get("start_line", 0),
+                row.get("end_line", 0),
+                row.get("chunk_hash", ""),
+            )
+        )
+        if limit is not None:
+            return results[:limit]
+        return results
+
     def hashes_by_source(self, source: str) -> set[str]:
         """Return all chunk_hash values for a given source file."""
         escaped = _escape_filter_value(source)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -19,6 +19,7 @@ from memsearch.cli import cli
         pytest.param(["config", "list", "--help"], "Usage:", id="config-list-help"),
         pytest.param(["index", "--help"], "Usage:", id="index-help"),
         pytest.param(["search", "--help"], "Usage:", id="search-help"),
+        pytest.param(["list", "--help"], "Usage:", id="list-help"),
         pytest.param(["expand", "--help"], "Usage:", id="expand-help"),
         pytest.param(["stats", "--help"], "Usage:", id="stats-help"),
         pytest.param(["reset", "--help"], "Usage:", id="reset-help"),

--- a/tests/test_list_memories.py
+++ b/tests/test_list_memories.py
@@ -1,0 +1,125 @@
+"""Tests for listing indexed memories."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+from memsearch.core import MemSearch
+from memsearch.store import MilvusStore
+
+
+def _vector(dim: int, index: int) -> list[float]:
+    values = [0.0] * dim
+    values[index] = 1.0
+    return values
+
+
+def _sample_chunks(source_a: str, source_b: str, *, dim: int = 4) -> list[dict]:
+    return [
+        {
+            "embedding": _vector(dim, 0),
+            "content": "Investigated Rust setup and fixed cargo PATH.",
+            "source": source_b,
+            "heading": "Rust setup",
+            "chunk_hash": "h-rust",
+            "heading_level": 2,
+            "start_line": 8,
+            "end_line": 12,
+        },
+        {
+            "embedding": _vector(dim, 1),
+            "content": "Documented Redis TTL decision for the cache layer.",
+            "source": source_a,
+            "heading": "Redis cache",
+            "chunk_hash": "h-redis",
+            "heading_level": 2,
+            "start_line": 4,
+            "end_line": 7,
+        },
+        {
+            "embedding": _vector(dim, 2),
+            "content": "Captured deployment notes for staging rollout.",
+            "source": source_a,
+            "heading": "Deployment",
+            "chunk_hash": "h-deploy",
+            "heading_level": 2,
+            "start_line": 20,
+            "end_line": 24,
+        },
+    ]
+
+
+def test_store_list_memories_orders_and_filters(tmp_path: Path) -> None:
+    db = tmp_path / "memories.db"
+    source_a = str((tmp_path / "memory" / "2026-04-01.md").resolve())
+    source_b = str((tmp_path / "memory" / "2026-04-02.md").resolve())
+
+    store = MilvusStore(uri=str(db), dimension=4)
+    store.upsert(_sample_chunks(source_a, source_b))
+
+    all_memories = store.list_memories()
+    assert [row["chunk_hash"] for row in all_memories] == ["h-redis", "h-deploy", "h-rust"]
+
+    limited = store.list_memories(limit=2)
+    assert [row["chunk_hash"] for row in limited] == ["h-redis", "h-deploy"]
+
+    filtered = store.list_memories(source_prefix=tmp_path / "memory")
+    assert [row["chunk_hash"] for row in filtered] == ["h-redis", "h-deploy", "h-rust"]
+
+    other = store.list_memories(source_prefix=tmp_path / "other")
+    assert other == []
+
+    store.close()
+
+
+def test_core_list_memories(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    source_a = str((tmp_path / "memory" / "2026-04-01.md").resolve())
+    source_b = str((tmp_path / "memory" / "2026-04-02.md").resolve())
+
+    mem = MemSearch(milvus_uri=str(db), embedding_api_key="test-key")
+    mem._store.upsert(_sample_chunks(source_a, source_b, dim=1536))
+
+    memories = asyncio.run(mem.list_memories(limit=2))
+    assert [row["chunk_hash"] for row in memories] == ["h-redis", "h-deploy"]
+
+    mem.close()
+
+
+def test_cli_list_outputs_text_and_json(tmp_path: Path) -> None:
+    db = tmp_path / "cli.db"
+    source_a = str((tmp_path / "memory" / "2026-04-01.md").resolve())
+    source_b = str((tmp_path / "memory" / "2026-04-02.md").resolve())
+
+    store = MilvusStore(uri=str(db), dimension=4)
+    store.upsert(_sample_chunks(source_a, source_b))
+    store.close()
+
+    runner = CliRunner()
+
+    text_result = runner.invoke(cli, ["list", "--milvus-uri", str(db), "--limit", "2"])
+    assert text_result.exit_code == 0
+    assert "--- Memory 1 ---" in text_result.output
+    assert "Heading: Redis cache" in text_result.output
+    assert "Chunk: h-redis" in text_result.output
+    assert "Chunk: h-deploy" in text_result.output
+
+    json_result = runner.invoke(
+        cli,
+        [
+            "list",
+            "--milvus-uri",
+            str(db),
+            "--source-prefix",
+            str(tmp_path / "memory"),
+            "--json-output",
+        ],
+    )
+    assert json_result.exit_code == 0
+    payload = json.loads(json_result.output)
+    assert [row["chunk_hash"] for row in payload] == ["h-redis", "h-deploy", "h-rust"]


### PR DESCRIPTION
## Summary
- add `list_memories()` to the store and core layers so indexed chunks can be enumerated deterministically
- add a new `memsearch list` command with optional source-prefix filtering, JSON output, and preview-friendly text formatting
- document the new listing workflow in the README, CLI docs, and Python API docs
- add pytest coverage for store ordering, the core API, CLI output, and CLI help

Closes #277.

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
- `.venv/bin/python -m pytest`