### PR TITLE
test: cover numeric-only search path

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -13,6 +14,16 @@ logger = logging.getLogger(__name__)
 def _escape_filter_value(value: str) -> str:
     """Escape backslashes and double quotes for Milvus filter expressions."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _bm25_query_text(query_text: str) -> str:
+    """Return a BM25-safe query string or empty string when no lexical tokens remain."""
+    normalized = query_text.strip()
+    if not normalized:
+        return ""
+    if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
+        return ""
+    return normalized
 
 
 class MilvusStore:
@@ -159,17 +170,22 @@ class MilvusStore:
             **req_kwargs,
         )
 
-        bm25_req = AnnSearchRequest(
-            data=[query_text] if query_text else [""],
-            anns_field="sparse_vector",
-            param={"metric_type": "BM25"},
-            limit=top_k,
-            **req_kwargs,
-        )
+        reqs = [dense_req]
+        bm25_query = _bm25_query_text(query_text)
+        if bm25_query:
+            reqs.append(
+                AnnSearchRequest(
+                    data=[bm25_query],
+                    anns_field="sparse_vector",
+                    param={"metric_type": "BM25"},
+                    limit=top_k,
+                    **req_kwargs,
+                )
+            )
 
         results = self._client.hybrid_search(
             collection_name=self._collection,
-            reqs=[dense_req, bm25_req],
+            reqs=reqs,
             ranker=RRFRanker(k=60),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from memsearch.store import MilvusStore
+from memsearch.store import MilvusStore, _bm25_query_text
 
 
 @pytest.fixture
@@ -93,6 +93,12 @@ def test_upsert_is_idempotent(store: MilvusStore):
     results = store.search([1.0, 0.0, 0.0, 0.0], top_k=10)
     hashes = [r["chunk_hash"] for r in results]
     assert hashes.count("same_hash") == 1
+
+
+def test_bm25_query_text_skips_numeric_only_queries():
+    assert _bm25_query_text("111123") == ""
+    assert _bm25_query_text("   42-7 ") == ""
+    assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
 def test_hybrid_search(store: MilvusStore):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -101,6 +101,24 @@ def test_bm25_query_text_skips_numeric_only_queries():
     assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
+def test_search_numeric_only_query_does_not_raise(store: MilvusStore):
+    chunk = {
+        "embedding": [1.0, 0.0, 0.0, 0.0],
+        "content": "Version 111123 release checklist",
+        "source": "test.md",
+        "heading": "Release",
+        "chunk_hash": "h_numeric",
+        "heading_level": 1,
+        "start_line": 1,
+        "end_line": 3,
+    }
+    store.upsert([chunk])
+
+    results = store.search([1.0, 0.0, 0.0, 0.0], query_text="111123", top_k=5)
+
+    assert isinstance(results, list)
+
+
 def test_hybrid_search(store: MilvusStore):
     chunks = [
         {


### PR DESCRIPTION
## Summary
- add a store-level regression test for numeric-only search queries
- cover the user-facing `search ... --query-text 111123` path after the sparse/BM25 crash fix
- make sure the numeric-only query case stays non-crashing beyond the helper-only unit test

## Testing
- uv run python -m pytest tests/test_store.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
