### PR TITLE
docs: update OpenClaw capture architecture to agent_end

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ memsearch supports 4 AI coding agent platforms: [Claude Code](platforms/claude-c
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
-        OC["OpenClaw<br/>(llm_output + agent)"]
+        OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]
         CX["Codex CLI<br/>(Stop hook + Codex)"]
     end

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -43,7 +43,7 @@ This is memsearch's key differentiator: **memories written by one agent are sear
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
-        OC["OpenClaw<br/>(llm_output + agent)"]
+        OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]
         CX["Codex CLI<br/>(Stop hook + Codex)"]
     end

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ All platforms share the same markdown memory format and derive collection names 
 | | [Claude Code](platforms/claude-code/index.md) | [OpenClaw](platforms/openclaw/index.md) | [OpenCode](platforms/opencode/index.md) | [Codex CLI](platforms/codex/index.md) |
 |---|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | TS plugin | TS plugin | Shell hooks |
-| **Capture** | Stop hook + Haiku | llm_output debounce | SQLite daemon | Stop hook + Codex |
+| **Capture** | Stop hook + Haiku | agent_end hook | SQLite daemon | Stop hook + Codex |
 | **Recall** | SKILL.md (fork) | memory_search tool | memory_search tool | SKILL.md |
 | **Install** | Plugin marketplace | `openclaw plugins install` | npm + opencode.json | `install.sh` |
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -9,7 +9,7 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | Feature | [Claude Code](claude-code/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) | [Codex CLI](codex/index.md) |
 |---------|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
-| **Capture method** | Stop hook (async) | llm_output debounce | SQLite daemon | Stop hook (async) |
+| **Capture method** | Stop hook (async) | agent_end hook | SQLite daemon | Stop hook (async) |
 | **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
 | **Recall mechanism** | SKILL.md (context: fork) | memory_search tool | memory_search tool | SKILL.md |
 | **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |

--- a/docs/platforms/openclaw/how-it-works.md
+++ b/docs/platforms/openclaw/how-it-works.md
@@ -5,8 +5,7 @@
 | Event | What memsearch does |
 |-------|-------------------|
 | **Agent starts** | Recent memories from the 2 most recent daily logs are injected as context (`before_agent_start`) |
-| **Each turn ends** | Conversation is summarized by the OpenClaw agent and appended to daily `.md` (`llm_output` debounce) |
-| **Agent ends** | Fallback capture for non-interactive mode (`agent_end` hook) |
+| **Each turn ends** | Conversation is summarized by the OpenClaw agent and appended to daily `.md` (`agent_end` hook) |
 | **LLM needs history** | Calls `memory_search`, `memory_get`, or `memory_transcript` tools progressively |
 
 ---
@@ -19,13 +18,12 @@ The plugin is a single `index.ts` file that registers tools, hooks, and a CLI su
 graph TB
     subgraph "Plugin Registration (index.ts)"
         TOOLS["registerTool (factory pattern)<br/>memory_search · memory_get · memory_transcript"]
-        HOOKS["Event hooks<br/>before_agent_start · llm_output · agent_end · session_start"]
+        HOOKS["Event hooks<br/>before_agent_start · agent_end · session_start"]
         CLI["registerCli<br/>openclaw memsearch search/index/status"]
     end
 
     subgraph "Capture Pipeline"
-        LLM_OUT["llm_output event"] --> DEBOUNCE["5s debounce timer"]
-        DEBOUNCE --> EXTRACT["Extract last turn<br/>(user question + assistant response)"]
+        AGENT_END["agent_end event"] --> EXTRACT["Extract last user+assistant turn<br/>from event.messages"]
         EXTRACT --> SUMMARIZE["summarizeWithLLM()<br/>openclaw agent --local"]
         SUMMARIZE --> WRITE["Append to YYYY-MM-DD.md<br/>with session anchors"]
         WRITE --> INDEX["memsearch index<br/>(background, non-blocking)"]
@@ -65,42 +63,31 @@ When the tool is called, `ctx.agentId` tells the plugin which agent is running. 
 
 ## Capture
 
