### PR TITLE
fix: skip bm25 for tokenless query

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -13,6 +14,16 @@ logger = logging.getLogger(__name__)
 def _escape_filter_value(value: str) -> str:
     """Escape backslashes and double quotes for Milvus filter expressions."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _bm25_query_text(query_text: str) -> str:
+    """Return a BM25-safe query string or empty string when no lexical tokens remain."""
+    normalized = query_text.strip()
+    if not normalized:
+        return ""
+    if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
+        return ""
+    return normalized
 
 
 class MilvusStore:
@@ -159,17 +170,22 @@ class MilvusStore:
             **req_kwargs,
         )
 
-        bm25_req = AnnSearchRequest(
-            data=[query_text] if query_text else [""],
-            anns_field="sparse_vector",
-            param={"metric_type": "BM25"},
-            limit=top_k,
-            **req_kwargs,
-        )
+        reqs = [dense_req]
+        bm25_query = _bm25_query_text(query_text)
+        if bm25_query:
+            reqs.append(
+                AnnSearchRequest(
+                    data=[bm25_query],
+                    anns_field="sparse_vector",
+                    param={"metric_type": "BM25"},
+                    limit=top_k,
+                    **req_kwargs,
+                )
+            )
 
         results = self._client.hybrid_search(
             collection_name=self._collection,
-            reqs=[dense_req, bm25_req],
+            reqs=reqs,
             ranker=RRFRanker(k=60),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from memsearch.store import MilvusStore
+from memsearch.store import MilvusStore, _bm25_query_text
 
 
 @pytest.fixture
@@ -93,6 +93,12 @@ def test_upsert_is_idempotent(store: MilvusStore):
     results = store.search([1.0, 0.0, 0.0, 0.0], top_k=10)
     hashes = [r["chunk_hash"] for r in results]
     assert hashes.count("same_hash") == 1
+
+
+def test_bm25_query_text_skips_numeric_only_queries():
+    assert _bm25_query_text("111123") == ""
+    assert _bm25_query_text("   42-7 ") == ""
+    assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
 def test_hybrid_search(store: MilvusStore):


### PR DESCRIPTION
## Summary
- skip the BM25/sparse search leg when the query text has no lexical tokens to contribute
- avoid the Milvus Lite `Invalid sparse row: NaN or Inf value` crash reported for numeric-only queries like `memsearch search 111123`
- add a focused store test for the BM25 query-text normalization helper

## Testing
- uv run python -m pytest tests/test_store.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
