### PR TITLE
docs(claude-code): add embedding evaluation page

### DIFF
--- a/docs/platforms/claude-code/evaluation.md
+++ b/docs/platforms/claude-code/evaluation.md
@@ -1,0 +1,43 @@
+# Embedding Provider Evaluation
+
+The Claude Code plugin defaults to **ONNX bge-m3 int8** because it gave the best practical trade-off we found for bilingual memory retrieval:
+
+- **Strong Chinese + English retrieval quality**
+- **No API key required**
+- **Runs locally on CPU**
+- **Smaller dependency footprint** than PyTorch-based local stacks
+
+## Why this page exists
+
+The full benchmark write-up originally lived only in `ccplugin/evaluation/README.md`, which is useful in the repository but easy to miss from the documentation site. This page makes the result discoverable from the docs navigation while keeping the benchmark source material linked.
+
+## Benchmark summary
+
+The evaluation compared cloud APIs, local transformer models, ONNX variants, and Ollama models using bilingual memory-retrieval queries derived from real memsearch logs.
+
+### Main conclusion
+
+**`gpahal/bge-m3-onnx-int8`** became the plugin default because it was the best practical default for Claude Code plugin users:
+
+- **Top-tier bilingual retrieval** among local options
+- **Very small quality drop** versus full PyTorch bge-m3
+- **Much lighter install/runtime cost**
+- **Works out of the box** for users who do not want to configure remote API credentials
+
+### Operational trade-off
+
+Compared with OpenAI embeddings, the ONNX default removes first-run credential friction and per-token API cost, at the expense of a one-time local model download.
+
+## Full methodology and raw comparison
+
+For the complete benchmark details — dataset construction, evaluated models, Recall@K / MRR metrics, ONNX vs. PyTorch comparison tables, and migration guidance — see the source evaluation document in the repository:
+
+- <https://github.com/zilliztech/memsearch/blob/main/ccplugin/evaluation/README.md>
+
+## Related docs
+
+- [Claude Code Plugin Overview](index.md)
+- [Installation](installation.md)
+- [How It Works](how-it-works.md)
+- [Memory Recall](memory-recall.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/platforms/claude-code/index.md
+++ b/docs/platforms/claude-code/index.md
@@ -74,7 +74,7 @@ sequenceDiagram
 - **Semantic recall** -- Claude automatically searches past sessions when your question needs historical context
 - **Three-layer progressive disclosure** -- search, expand, and drill into original transcripts ([details](memory-recall.md))
 - **Forked subagent** -- memory recall runs in an isolated context, keeping your main conversation clean
-- **ONNX embedding by default** -- no API key required, runs locally on CPU
+- **ONNX embedding by default** -- no API key required, runs locally on CPU ([why this default](evaluation.md))
 - **Markdown is the source of truth** -- human-readable, git-friendly, portable ([details](how-it-works.md#markdown-is-the-source-of-truth))
 
 ---

--- a/docs/platforms/claude-code/installation.md
+++ b/docs/platforms/claude-code/installation.md
@@ -24,7 +24,7 @@ claude --plugin-dir ./plugins/claude-code
 ```
 
 !!! note "First-time ONNX model download"
-    The plugin defaults to **ONNX bge-m3** embedding -- no API key required, runs locally on CPU. On first launch, the model (~558 MB) is downloaded from HuggingFace Hub. Pre-download it manually:
+    The plugin defaults to **ONNX bge-m3** embedding -- no API key required, runs locally on CPU. See [Embedding Evaluation](evaluation.md) for why this became the default. On first launch, the model (~558 MB) is downloaded from HuggingFace Hub. Pre-download it manually:
 
     ```bash
     uvx --from 'memsearch[onnx]' memsearch search --provider onnx "warmup" 2>/dev/null || true
@@ -36,7 +36,7 @@ claude --plugin-dir ./plugins/claude-code
 
 ## Configuration
 
-The plugin defaults to **ONNX bge-m3** embedding (no API key, CPU-only). To use a different provider:
+The plugin defaults to **ONNX bge-m3** embedding (no API key, CPU-only). If you want the benchmark rationale for that choice, see [Embedding Evaluation](evaluation.md). To use a different provider:
 
 ```bash
 memsearch config set embedding.provider openai

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Claude Code Plugin:
     - Overview: platforms/claude-code/index.md
     - Installation: platforms/claude-code/installation.md
+    - Embedding Evaluation: platforms/claude-code/evaluation.md
     - How It Works: platforms/claude-code/how-it-works.md
     - Memory Recall: platforms/claude-code/memory-recall.md
     - Troubleshooting: platforms/claude-code/troubleshooting.md


### PR DESCRIPTION
## Summary
- add a first-class docs page for the Claude Code plugin embedding benchmark
- surface that page in the MkDocs navigation
- link the Claude Code overview page to the new evaluation page when describing the ONNX default

## Why
Part of #91.

The benchmark for why the Claude Code plugin defaults to ONNX bge-m3 already exists, but it lived only in `ccplugin/evaluation/README.md`. That makes the reasoning hard to discover from the published docs site. This PR turns it into a navigable docs page while still linking to the full source benchmark.

## Testing
- docs only
