### PR TITLE
chore: bump memsearch to 0.2.4 and OpenClaw plugin to 0.2.0

### DIFF
--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "openclaw": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.2.3"
+version = "0.2.4"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump memsearch (PyPI) from 0.2.3 → 0.2.4
- Bump OpenClaw plugin from 0.1.1 → 0.2.0

### memsearch 0.2.4
- fix: guard hybrid_search against empty collection BM25 crash (#316)

### OpenClaw plugin 0.2.0
- refactor: replace child_process with runCommandWithTimeout (#321)
- refactor: simplify auto-capture to use agent_end (#321)
- fix: add descriptors to registerCli for OpenClaw 2026.4+ (#321)