### PR TITLE
fix: keep alnum tech tokens in bm25

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -13,6 +14,16 @@ logger = logging.getLogger(__name__)
 def _escape_filter_value(value: str) -> str:
     """Escape backslashes and double quotes for Milvus filter expressions."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _bm25_query_text(query_text: str) -> str:
+    """Return a BM25-safe query string or empty string when no lexical tokens remain."""
+    normalized = query_text.strip()
+    if not normalized:
+        return ""
+    if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
+        return ""
+    return normalized
 
 
 class MilvusStore:
@@ -159,17 +170,22 @@ class MilvusStore:
             **req_kwargs,
         )
 
-        bm25_req = AnnSearchRequest(
-            data=[query_text] if query_text else [""],
-            anns_field="sparse_vector",
-            param={"metric_type": "BM25"},
-            limit=top_k,
-            **req_kwargs,
-        )
+        reqs = [dense_req]
+        bm25_query = _bm25_query_text(query_text)
+        if bm25_query:
+            reqs.append(
+                AnnSearchRequest(
+                    data=[bm25_query],
+                    anns_field="sparse_vector",
+                    param={"metric_type": "BM25"},
+                    limit=top_k,
+                    **req_kwargs,
+                )
+            )
 
         results = self._client.hybrid_search(
             collection_name=self._collection,
-            reqs=[dense_req, bm25_req],
+            reqs=reqs,
             ranker=RRFRanker(k=60),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -23,6 +23,11 @@ def _bm25_query_text(query_text: str) -> str:
         return ""
     if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
         return ""
+    if not re.search(
+        r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF].*\d|\d.*[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]|[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]{2,}",
+        normalized,
+    ):
+        return ""
     return normalized
 
 

--- a/tests/test_search_cli.py
+++ b/tests/test_search_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+
+
+class DummyMemSearch:
+    last_query = None
+
+    async def search(self, query: str, **kwargs):
+        DummyMemSearch.last_query = query
+        return [
+            {
+                "content": "Version 111123 release checklist",
+                "source": "/tmp/notes.md",
+                "heading": "Release",
+                "score": 0.99,
+                "chunk_hash": "h_numeric",
+            }
+        ]
+
+    def close(self) -> None:
+        pass
+
+
+def test_search_cli_accepts_numeric_only_query(monkeypatch):
+    monkeypatch.setattr("memsearch.core.MemSearch", lambda **kwargs: DummyMemSearch())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "111123"])
+
+    assert result.exit_code == 0
+    assert DummyMemSearch.last_query == "111123"
+    assert "Version 111123 release checklist" in result.output

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from memsearch.store import MilvusStore
+from memsearch.store import MilvusStore, _bm25_query_text
 
 
 @pytest.fixture
@@ -93,6 +93,12 @@ def test_upsert_is_idempotent(store: MilvusStore):
     results = store.search([1.0, 0.0, 0.0, 0.0], top_k=10)
     hashes = [r["chunk_hash"] for r in results]
     assert hashes.count("same_hash") == 1
+
+
+def test_bm25_query_text_skips_numeric_only_queries():
+    assert _bm25_query_text("111123") == ""
+    assert _bm25_query_text("   42-7 ") == ""
+    assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
 def test_hybrid_search(store: MilvusStore):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -101,6 +101,24 @@ def test_bm25_query_text_skips_numeric_only_queries():
     assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
+def test_search_numeric_only_query_does_not_raise(store: MilvusStore):
+    chunk = {
+        "embedding": [1.0, 0.0, 0.0, 0.0],
+        "content": "Version 111123 release checklist",
+        "source": "test.md",
+        "heading": "Release",
+        "chunk_hash": "h_numeric",
+        "heading_level": 1,
+        "start_line": 1,
+        "end_line": 3,
+    }
+    store.upsert([chunk])
+
+    results = store.search([1.0, 0.0, 0.0, 0.0], query_text="111123", top_k=5)
+
+    assert isinstance(results, list)
+
+
 def test_hybrid_search(store: MilvusStore):
     chunks = [
         {

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -99,6 +99,9 @@ def test_bm25_query_text_skips_numeric_only_queries():
     assert _bm25_query_text("111123") == ""
     assert _bm25_query_text("   42-7 ") == ""
     assert _bm25_query_text("Redis 111123") == "Redis 111123"
+    assert _bm25_query_text("gpt-4o") == "gpt-4o"
+    assert _bm25_query_text("RFC-9110") == "RFC-9110"
+    assert _bm25_query_text("v2.1.0") == "v2.1.0"
 
 
 def test_search_numeric_only_query_does_not_raise(store: MilvusStore):


### PR DESCRIPTION
## Summary
- keep BM25 enabled for technical query tokens that mix letters and digits, such as `gpt-4o`, `RFC-9110`, and `v2.1.0`
- avoid over-correcting the numeric-only query crash fix by treating these common technical identifiers as tokenless input
- extend the store test coverage for BM25 query normalization

## Testing
- uv run python -m pytest tests/test_store.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
