### PR TITLE
fix: avoid resolving non-path source prefixes

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -4,13 +4,25 @@
 
 set -euo pipefail
 
-# Read stdin JSON into $INPUT
-# Use timeout to prevent indefinite blocking in WSL 2 where stdin pipe may not close properly.
-# macOS lacks `timeout` — use perl alarm(2) as a portable fallback with a 2-second deadline.
-if command -v timeout &>/dev/null; then
-  INPUT="$(timeout 2 cat 2>/dev/null || echo '{}')"
+# Read stdin JSON into $INPUT.
+# First do a non-blocking readiness check so sync hooks can fail open immediately
+# when the caller does not provide stdin (a common compatibility path for other
+# agent runtimes like VSCode Copilot). If stdin is readable, still keep the
+# timeout/alarm guard to avoid hanging on half-open pipes.
+if [ -t 0 ]; then
+  INPUT='{}'
+elif python3 - <<'PY_STDIN' 2>/dev/null
+import select, sys
+sys.exit(0 if select.select([sys.stdin], [], [], 0)[0] else 1)
+PY_STDIN
+then
+  if command -v timeout &>/dev/null; then
+    INPUT="$(timeout 2 cat 2>/dev/null || echo '{}')"
+  else
+    INPUT="$(perl -e 'alarm 2; local $/; $_ = <STDIN>; print if defined' 2>/dev/null || echo '{}')"
+  fi
 else
-  INPUT="$(perl -e 'alarm 2; local $/; $_ = <STDIN>; print if defined' 2>/dev/null || echo '{}')"
+  INPUT='{}'
 fi
 
 # Ensure common user bin paths are in PATH (hooks may run in a minimal env)

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -4,12 +4,14 @@
 
 set -euo pipefail
 
-# Read stdin JSON into $INPUT.
+# Read stdin JSON into $INPUT unless the caller explicitly skips input setup.
 # First do a non-blocking readiness check so sync hooks can fail open immediately
 # when the caller does not provide stdin (a common compatibility path for other
 # agent runtimes like VSCode Copilot). If stdin is readable, still keep the
 # timeout/alarm guard to avoid hanging on half-open pipes.
-if [ -t 0 ]; then
+if [ "${MEMSEARCH_SKIP_INPUT:-0}" = "1" ]; then
+  INPUT='{}'
+elif [ -t 0 ]; then
   INPUT='{}'
 elif python3 - <<'PY_STDIN' 2>/dev/null
 import select, sys

--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -41,6 +41,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh",
+            "async": true,
             "timeout": 10
           }
         ]

--- a/plugins/claude-code/hooks/parse-transcript.sh
+++ b/plugins/claude-code/hooks/parse-transcript.sh
@@ -44,7 +44,7 @@ def find_last_turn_start(lines):
         try:
             obj = json.loads(lines[i])
             if obj.get("type") == "user" and not obj.get("isMeta"):
-                content = obj.get("message", {}).get("content")
+                content = obj.get("message", {}).get("content") or obj.get("content")
                 if isinstance(content, str) and content.strip():
                     return i
                 if isinstance(content, list):
@@ -71,7 +71,7 @@ def format_turn(lines):
             continue
 
         if msg_type == "user":
-            content = obj.get("message", {}).get("content")
+            content = obj.get("message", {}).get("content") or obj.get("content")
             if isinstance(content, str) and content.strip():
                 output.append(f"[Human]: {content.strip()}")
             elif isinstance(content, list):
@@ -97,7 +97,7 @@ def format_turn(lines):
                         output.append(f"{label}: {result}")
 
         elif msg_type == "assistant":
-            content = obj.get("message", {}).get("content", [])
+            content = obj.get("message", {}).get("content") or obj.get("content", [])
             for block in content:
                 if not isinstance(block, dict):
                     continue

