### PR TITLE
fix(claude-code): derive recall collection from git root

### DIFF
--- a/docs/platforms/claude-code/troubleshooting.md
+++ b/docs/platforms/claude-code/troubleshooting.md
@@ -201,6 +201,7 @@ After the first download, the model is cached at `~/.cache/huggingface/hub/` and
 |---------|-------|-----|
 | "ERROR: KEY not set" in status | Export the required API key | `export OPENAI_API_KEY="sk-..."` or switch to `onnx` |
 | Search returns no results | `memsearch stats` + manual search | Re-index with `memsearch index .memsearch/memory/ --force` |
+| Recall returns empty from a git subdirectory | Compare collection / launch directory | Launch from repo root or upgrade to a version containing the git-root recall fix |
 | New memories not indexed | Watch process status | Check `.memsearch/.watch.pid`, restart if needed |
 | Skill never triggers automatically | Manual `/memory-recall` test | Ensure prompt >= 10 chars; memsearch in PATH |
 | First session hangs | ONNX model downloading | Pre-download with warmup command |

--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -9,7 +9,9 @@ You are a memory retrieval agent for memsearch. Your job is to search past memor
 
 ## Project Collection
 
-Collection: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh`
+Use the git toplevel when available so the skill targets the same collection as the SessionStart hook, even if Claude Code was launched from a subdirectory.
+
+Collection: !`bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || echo ""); if [ -n "$root" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$root"; else bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh"; fi'`
 
 ## Your Task
 


### PR DESCRIPTION
## Summary
- make the Claude Code `memory-recall` skill derive its collection from the git toplevel when available
- add an inline note explaining that this intentionally matches the SessionStart hook logic

## Why
Closes #324.

The SessionStart hook already resolves the project directory via `git rev-parse --show-toplevel` before deriving the collection name. The `memory-recall` skill was deriving from bare `pwd`, which produced a different collection when Claude Code was launched from a git subdirectory. That made recall search an empty collection even though indexing had succeeded.

## Testing
- validated the skill command now follows the same git-root-first logic described in the issue reproduction
