### PR TITLE
fix: derive memory-recall collection from git root (#324)

### DIFF
--- a/docs/platforms/claude-code/memory-recall.md
+++ b/docs/platforms/claude-code/memory-recall.md
@@ -113,6 +113,12 @@ Manual invocation is useful when:
 
 **Edit memory files directly.** If a summary is inaccurate or contains sensitive information, open `.memsearch/memory/YYYY-MM-DD.md` in your editor and fix it. The watcher will re-index automatically. Memory files are plain markdown -- you're in full control.
 
+**Debug collection mismatches from subdirectories.** If Claude Code is launched from a git subdirectory, derive the collection from the repo root so manual debugging matches the hook and skill behavior:
+```bash
+root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+bash /path/to/plugins/claude-code/scripts/derive-collection.sh "$root"
+```
+
 **Rebuild the index if search quality degrades.** If you change embedding providers or suspect index corruption:
 ```bash
 memsearch index .memsearch/memory/ --force

--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -9,7 +9,7 @@ You are a memory retrieval agent for memsearch. Your job is to search past memor
 
 ## Project Collection
 
-Collection: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh`
+Collection: !`bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$root"; else bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh"; fi'`
 
 ## Your Task
 


### PR DESCRIPTION
## Summary

Fixes #324.

The `memory-recall` skill derived its collection name from `pwd`, while the session-start hook (`common.sh`) derives it from the git repo root. When Claude Code was launched from a subdirectory of a git repo, the two produced different collection names — the hook indexed into one collection while the skill searched an empty one.

## Fix

Mirror the git-root detection logic already used in `common.sh` inside `skills/memory-recall/SKILL.md` so the skill and hook converge on the same collection regardless of the launch directory.

- `plugins/claude-code/skills/memory-recall/SKILL.md` — prefer `git rev-parse --show-toplevel` before falling back to `pwd`
- `docs/platforms/claude-code/memory-recall.md` — add a manual debug snippet so manual collection derivation matches the hook/skill behavior

## Verification

From a git subdirectory, the hook and the fixed skill now produce the same collection name:

```
hook (repo root):            ms_memsearch_85743e23
hook (subdir src/memsearch): ms_memsearch_85743e23
skill fixed (subdir):        ms_memsearch_85743e23  ✓
skill before (subdir):       ms_memsearch_7509cf03  ✗ (empty collection)
```

## Notes

- Scope kept minimal — only the git-root mismatch is fixed here.
- `derive-collection.sh` intentionally untouched so it remains a pure function (given-path → hash); the git-root policy lives in the caller, matching how `common.sh` does it.