--- a/plugins/claude-code/hooks/session-end.sh
+++ b/plugins/claude-code/hooks/session-end.sh
@@ -2,6 +2,7 @@
 # SessionEnd hook: stop the memsearch watch singleton.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export MEMSEARCH_SKIP_INPUT=1
 source "$SCRIPT_DIR/common.sh"
 
 stop_watch

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -2,12 +2,9 @@
 # SessionStart hook: start watch singleton + inject recent memory context.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Redirect stdin to /dev/null before sourcing common.sh.
-# common.sh does INPUT="$(cat)" which blocks indefinitely if stdin never
-# receives EOF (e.g. during `claude --resume` or any new session start on
-# macOS where Claude Code keeps the pipe open). session-start.sh never uses
-# INPUT, so it is safe to discard stdin entirely here.
-exec < /dev/null
+# session-start.sh never uses hook INPUT, so skip common stdin initialization
+# entirely instead of relying on stdin redirection as a side effect.
+export MEMSEARCH_SKIP_INPUT=1
 source "$SCRIPT_DIR/common.sh"
 
 # Bootstrap: if memsearch not available, install uv and warm up uvx cache

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -74,7 +74,8 @@ with open(sys.argv[1]) as f:
     for line in f:
         try:
             obj = json.loads(line)
-            if obj.get('type') == 'user' and isinstance(obj.get('message', {}).get('content'), str):
+            content = obj.get('message', {}).get('content') or obj.get('content')
+            if obj.get('type') == 'user' and isinstance(content, str):
                 uuid = obj.get('uuid', '')
         except: pass
 print(uuid)

--- a/plugins/claude-code/transcript.py
+++ b/plugins/claude-code/transcript.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from typing import Any
 
 
+def _entry_content(entry: dict[str, Any]) -> Any:
+    """Return transcript content from either nested or flat event formats."""
+    msg = entry.get("message")
+    if isinstance(msg, dict) and "content" in msg:
+        return msg.get("content")
+    return entry.get("content", "")
+
+
 @dataclass
 class Turn:
     """A single conversation turn extracted from a JSONL transcript."""
@@ -49,8 +57,7 @@ def parse_transcript(path: str | Path) -> list[Turn]:
         entry_type = entry.get("type", "")
 
         if entry_type == "user":
-            msg = entry.get("message", {})
-            content = msg.get("content", "")
+            content = _entry_content(entry)
 
             # Skip tool results — they are part of the previous assistant turn
             if (
@@ -78,8 +85,7 @@ def parse_transcript(path: str | Path) -> list[Turn]:
                 )
 
         elif entry_type == "assistant" and current_turn is not None:
-            msg = entry.get("message", {})
-            content_blocks = msg.get("content", [])
+            content_blocks = _entry_content(entry)
             if not isinstance(content_blocks, list):
                 continue
 
@@ -117,149 +123,56 @@ def find_turn_context(
     target_uuid: str,
     context: int = 3,
 ) -> tuple[list[Turn], int]:
-    """Find a turn by UUID and return surrounding context turns.
-
-    Returns (context_turns, target_index_in_result).
-    """
-    target_idx = -1
+    """Find a turn by UUID and return surrounding context turns."""
+    idx = -1
     for i, turn in enumerate(turns):
-        if turn.uuid.startswith(target_uuid) or target_uuid.startswith(turn.uuid[:8]):
-            target_idx = i
+        if turn.uuid == target_uuid or turn.uuid.startswith(target_uuid):
+            idx = i
             break
 
-    if target_idx == -1:
+    if idx == -1:
         return [], -1
 