-The capture pipeline hooks into OpenClaw's `llm_output` event, which fires on every LLM response (including intermediate tool-call responses).
-
-### Why llm_output + Debounce?
-
-In OpenClaw's TUI mode, `agent_end` only fires when the entire session exits -- not after each conversational turn. To capture per-turn summaries in interactive sessions, the plugin uses `llm_output` with a **5-second debounce**:
+The capture pipeline hooks into OpenClaw's `agent_end` event, which fires after every conversational turn in TUI mode. The event provides `event.messages` — a complete snapshot of the message history up to that point.
 
 ```mermaid
 sequenceDiagram
-    participant LLM as LLM Output
+    participant User
+    participant Agent as OpenClaw Agent
     participant Plugin as memsearch plugin
-    participant Timer as Debounce Timer
     participant File as Daily .md
 
-    LLM->>Plugin: llm_output (tool call response)
-    Plugin->>Timer: Reset timer (5s)
-    LLM->>Plugin: llm_output (final response)
-    Plugin->>Timer: Reset timer (5s)
-    Note over Timer: 5 seconds pass, no more output...
-    Timer->>Plugin: Timer fires → turn complete
-    Plugin->>Plugin: Extract user question + assistant response
-    Plugin->>Plugin: Filter noise (system logs, injected context)
+    User->>Agent: Ask question
+    Agent->>Agent: LLM calls, tool use, etc.
+    Agent->>Plugin: agent_end (event.messages)
+    Plugin->>Plugin: Extract last user+assistant turn
     Plugin->>Plugin: summarizeWithLLM()
     Plugin->>File: Append summary with anchors
     Plugin->>Plugin: memsearch index (background)
 ```
 
-After 5 seconds of silence from the LLM, the plugin treats the turn as complete and captures it. If a new `llm_input` event arrives (new user prompt) while a timer is still pending, the previous turn is flushed immediately before starting a new one.
+The plugin extracts the last user question and assistant response from `event.messages`, summarizes them via LLM, and appends the summary to the daily markdown file. No debounce or noise filtering is needed — `agent_end` provides a clean, complete message history for each turn.
 
-### Noise Filtering
+!!! note "Known limitations"
 
