### PR TITLE
fix: guard hybrid_search against empty collection BM25 crash

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -147,6 +147,11 @@ class MilvusStore:
         """Hybrid search: dense vector + BM25 full-text with RRF reranking."""
         from pymilvus import AnnSearchRequest, RRFRanker
 
+        # BM25 crashes on empty collections (avgdl=0 → NaN). See #306.
+        stats = self._client.get_collection_stats(self._collection)
+        if int(stats.get("row_count", 0)) == 0:
+            return []
+
         req_kwargs: dict[str, Any] = {}
         if filter_expr:
             req_kwargs["expr"] = filter_expr


### PR DESCRIPTION
## Summary

- Guard `MilvusStore.search()` against the BM25 NaN/Inf crash that occurs when `hybrid_search` is called on an empty collection
- Milvus Lite's BM25 function computes `avgdl = 0` when no documents exist, producing NaN sparse vectors that fail the `std::isfinite` assertion in the C++ core
- Check `row_count` before searching — return `[]` immediately when the collection is empty

## Root cause

The crash is **not** caused by numeric-only queries (as initially suspected). It happens on **any** BM25 hybrid search against an empty collection, because:

1. Empty collection → `avgdl = 0` (average document length)
2. BM25 IDF calculation divides by `avgdl` → produces `NaN`
3. Milvus Lite C++ assertion `std::isfinite(element.val)` fails → exception

This is an upstream Milvus Lite bug (similar to milvus-io/milvus#41490, which was fixed for Milvus Server but not ported to Milvus Lite). This PR adds the application-level guard.

## Test plan

- [x] Verified crash reproduces on milvus-lite 2.5.1 with empty collection
- [x] Verified fix returns `[]` on empty collection without crash
- [x] Existing `tests/test_store.py` (8 tests) pass

Fixes #306