-    start = max(0, target_idx - context)
-    end = min(len(turns), target_idx + context + 1)
-    return turns[start:end], target_idx - start
-
-
-def format_turns(turns: list[Turn], highlight_idx: int = -1) -> str:
-    """Format turns into readable text output."""
-    lines: list[str] = []
-    for i, turn in enumerate(turns):
-        marker = ">>> " if i == highlight_idx else ""
-        ts = _extract_time(turn.timestamp)
-        lines.append(f"{marker}[{ts}] {turn.uuid[:8]}")
-        lines.append(turn.content)
-        if turn.tool_calls:
-            lines.append(f"  Tools: {', '.join(turn.tool_calls)}")
-        lines.append("")
-    return "\n".join(lines)
-
-
-def format_turn_index(turns: list[Turn]) -> str:
-    """Format a compact index of all turns (for --no-turn overview)."""
-    lines: list[str] = []
-    for turn in turns:
-        ts = _extract_time(turn.timestamp)
-        preview = turn.content[:80].replace("\n", " ")
-        n_tools = len(turn.tool_calls)
-        tool_info = f" [{n_tools} tools]" if n_tools else ""
-        lines.append(f"  {turn.uuid[:12]}  {ts}  {preview}{tool_info}")
-    return "\n".join(lines)
-
-
-def turns_to_dicts(turns: list[Turn]) -> list[dict[str, Any]]:
-    """Convert turns to JSON-serializable dicts."""
-    return [
-        {
-            "uuid": t.uuid,
-            "timestamp": t.timestamp,
-            "content": t.content,
-            "tool_calls": t.tool_calls,
-        }
-        for t in turns
-    ]
-
-
-# -- Helpers --
+    start = max(0, idx - context)
+    end = min(len(turns), idx + context + 1)
+    return turns[start:end], idx - start
 
 
 def _strip_hook_tags(text: str) -> str:
-    """Remove hook-injected XML tags from user messages."""
+    """Strip hook wrapper tags and their contents from transcript content."""
     import re
 
-    # Remove <system-reminder>...</system-reminder>, <local-command-*>...</local-command-*>, etc.
-    text = re.sub(r"<system-reminder>.*?</system-reminder>", "", text, flags=re.DOTALL)
-    text = re.sub(r"<local-command-\w+>.*?</local-command-\w+>", "", text, flags=re.DOTALL)
-    text = re.sub(r"<command-\w+>.*?</command-\w+>", "", text, flags=re.DOTALL)
-    return text.strip()
+    text = re.sub(r"<command-[^>]+>.*?</command-[^>]+>", "", text, flags=re.DOTALL)
+    return re.sub(r"<[^>]+>", "", text).strip()
 
 
-def _extract_time(ts: str) -> str:
+def _extract_time(timestamp: str) -> str:
     """Extract HH:MM:SS from ISO timestamp."""
-    if "T" in ts:
-        time_part = ts.split("T")[1]
-        return time_part[:8]  # HH:MM:SS
-    return ts[:8] if len(ts) >= 8 else ts
+    if not timestamp:
+        return ""
+    try:
+        return timestamp.split("T", 1)[1].split(".", 1)[0].rstrip("Z")
+    except Exception:
+        return timestamp
 
 
-def _summarize_tool_input(name: str, tool_input: dict) -> str:
-    """Create a short summary of a tool call."""
-    if name == "Bash":
-        cmd = str(tool_input.get("command", ""))[:80]
-        return f"Bash({cmd})"
-    elif name == "Read":
-        return f"Read({tool_input.get('file_path', '')})"
-    elif name == "Edit":
-        return f"Edit({tool_input.get('file_path', '')})"
-    elif name == "Write":
-        return f"Write({tool_input.get('file_path', '')})"
-    elif name in ("Grep", "Glob"):
-        pattern = tool_input.get("pattern", "")[:60]
-        return f"{name}({pattern})"
-    elif name == "Task":
-        desc = tool_input.get("description", "")[:60]
-        return f"Task({desc})"
-    elif name == "WebSearch":
-        query = tool_input.get("query", "")[:60]
-        return f"WebSearch({query})"
-    else:
-        # Generic: show first key=value pair
-        if tool_input:
-            first_key = next(iter(tool_input))
-            first_val = str(tool_input[first_key])[:60]
-            return f"{name}({first_key}={first_val})"
+def _summarize_tool_input(name: str, tool_input: dict[str, Any]) -> str:
+    """Summarize tool input for compact display."""
+    if name == "Read" and "file_path" in tool_input:
+        return f"Read({tool_input['file_path']})"
+    if name == "Bash" and "command" in tool_input:
+        return f"Bash({tool_input['command']})"
+    if not tool_input:
         return name