-The plugin aggressively filters noise to avoid capturing system messages, plugin logs, or injected context as "memories":
-
-- System/log lines (`[plugins]`, `WARNING:`, `Error:`, etc.)
-- Injected cold-start context (prevents capture → inject → re-capture loops)
-- OpenClaw reply directives (`[[reply_to_current]]`)
-- Lines that are mostly `[Human]:` prefixed (prependContext leak)
+    - Non-default agents may not fire `agent_end` reliably ([#50025](https://github.com/openclaw/openclaw/issues/50025))
+    - Feishu channel mode does not trigger `agent_end` ([#51189](https://github.com/openclaw/openclaw/issues/51189))
+    - Main agent vs subagent distinction not yet available in event metadata ([#57636](https://github.com/openclaw/openclaw/issues/57636))
 
 ### Summarization
 
@@ -113,10 +100,6 @@ Write in third person: 'User asked...', 'OpenClaw replied...'
 ```
 
 If `openclaw agent` fails (e.g., no model configured), the plugin falls back to raw truncated text.
-
-### Fallback: agent_end Hook
-
-For non-interactive mode (one-shot agent runs via `openclaw agent -m "do something"`), the `agent_end` hook acts as a fallback. It checks whether `llm_output` already captured the turn (via a `capturedSinceLastAgentStart` flag) to avoid duplicates.
 
 ---
 
@@ -217,7 +200,7 @@ plugins/openclaw/
 |------|---------|
 | `package.json` | npm package with `openclaw >=2026.3.11` as peer dependency |
 | `openclaw.plugin.json` | Plugin configuration schema: `provider`, `autoCapture`, `autoRecall` settings |
-| `index.ts` | Main plugin entry. Registers 3 tools (factory pattern), 4 event hooks, and CLI subcommand |
+| `index.ts` | Main plugin entry. Registers 3 tools (factory pattern), 3 event hooks, and CLI subcommand |
 | `install.sh` | Installation script: checks memsearch availability, registers plugin |
 | `SKILL.md` | Memory recall skill guide -- helps the LLM decide when and how to use the memory tools |
 | `derive-collection.sh` | Generates deterministic per-agent Milvus collection names |

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -54,7 +54,7 @@ This means agents with different workspaces have isolated memories, while agents
 ## When Is This Useful?
 
 - **Multi-agent workflows.** You use OpenClaw's main agent for general coding and a work agent for devops. Each needs its own context -- memsearch isolates them automatically.
-- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures every turn with debounced llm_output hooks, so nothing is lost even in marathon sessions.
+- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures every turn via the `agent_end` hook, so nothing is lost even in marathon sessions.
 - **Cross-platform memory.** You use OpenClaw for some projects and Claude Code for others. memsearch's markdown-based storage means memories are portable -- the same `.md` files work with any plugin.
 - **Auditing agent behavior.** memsearch's three-layer drill-down lets you trace from a summary back to the original JSONL transcript, useful for understanding what the agent actually did.
 
@@ -62,12 +62,12 @@ This means agents with different workspaces have isolated memories, while agents
 
 ## Key Features
 
-- **Automatic capture** -- conversations summarized and saved after each LLM response via debounced `llm_output` hook
+- **Automatic capture** -- conversations summarized and saved after each turn via `agent_end` hook
 - **Three-layer progressive recall** -- search, expand, and drill into original transcripts ([details](memory-tools.md))
 - **Multi-agent isolation** -- each agent gets its own memory directory and Milvus collection
 - **Cold-start context** -- recent memories injected on agent start via `before_agent_start` hook
 - **ONNX embedding by default** -- no API key required, runs locally on CPU
-- **Fallback capture** -- `agent_end` hook catches turns missed in non-interactive mode
+- **Cross-platform sharing** -- same collection names as Claude Code, Codex, and OpenCode for seamless memory portability
 
 ---
 

--- a/docs/platforms/opencode/how-it-works.md
+++ b/docs/platforms/opencode/how-it-works.md
@@ -188,7 +188,7 @@ The `<!-- session:... db:~/.local/share/opencode/opencode.db -->` anchors are us
 
 | Aspect | OpenCode | Claude Code | OpenClaw | Codex |
 |--------|----------|-------------|----------|-------|
-| **Capture** | SQLite daemon (polling) | Stop hook (event-driven) | llm_output hook (event-driven) | Stop hook (event-driven) |
+| **Capture** | SQLite daemon (polling) | Stop hook (event-driven) | agent_end hook (event-driven) | Stop hook (event-driven) |
 | **Summarizer** | `opencode run` (isolated) | `claude -p --model haiku` | `openclaw agent --local` | `codex exec` (isolated) |
 | **L3 source** | OpenCode SQLite DB | Claude Code JSONL | OpenClaw JSONL | Codex rollout JSONL |
 | **Recall trigger** | Tool-based (LLM decides) | Skill in forked subagent (`context: fork`) | Tool-based (LLM decides) | Skill-based (main context) |

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -4,7 +4,7 @@ Automatic persistent memory for [OpenClaw](https://github.com/openclaw/openclaw)
 
 ## Prerequisites
 
-- [OpenClaw](https://github.com/openclaw/openclaw) >= 2026.3.22
+- [OpenClaw](https://github.com/openclaw/openclaw) >= 2026.3.22 (2026.4+ recommended for full CLI support)
 - Python 3.10+
 
 ## Install


### PR DESCRIPTION
## Summary

- Update documentation to reflect OpenClaw plugin v0.2.0 capture refactor
- Replace all `llm_output` + debounce references with `agent_end` as the sole capture path
- Update mermaid diagrams, platform comparison tables, and capture mechanism descriptions

## Changes

| File | Change |
|------|--------|
| `docs/platforms/openclaw/how-it-works.md` | Replace capture section: remove debounce diagram + noise filtering, add agent_end flow + known limitations |
| `docs/platforms/openclaw/index.md` | Update 3 capture references |
| `docs/architecture.md` | Mermaid: `(llm_output + agent)` → `(agent_end)` |
| `docs/design-philosophy.md` | Same mermaid fix |
| `docs/index.md` | Platform table: capture method update |
| `docs/platforms/index.md` | Comparison table update |
| `docs/platforms/opencode/how-it-works.md` | Cross-platform comparison table fix |
| `plugins/openclaw/README.md` | Add "2026.4+ recommended for full CLI support" |