### PR TITLE
fix: apply git-root collection fix to codex/opencode; async session-end

### DIFF
--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -41,6 +41,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh",
+            "async": true,
             "timeout": 10
           }
         ]

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -9,7 +9,7 @@ You are performing memory retrieval for memsearch. Search past memories and retu
 
 Determine the collection name by running:
 ```
-bash __INSTALL_DIR__/scripts/derive-collection.sh
+bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi'
 ```
 
 ## Steps

--- a/plugins/opencode/skills/memory-recall/SKILL.md
+++ b/plugins/opencode/skills/memory-recall/SKILL.md
@@ -8,7 +8,7 @@ You are a memory retrieval agent for memsearch. Your job is to search past memor
 
 ## Project Collection
 
-Collection: !`bash __INSTALL_DIR__/scripts/derive-collection.sh`
+Collection: !`bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi'`
 
 ## Your Task
 


### PR DESCRIPTION
## Summary

Two small fixes continuing the work in #330:

1. **Codex / OpenCode plugins had the same git-root bug as #324.** Their `memory-recall` skills called `derive-collection.sh` without arguments (defaults to `pwd`) while the hook/install scripts resolve to the git repo root. Launching from a subdirectory produced mismatched collections and empty searches — exactly the same symptom #324 reported for Claude Code. Mirror the `common.sh`-style git-root detection into both skills so all three plugins converge on the same collection regardless of launch directory.

2. **SessionEnd hook marked `async: true`.** The hook only runs `stop_watch` (kill watch PID + orphan sweep). The user does not need to wait for this cleanup — `pgrep -f` + multiple kills can easily take a few hundred milliseconds. Making SessionEnd async improves perceived exit latency without changing behavior. SessionStart cannot be async because it injects `additionalContext`, but SessionEnd is pure cleanup.

## Changes

- `plugins/codex/skills/memory-recall/SKILL.md` — prefer git root before falling back to pwd
- `plugins/opencode/skills/memory-recall/SKILL.md` — same
- `plugins/claude-code/hooks/hooks.json` — add `"async": true` to SessionEnd

## Notes

- Uses `bash -c` (not `bash -lc`) to avoid loading the user's login shell profile.
- Scope deliberately minimal — one fix per plugin, plus the SessionEnd async toggle. No other changes bundled.