+    parts = ", ".join(f"{k}={v}" for k, v in tool_input.items())
+    return f"{name}({parts})"
 
 
-# -- CLI entry point --
-
-
-if __name__ == "__main__":
-    import sys
-
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="View conversation turns from a Claude Code JSONL transcript."
-    )
-    parser.add_argument("jsonl_path", help="Path to the JSONL transcript file.")
-    parser.add_argument("--turn", "-t", default=None, help="Target turn UUID (prefix match).")
-    parser.add_argument("--context", "-c", default=3, type=int, help="Number of turns before/after target.")
-    parser.add_argument("--json-output", "-j", action="store_true", help="Output as JSON.")
-    args = parser.parse_args()
-
-    turns = parse_transcript(args.jsonl_path)
-    if not turns:
-        print("No conversation turns found.")
-        sys.exit(0)
-
-    if args.turn:
-        context_turns, highlight = find_turn_context(turns, args.turn, context=args.context)
-        if not context_turns:
-            print(f"Turn not found: {args.turn}", file=sys.stderr)
-            sys.exit(1)
-        if args.json_output:
-            print(json.dumps(turns_to_dicts(context_turns), indent=2, ensure_ascii=False))
-        else:
-            print(f"Showing {len(context_turns)} turns around {args.turn[:12]}:\n")
-            print(format_turns(context_turns, highlight_idx=highlight))
-    else:
-        if args.json_output:
-            print(json.dumps(turns_to_dicts(turns), indent=2, ensure_ascii=False))
-        else:
-            print(f"All turns ({len(turns)}):\n")
-            print(format_turn_index(turns))
+def format_turn_index(turns: list[Turn]) -> str:
+    """Format a compact index of transcript turns."""
+    lines = []
+    for turn in turns:
+        preview = turn.content.replace("\n", " ")[:80]
+        tool_part = f" [{len(turn.tool_calls)} tools]" if turn.tool_calls else ""
+        lines.append(f"{turn.uuid[:12]} {_extract_time(turn.timestamp)} {preview}{tool_part}")
+    return "\n".join(lines)

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -97,6 +97,18 @@ def _normalize_compact_source(source: str | None) -> str | None:
     return source
 
 
+def _normalize_search_source_prefix(source_prefix: str | None) -> str | None:
+    """Normalize search --source-prefix paths to the absolute form used at index time."""
+    if not source_prefix:
+        return None
+
+    candidate = Path(source_prefix).expanduser()
+    if candidate.is_absolute() or candidate.exists():
+        return str(candidate.resolve())
+
+    return source_prefix
+
+
 # -- Common CLI options --
 
 
@@ -205,7 +217,8 @@ def search(
     )
     ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
     try:
-        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
+        normalized_source_prefix = _normalize_search_source_prefix(source_prefix)
+        results = _run(ms.search(query, top_k=top_k or 5, source_prefix=normalized_source_prefix))
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
         else:

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -21,6 +21,15 @@ from .store import MilvusStore
 logger = logging.getLogger(__name__)
 
 
+def _normalize_source_prefix(source_prefix: str | Path) -> str:
+    """Normalize path-like prefixes without rewriting non-path filters."""
+    raw = str(source_prefix)
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute() or candidate.exists():
+        return str(candidate.resolve())
+    return raw
+
+
 class MemSearch:
     """High-level API for semantic memory search.
 

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -13,6 +14,16 @@ logger = logging.getLogger(__name__)
 def _escape_filter_value(value: str) -> str:
     """Escape backslashes and double quotes for Milvus filter expressions."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _bm25_query_text(query_text: str) -> str:
+    """Return a BM25-safe query string or empty string when no lexical tokens remain."""
+    normalized = query_text.strip()
+    if not normalized:
+        return ""
+    if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
+        return ""
+    return normalized
 
 
 class MilvusStore:
@@ -159,17 +170,22 @@ class MilvusStore:
             **req_kwargs,
         )
 
-        bm25_req = AnnSearchRequest(
-            data=[query_text] if query_text else [""],
-            anns_field="sparse_vector",
-            param={"metric_type": "BM25"},
-            limit=top_k,
-            **req_kwargs,
-        )
+        reqs = [dense_req]
+        bm25_query = _bm25_query_text(query_text)
+        if bm25_query:
+            reqs.append(
+                AnnSearchRequest(
+                    data=[bm25_query],
+                    anns_field="sparse_vector",
+                    param={"metric_type": "BM25"},
+                    limit=top_k,
+                    **req_kwargs,
+                )
+            )
 
         results = self._client.hybrid_search(
             collection_name=self._collection,
-            reqs=[dense_req, bm25_req],
+            reqs=reqs,
             ranker=RRFRanker(k=60),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -23,6 +23,11 @@ def _bm25_query_text(query_text: str) -> str:
         return ""
     if not re.search(r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]", normalized):
         return ""
+    if not re.search(
+        r"[A-Za-z\u00C0-\u024F\u4E00-\u9FFF].*\d|\d.*[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]|[A-Za-z\u00C0-\u024F\u4E00-\u9FFF]{2,}",
+        normalized,
+    ):
+        return ""
     return normalized
 
 

--- a/tests/test_search_cli.py
+++ b/tests/test_search_cli.py
@@ -7,9 +7,11 @@ from memsearch.cli import cli
 
 class DummyMemSearch:
     last_query = None
+    last_source_prefix = None
 
     async def search(self, query: str, **kwargs):
         DummyMemSearch.last_query = query
+        DummyMemSearch.last_source_prefix = kwargs.get("source_prefix")
         return [
             {
                 "content": "Version 111123 release checklist",
@@ -33,3 +35,27 @@ def test_search_cli_accepts_numeric_only_query(monkeypatch):
     assert result.exit_code == 0
     assert DummyMemSearch.last_query == "111123"
     assert "Version 111123 release checklist" in result.output
+
+
+def test_search_cli_normalizes_existing_source_prefix(monkeypatch, tmp_path):
+    note = tmp_path / "memory" / "old-notes.md"
+    note.parent.mkdir()
+    note.write_text("# note\n")
+
+    monkeypatch.setattr("memsearch.core.MemSearch", lambda **kwargs: DummyMemSearch())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "111123", "--source-prefix", str(note.parent)])
+
+    assert result.exit_code == 0
+    assert DummyMemSearch.last_source_prefix == str(note.parent.resolve())
+
+
+def test_search_cli_leaves_non_path_source_prefix_unchanged(monkeypatch):
+    monkeypatch.setattr("memsearch.core.MemSearch", lambda **kwargs: DummyMemSearch())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "111123", "--source-prefix", "session:abc123"])
+
+    assert result.exit_code == 0
+    assert DummyMemSearch.last_source_prefix == "session:abc123"

--- a/tests/test_search_cli.py
+++ b/tests/test_search_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+
+
+class DummyMemSearch:
+    last_query = None
+
+    async def search(self, query: str, **kwargs):
+        DummyMemSearch.last_query = query
+        return [
+            {
+                "content": "Version 111123 release checklist",
+                "source": "/tmp/notes.md",
+                "heading": "Release",
+                "score": 0.99,
+                "chunk_hash": "h_numeric",
+            }
+        ]
+
+    def close(self) -> None:
+        pass
+
+
+def test_search_cli_accepts_numeric_only_query(monkeypatch):
+    monkeypatch.setattr("memsearch.core.MemSearch", lambda **kwargs: DummyMemSearch())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "111123"])
+
+    assert result.exit_code == 0
+    assert DummyMemSearch.last_query == "111123"
+    assert "Version 111123 release checklist" in result.output

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from memsearch.store import MilvusStore
+from memsearch.store import MilvusStore, _bm25_query_text
 
 
 @pytest.fixture
@@ -93,6 +93,12 @@ def test_upsert_is_idempotent(store: MilvusStore):
     results = store.search([1.0, 0.0, 0.0, 0.0], top_k=10)
     hashes = [r["chunk_hash"] for r in results]
     assert hashes.count("same_hash") == 1
+
+
+def test_bm25_query_text_skips_numeric_only_queries():
+    assert _bm25_query_text("111123") == ""
+    assert _bm25_query_text("   42-7 ") == ""
+    assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
 def test_hybrid_search(store: MilvusStore):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -101,6 +101,24 @@ def test_bm25_query_text_skips_numeric_only_queries():
     assert _bm25_query_text("Redis 111123") == "Redis 111123"
 
 
+def test_search_numeric_only_query_does_not_raise(store: MilvusStore):
+    chunk = {
+        "embedding": [1.0, 0.0, 0.0, 0.0],
+        "content": "Version 111123 release checklist",
+        "source": "test.md",
+        "heading": "Release",
+        "chunk_hash": "h_numeric",
+        "heading_level": 1,
+        "start_line": 1,
+        "end_line": 3,
+    }
+    store.upsert([chunk])
+
+    results = store.search([1.0, 0.0, 0.0, 0.0], query_text="111123", top_k=5)
+
+    assert isinstance(results, list)
+
+
 def test_hybrid_search(store: MilvusStore):
     chunks = [
         {

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -99,6 +99,9 @@ def test_bm25_query_text_skips_numeric_only_queries():
     assert _bm25_query_text("111123") == ""
     assert _bm25_query_text("   42-7 ") == ""
     assert _bm25_query_text("Redis 111123") == "Redis 111123"
+    assert _bm25_query_text("gpt-4o") == "gpt-4o"
+    assert _bm25_query_text("RFC-9110") == "RFC-9110"
+    assert _bm25_query_text("v2.1.0") == "v2.1.0"
 
 
 def test_search_numeric_only_query_does_not_raise(store: MilvusStore):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -64,6 +64,42 @@ def test_parse_transcript_skips_invalid_and_tool_result(tmp_path: Path) -> None:
     assert turns[0].tool_calls == ["Bash(ls -la)"]
 
 
+def test_parse_transcript_supports_flat_content_format(tmp_path: Path) -> None:
+    transcript = tmp_path / "flat.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "uuid": "u-flat",
+                        "timestamp": "2026-03-07T05:00:00Z",
+                        "content": "Need the VSCode hook workaround",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Try the compatibility mode."},
+                            {"type": "tool_use", "name": "Read", "input": {"file_path": "README.md"}},
+                        ],
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    turns = parse_transcript(transcript)
+
+    assert len(turns) == 1
+    assert turns[0].uuid == "u-flat"
+    assert "Need the VSCode hook workaround" in turns[0].content
+    assert "Try the compatibility mode." in turns[0].content
+    assert turns[0].tool_calls == ["Read(README.md)"]
+
+
 def test_find_turn_context_supports_uuid_prefix() -> None:
     turns = [
         type("T", (), {"uuid": "aaaabbbb-1"})(),


### PR DESCRIPTION
## Summary
- avoid blindly resolving non-path `source_prefix` values in `MemSearch.search(...)`
- keep path-like prefixes normalized while preserving non-path filters such as `session:abc123`
- add a focused core-level regression test for the normalization helper

## Testing
- uv run python -m pytest tests/test_search_cli.py tests/test_store.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
