### PR TITLE
fix: harden Codex hooks for current CLI payloads

### DIFF
--- a/docs/platforms/codex/how-it-works.md
+++ b/docs/platforms/codex/how-it-works.md
@@ -16,9 +16,9 @@ The Codex plugin uses 3 shell hooks (Codex does not have a `SessionEnd` hook):
 
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
-| **SessionStart** | command | no | 10s | Cleanup orphans, bootstrap memsearch, start watch/index, write session heading, inject memories, display status |
-| **UserPromptSubmit** | command | no | 15s | Return `systemMessage` hint "[memsearch] Memory available" |
-| **Stop** | command | **yes** | 120s | Parse rollout, summarize via `codex exec`, append to daily `.md`, re-index (Server only) |
+| **SessionStart** | command | no | 30s | Cleanup orphans, bootstrap memsearch, start watch/index, write session heading, inject memories, display status |
+| **UserPromptSubmit** | command | no | 10s | Return `systemMessage` hint "[memsearch] Memory available" |
+| **Stop** | command | **yes** | 30s | Summarize the last turn via `codex exec`, using a rollout transcript when available and `history.jsonl` + `last_assistant_message` otherwise |
 
 ### Hook Lifecycle
 
@@ -93,11 +93,12 @@ graph TD
     B -->|"stop_hook_active=true"| Z[Skip — return empty JSON]
     B -->|First call| C{API key available?}
     C -->|No| Z
-    C -->|Yes| D[Validate rollout file]
-    D -->|"< 3 lines"| Z
-    D -->|Valid| E["parse-rollout.sh<br/>Extract last turn"]
+    C -->|Yes| D{transcript_path available?}
+    D -->|Yes| E["parse-rollout.sh<br/>Extract last turn"]
+    D -->|No| E2["history.jsonl + last_assistant_message<br/>Recover latest user turn"]
     E --> F{"codex exec available?"}
-    F -->|Yes| G["codex exec --ephemeral<br/>-s read-only -m gpt-5.1-codex-mini<br/>(isolated CODEX_HOME)"]
+    E2 --> F
+    F -->|Yes| G["codex exec --ephemeral<br/>-s read-only -c features.codex_hooks=false<br/>-m gpt-5.1-codex-mini"]
     F -->|No| H["Local fallback<br/>Truncate raw text"]
     G --> I["Append to YYYY-MM-DD.md<br/>with rollout anchors"]
     H --> I
@@ -106,22 +107,30 @@ graph TD
     J -->|No (Lite)| L[Skip re-index]
 ```
 
+### Payload Compatibility
+
+Current Codex builds do **not** reliably provide `transcript_path` in the Stop hook payload. On current CLI builds the hook receives `session_id`, `turn_id`, `cwd`, `model`, `permission_mode`, `stop_hook_active`, and `last_assistant_message`, while `transcript_path` may be `null`.
+
+The plugin handles both cases:
+
+- If `transcript_path` exists, it parses the rollout with `parse-rollout.sh` and keeps the richer rollout anchor for L3 drill-down.
+- If `transcript_path` is missing, it falls back to the latest matching user prompt in `~/.codex/history.jsonl` plus `last_assistant_message`.
+
+This keeps memory capture working on current Codex releases, but rollout drill-down is now **best-effort** rather than guaranteed.
+
 ### Codex exec Isolation
 
-The Stop hook calls `codex exec` for LLM summarization. To prevent **hook recursion** (the summarization call triggering another Stop hook), it uses an isolated `CODEX_HOME`:
+The Stop hook calls `codex exec` for LLM summarization. To prevent **hook recursion** (the summarization call triggering another Stop hook), it disables hooks in the child process:
 
 ```bash
-CODEX_ISOLATED="/tmp/codex-no-hooks"
-mkdir -p "$CODEX_ISOLATED"
-# Symlink auth.json for API access, but NO hooks.json → no hooks trigger
-ln -sf "$HOME/.codex/auth.json" "$CODEX_ISOLATED/auth.json"
-
-CODEX_HOME="$CODEX_ISOLATED" MEMSEARCH_NO_WATCH=1 \
+MEMSEARCH_NO_WATCH=1 \
   codex exec --ephemeral --skip-git-repo-check -s read-only \
+  -c features.codex_hooks=false \
+  -c model_reasoning_effort='"low"' \
   -m gpt-5.1-codex-mini "$LLM_PROMPT"
 ```
 
-The isolated `CODEX_HOME` contains only `auth.json` (for API authentication) -- no `hooks.json` means no hooks fire in the child process. The `--ephemeral` flag prevents session state pollution.
+This avoids assuming `~/.codex/auth.json` exists. Installations that authenticate through Codex's default keyring flow still work, and the child `codex exec` cannot recurse because hooks are disabled explicitly.
 
 ### Local Fallback
 
@@ -133,40 +142,59 @@ SUMMARY="- User asked: ${USER_QUESTION}
 - Codex: ${TRUNCATED_MSG}"
 ```
 
-This ensures memory capture works even when the summarization model is unavailable.
+This ensures memory capture works even when the summarization model is unavailable or Codex omits the rollout transcript path.
 
 ---
 
 ## hooks.json Format
 
-Codex CLI uses a `hooks.json` file (at `~/.codex/hooks.json`) to define hook scripts. The installer generates this file with a `matcher` field (required by Codex):
+Codex CLI uses a `hooks.json` file (at `~/.codex/hooks.json`) to define hook scripts. The installer updates the nested `hooks` object, replacing only older memsearch Codex entries and preserving unrelated hooks:
 
 ```json
-[
-  {
-    "event": "SessionStart",
-    "command": "/path/to/plugins/codex/hooks/session-start.sh",
-    "matcher": ".*",
-    "timeout_ms": 10000
-  },
-  {
-    "event": "UserPromptSubmit",
-    "command": "/path/to/plugins/codex/hooks/user-prompt-submit.sh",
-    "matcher": ".*",
-    "timeout_ms": 15000
-  },
-  {
-    "event": "Stop",
-    "command": "/path/to/plugins/codex/hooks/stop.sh",
-    "matcher": ".*",
-    "timeout_ms": 120000,
-    "async": true
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /path/to/plugins/codex/hooks/session-start.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /path/to/plugins/codex/hooks/user-prompt-submit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /path/to/plugins/codex/hooks/stop.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
-]
+}
 ```
 
-!!! note "matcher field"
-    The `matcher` field is required by Codex CLI. Use `".*"` to match all events of the specified type.
+!!! note "Installer behavior"
+    The installer updates the nested `hooks` object in `~/.codex/hooks.json`, replacing only older memsearch Codex hook entries and preserving unrelated hooks.
 
 ---
 
@@ -210,7 +238,7 @@ your-project/.memsearch/memory/
 - Added regression test with emoji and CJK characters
 ```
 
-The `<!-- session:... rollout:... -->` anchors enable L3 drill-down: the memory-recall skill uses `parse-rollout.sh` to read the original Codex conversation when deeper context is needed.
+When the `rollout:` anchor is populated, the memory-recall skill can use `parse-rollout.sh` for L3 drill-down. On current Codex builds the Stop payload may omit `transcript_path`, so some memories keep only the `session:` anchor plus the summarized bullets.
 
 ---
 
@@ -220,11 +248,11 @@ The `<!-- session:... rollout:... -->` anchors enable L3 drill-down: the memory-
 |--------|-------------|-------------------|
 | **SessionEnd hook** | Not available -- orphans cleaned at next SessionStart | Available -- clean shutdown |
 | **Summarizer** | `codex exec -m gpt-5.1-codex-mini` | `claude -p --model haiku` |
-| **Recursion prevention** | Isolated `CODEX_HOME` (no hooks.json) | `stop_hook_active` flag + `CLAUDECODE=` |
+| **Recursion prevention** | `features.codex_hooks=false` on child `codex exec` | `stop_hook_active` flag + `CLAUDECODE=` |
 | **Skill context** | Main context (no `context: fork`) | Forked subagent (`context: fork`) |
 | **Milvus Lite** | One-time index + skip re-index in Stop | Same approach via `start_watch()` logic |
 | **Auto-install** | Bootstrap installs `uv` if missing | Requires pre-installed memsearch |
-| **hooks.json** | Generated by install.sh (requires `matcher`) | Part of plugin manifest |
+| **hooks.json** | Installer updates only memsearch Codex hook entries and preserves unrelated hooks | Part of plugin manifest |
 
 ---
 
@@ -250,8 +278,8 @@ plugins/codex/
 |------|---------|
 | `common.sh` | Shared library sourced by all hooks. Includes JSON helpers (`_json_val`, `_json_encode_str`), memsearch detection, watch/index singleton management, and `cleanup_orphaned_processes()` for Codex's missing SessionEnd. |
 | `session-start.sh` | Bootstrap memsearch, start watch (Server) or one-time index (Lite), write session heading, inject cold-start context, check for updates. |
-| `stop.sh` | Async capture: parse rollout, summarize via `codex exec` with isolated `CODEX_HOME`, append to daily `.md`, re-index (Server only). Falls back to raw text if `codex exec` fails. |
+| `stop.sh` | Async capture: summarize via `codex exec` with hooks disabled, using `parse-rollout.sh` when Codex provides a rollout path and `history.jsonl` + `last_assistant_message` otherwise. Falls back to raw text if `codex exec` fails. |
 | `user-prompt-submit.sh` | Return lightweight `systemMessage` hint about memory availability. |
 | `SKILL.md` | Memory recall skill with `__INSTALL_DIR__` placeholder (resolved at install time). Includes direct file read fallback for L2 in case `memsearch expand` hits sandbox restrictions. |
-| `install.sh` | One-click installer: checks/installs memsearch, copies skill, generates `hooks.json` with `matcher` field, enables experimental hooks feature flag. |
+| `install.sh` | One-click installer: checks/installs memsearch, copies the skill, installs or updates memsearch hook entries in `hooks.json`, and enables the experimental hooks feature flag. |
 | `parse-rollout.sh` | Parses Codex rollout JSONL files, extracting the last user message through EOF with role labels. |

--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -17,12 +17,12 @@ memsearch fills this gap with a shell-hook-based plugin that gives Codex the sam
 
 ---
 
-## `--yolo` Mode and Sandbox
+## Full-Access Mode and Sandbox
 
 Codex CLI runs in a sandboxed environment by default. The memsearch plugin requires file system access to write memory files and run the `memsearch` CLI. The recommended approach:
 
 - **Install option**: The `install.sh` script configures `hooks.json` which works in any mode
-- **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only` with an isolated `CODEX_HOME` to prevent sandbox conflicts during summarization
+- **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only -c features.codex_hooks=false` so summarization reuses normal auth without recursing into hooks
 
 If you experience issues with the Stop hook in strict sandbox mode, see [Troubleshooting](../../platforms/claude-code/troubleshooting.md) for diagnostic steps.
 
@@ -31,7 +31,7 @@ If you experience issues with the Stop hook in strict sandbox mode, see [Trouble
 ## Key Features
 
 - **Automatic capture** -- conversations summarized via `codex exec` using `gpt-5.1-codex-mini` after each turn
-- **Three-layer progressive recall** -- search, expand, and drill into original rollouts ([details](memory-recall.md))
+- **Best-effort rollout drill-down** -- search and expand always work, with original rollout parsing available when Codex includes rollout anchors ([details](memory-recall.md))
 - **Shell hook architecture** -- similar to [Claude Code plugin](../claude-code/index.md), easy to understand and modify
 - **Orphan cleanup** -- handles missing `SessionEnd` hook gracefully (Codex doesn't have one)
 - **Milvus Lite lock handling** -- automatically detects Milvus backend and skips concurrent index operations in Lite mode

--- a/docs/platforms/codex/memory-recall.md
+++ b/docs/platforms/codex/memory-recall.md
@@ -26,7 +26,7 @@ graph TD
     SKILL["$memory-recall skill<br/>(runs in main context)"]
     SKILL --> L1["L1: Search<br/>(memsearch search)"]
     L1 --> L2["L2: Expand<br/>(memsearch expand or direct file read)"]
-    L2 --> L3["L3: Rollout drill-down<br/>(parse-rollout.sh)"]
+    L2 --> L3["L3: Best-effort rollout drill-down<br/>(parse-rollout.sh)"]
     L3 --> RETURN["Curated summary"]
 
     style SKILL fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
@@ -40,7 +40,7 @@ graph TD
 |-------|---------|----------------|-------------|
 | **L1: Search** | `memsearch search "<query>" --top-k 5 --json-output` | Top-K relevant chunk snippets with scores | Always -- the starting point |
 | **L2: Expand** | `memsearch expand <chunk_hash>` (or direct `cat` fallback) | Full markdown section with rollout anchors | When a snippet needs more context |
-| **L3: Rollout** | `bash parse-rollout.sh <rollout_path>` | Original Codex conversation turns | When you need the exact exchange |
+| **L3: Rollout** | `bash parse-rollout.sh <rollout_path>` | Original Codex conversation turns when a rollout anchor exists | When you need the exact exchange and the memory entry includes a rollout path |
 
 ### L2 Fallback: Direct File Read
 
@@ -77,7 +77,10 @@ Score 0.71: "Added cache invalidation via pub/sub channel..."
 - Decided against Memcached due to lack of pub/sub support
 ```
 
-**L3 (optional):** If the summary isn't enough, the skill runs `parse-rollout.sh` to get the original conversation.
+**L3 (optional):** If the summary isn't enough and the memory entry includes a rollout anchor, the skill runs `parse-rollout.sh` to get the original conversation.
+
+!!! note "Current Codex payloads"
+    Current Codex Stop hook payloads may omit `transcript_path`. In those cases memsearch still captures the turn from `history.jsonl` plus `last_assistant_message`, but there is no rollout path to drill into later.
 
 **Result returned to user:** "We implemented a two-layer caching strategy: Redis L1 (5min TTL) + in-process LRU L2 (1000 entries). Cache invalidation uses Redis pub/sub on writes. We chose Redis over Memcached specifically for pub/sub support."
 

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -4,9 +4,16 @@
 
 set -euo pipefail
 
-# Read stdin JSON into $INPUT
-# Use timeout to prevent indefinite blocking when stdin pipe may not close properly
-INPUT="$(timeout 2 cat 2>/dev/null || echo '{}')"
+# Read stdin JSON into $INPUT unless a detached worker asked us to skip it.
+# Use timeout when available; macOS lacks GNU timeout, so fall back to perl
+# alarm(2) instead of a bare cat that can hang indefinitely.
+if [ "${MEMSEARCH_SKIP_HOOK_STDIN:-}" = "1" ]; then
+  INPUT='{}'
+elif command -v timeout &>/dev/null; then
+  INPUT="$(timeout 2 cat 2>/dev/null || echo '{}')"
+else
+  INPUT="$(perl -e 'alarm 2; local $/; $_ = <STDIN>; print if defined' 2>/dev/null || echo '{}')"
+fi
 
 # Ensure common user bin paths are in PATH (hooks may run in a minimal env)
 for p in "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/bin" "/usr/local/bin"; do
@@ -65,27 +72,52 @@ _json_encode_str() {
   return 0
 }
 
-# --- Project directory (from stdin JSON cwd field, fallback to pwd) ---
+# --- Project directory ---
+#
+# Prefer the git root so hooks and the memory-recall skill converge on the
+# same collection even when Codex is launched from a subdirectory.
+if [ -n "${MEMSEARCH_PROJECT_DIR:-}" ] && [ -d "${MEMSEARCH_PROJECT_DIR:-}" ]; then
+  PROJECT_DIR="$MEMSEARCH_PROJECT_DIR"
+else
+  HOOK_CWD=$(_json_val "$INPUT" "cwd" "$(pwd)")
+  if [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+    PROJECT_DIR="$HOOK_CWD"
+  else
+    PROJECT_DIR="$(pwd)"
+  fi
+fi
 
-PROJECT_DIR=$(_json_val "$INPUT" "cwd" "$(pwd)")
+_GIT_ROOT="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [ -n "$_GIT_ROOT" ]; then
+  PROJECT_DIR="$_GIT_ROOT"
+fi
 
 # Memory directory and memsearch state directory are project-scoped
 MEMSEARCH_DIR="${PROJECT_DIR}/.memsearch"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
-# Find memsearch binary: prefer PATH, fallback to uvx
+# Find memsearch binary: prefer PATH, fallback to uvx.
+# Keep the command as an argv array so the uvx fallback is invoked safely.
 _detect_memsearch() {
-  MEMSEARCH_CMD=""
+  MEMSEARCH_CMD=()
   if command -v memsearch &>/dev/null; then
-    MEMSEARCH_CMD="memsearch"
+    MEMSEARCH_CMD=(memsearch)
   elif command -v uvx &>/dev/null; then
-    MEMSEARCH_CMD="uvx --from memsearch[onnx] memsearch"
+    MEMSEARCH_CMD=(uvx --from "memsearch[onnx]" memsearch)
   fi
 }
 _detect_memsearch
 
-# Short command prefix for injected instructions (falls back to "memsearch" even if unavailable)
-MEMSEARCH_CMD_PREFIX="${MEMSEARCH_CMD:-memsearch}"
+memsearch_available() {
+  [ "${#MEMSEARCH_CMD[@]}" -gt 0 ]
+}
+
+_memsearch() {
+  if ! memsearch_available; then
+    return 127
+  fi
+  "${MEMSEARCH_CMD[@]}" "$@"
+}
 
 # Derive per-project collection name from project directory
 COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$PROJECT_DIR" 2>/dev/null || true)
@@ -100,10 +132,10 @@ COLLECTION_DESC=""
 
 # Helper: run memsearch with arguments, silently fail if not available
 run_memsearch() {
-  if [ -n "$MEMSEARCH_CMD" ] && [ -n "$COLLECTION_NAME" ]; then
-    $MEMSEARCH_CMD "$@" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
-  elif [ -n "$MEMSEARCH_CMD" ]; then
-    $MEMSEARCH_CMD "$@" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
+  if memsearch_available && [ -n "$COLLECTION_NAME" ]; then
+    _memsearch "$@" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
+  elif memsearch_available; then
+    _memsearch "$@" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
   fi
 }
 
@@ -185,7 +217,7 @@ start_watch() {
   if [ "${MEMSEARCH_NO_WATCH:-}" = "1" ]; then
     return 0
   fi
-  if [ -z "$MEMSEARCH_CMD" ]; then
+  if ! memsearch_available; then
     return 0
   fi
   ensure_memory_dir
@@ -194,7 +226,7 @@ start_watch() {
   stop_watch
 
   # Detect Milvus backend from URI
-  local _uri="${MILVUS_URI:-$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")}"
+  local _uri="${MILVUS_URI:-$(_memsearch config get milvus.uri 2>/dev/null || echo "")}"
 
   # Lite (local .db): skip watch entirely — file lock prevents concurrent access.
   # Session-start does a one-time index() instead.
@@ -202,14 +234,18 @@ start_watch() {
     return 0
   fi
 
-  # Server (http/tcp): setsid — watch runs persistently for real-time indexing.
-  local launch_prefix="nohup"
-  command -v setsid &>/dev/null && launch_prefix="setsid"
-
   if [ -n "$COLLECTION_NAME" ]; then
-    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    if command -v setsid &>/dev/null; then
+      setsid "${MEMSEARCH_CMD[@]}" watch "$MEMORY_DIR" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    else
+      nohup "${MEMSEARCH_CMD[@]}" watch "$MEMORY_DIR" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    fi
   else
-    $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    if command -v setsid &>/dev/null; then
+      setsid "${MEMSEARCH_CMD[@]}" watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    else
+      nohup "${MEMSEARCH_CMD[@]}" watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
+    fi
   fi
   echo $! > "$WATCH_PIDFILE"
 }

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SessionStart hook: clean up orphans, start watch singleton, inject recent memory context.
-# Codex-specific: handles "source" field (startup/resume/clear), no SessionEnd counterpart.
+# Codex-specific: no SessionEnd counterpart.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
@@ -8,11 +8,8 @@ source "$SCRIPT_DIR/common.sh"
 # Clean up orphaned processes from previous sessions (no SessionEnd in Codex)
 cleanup_orphaned_processes
 
-# Extract session source (startup/resume/clear) — Codex-specific field
-SESSION_SOURCE=$(_json_val "$INPUT" "source" "startup")
-
 # Bootstrap: if memsearch not available, install uv and warm up uvx cache
-if [ -z "$MEMSEARCH_CMD" ]; then
+if ! memsearch_available; then
   if ! command -v uvx &>/dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null
     export PATH="$HOME/.local/bin:$PATH"
@@ -23,20 +20,20 @@ if [ -z "$MEMSEARCH_CMD" ]; then
 fi
 
 # First-time setup: if no config file exists, default to onnx provider.
-if [ -n "$MEMSEARCH_CMD" ]; then
+if memsearch_available; then
   if [ ! -f "$HOME/.memsearch/config.toml" ] && [ ! -f "${PROJECT_DIR}/.memsearch.toml" ]; then
-    $MEMSEARCH_CMD config set embedding.provider onnx 2>/dev/null || true
+    _memsearch config set embedding.provider onnx 2>/dev/null || true
   fi
 fi
 
 # Read resolved config and version for status display
 PROVIDER="onnx"; MODEL=""; MILVUS_URI=""; VERSION=""
-if [ -n "$MEMSEARCH_CMD" ]; then
-  PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "onnx")
-  MODEL=$($MEMSEARCH_CMD config get embedding.model 2>/dev/null || echo "")
-  MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")
+if memsearch_available; then
+  PROVIDER=$(_memsearch config get embedding.provider 2>/dev/null || echo "onnx")
+  MODEL=$(_memsearch config get embedding.model 2>/dev/null || echo "")
+  MILVUS_URI=$(_memsearch config get milvus.uri 2>/dev/null || echo "")
   # "memsearch, version 0.1.10" → "0.1.10"
-  VERSION=$($MEMSEARCH_CMD --version 2>/dev/null | sed 's/.*version //' || echo "")
+  VERSION=$(_memsearch --version 2>/dev/null | sed 's/.*version //' || echo "")
 fi
 
 # Determine required API key for the configured provider
@@ -54,8 +51,8 @@ KEY_MISSING=false
 if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
   # Env var not set — check if API key is configured in memsearch config file
   CONFIG_API_KEY=""
-  if [ -n "$MEMSEARCH_CMD" ]; then
-    CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
+  if memsearch_available; then
+    CONFIG_API_KEY=$(_memsearch config get embedding.api_key 2>/dev/null || echo "")
   fi
   if [ -z "$CONFIG_API_KEY" ]; then
     KEY_MISSING=true
@@ -69,7 +66,7 @@ if [ -n "$VERSION" ]; then
   LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
     # Detect install method to suggest the right upgrade command
-    if [[ "$MEMSEARCH_CMD" == *"uvx"* ]]; then
+    if [ "${MEMSEARCH_CMD[0]:-}" = "uvx" ]; then
       UPGRADE_CMD="uvx --upgrade --from 'memsearch[onnx]' memsearch --version"
     else
       _MS_PATH=$(command -v memsearch 2>/dev/null || true)
@@ -102,6 +99,10 @@ fi
 PROJECT_BASENAME=$(basename "$PROJECT_DIR")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
+# Capture preexisting memory files before writing the new session heading.
+EXISTING_MEMORY_FILES=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort || true)
+EXISTING_MEMORY_COUNT=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | sed '/^$/d' | wc -l | tr -d ' ')
+
 # Write session heading to today's memory file
 ensure_memory_dir
 TODAY=$(date +%Y-%m-%d)
@@ -129,12 +130,12 @@ if [[ "$MILVUS_URI" != http* ]] && [[ "$MILVUS_URI" != tcp* ]]; then
     _index_args=("$MEMORY_DIR")
     [ -n "$COLLECTION_NAME" ] && _index_args+=(--collection "$COLLECTION_NAME")
     [ -n "$COLLECTION_DESC" ] && _index_args+=(--description "$COLLECTION_DESC")
-    INDEX_OUTPUT=$($MEMSEARCH_CMD index "${_index_args[@]}" 2>&1) || true
+    INDEX_OUTPUT=$(_memsearch index "${_index_args[@]}" 2>&1) || true
     if echo "$INDEX_OUTPUT" | grep -q "dimension mismatch"; then
       _reset_args=(--yes)
       [ -n "$COLLECTION_NAME" ] && _reset_args+=(--collection "$COLLECTION_NAME")
-      $MEMSEARCH_CMD reset "${_reset_args[@]}" 2>/dev/null || true
-      $MEMSEARCH_CMD index "${_index_args[@]}" 2>/dev/null || true
+      _memsearch reset "${_reset_args[@]}" 2>/dev/null || true
+      _memsearch index "${_index_args[@]}" 2>/dev/null || true
     fi
   ) >/dev/null 2>&1 &
   echo $! > "$INDEX_PIDFILE"
@@ -151,13 +152,14 @@ fi
 
 context=""
 
-# Count memory entries for the hint
-memory_count=$(ls -1 "$MEMORY_DIR"/*.md 2>/dev/null | wc -l)
-if [ "$memory_count" -gt 0 ]; then
-  # Get date range of memory files
-  oldest=$(ls -1 "$MEMORY_DIR"/*.md 2>/dev/null | sort | head -1 | xargs basename .md 2>/dev/null | sed 's/\.md//')
-  newest=$(ls -1 "$MEMORY_DIR"/*.md 2>/dev/null | sort -r | head -1 | xargs basename .md 2>/dev/null | sed 's/\.md//')
-  context="You have ${memory_count} past memory file(s) (${oldest} to ${newest}). Use \$memory-recall to search when the user's question could benefit from historical context."
+# Count only preexisting memory entries for the hint.
+# Do not treat the just-created session heading as past memory.
+if [ "$EXISTING_MEMORY_COUNT" -gt 0 ]; then
+  oldest_path=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | sed -n '1p')
+  newest_path=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | tail -1)
+  oldest=$(basename "$oldest_path" .md 2>/dev/null || true)
+  newest=$(basename "$newest_path" .md 2>/dev/null || true)
+  context="You have ${EXISTING_MEMORY_COUNT} past memory file(s) (${oldest} to ${newest}). Use \$memory-recall to search when the user's question could benefit from historical context."
 fi
 
 if [ -n "$context" ]; then

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
 # Stop hook: extract last turn context, summarize with codex exec LLM, save to memory.
-# Uses isolated CODEX_HOME (no hooks.json) to prevent hook recursion.
-# Async: outputs {} immediately, runs summarization in background.
+# Uses the normal CODEX_HOME auth context with hooks disabled to prevent recursion.
+# Async: outputs {} immediately, then hands work to a detached worker.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/common.sh"
 
-# Prevent infinite loop: if this Stop was triggered by a previous Stop hook, bail out
-STOP_HOOK_ACTIVE=$(_json_val "$INPUT" "stop_hook_active" "false")
-if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
-  echo '{}'
-  exit 0
-fi
-
-# Skip summarization when the required API key is missing
 _required_env_var() {
   case "$1" in
     openai) echo "OPENAI_API_KEY" ;;
@@ -22,104 +13,73 @@ _required_env_var() {
     *) echo "" ;;  # onnx, ollama, local — no API key needed
   esac
 }
-_PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "onnx")
-_REQ_KEY=$(_required_env_var "$_PROVIDER")
-if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
-  _CONFIG_API_KEY=""
-  if [ -n "$MEMSEARCH_CMD" ]; then
-    _CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
+
+_latest_user_prompt_from_history() {
+  local session_id="$1"
+  local history_file="${CODEX_HOME:-$HOME/.codex}/history.jsonl"
+  if [ -z "$session_id" ] || [ ! -f "$history_file" ]; then
+    return 0
   fi
-  if [ -z "$_CONFIG_API_KEY" ]; then
-    echo '{}'
-    exit 0
-  fi
-fi
 
-# Extract transcript path from hook input
-TRANSCRIPT_PATH=$(_json_val "$INPUT" "transcript_path" "")
-
-if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
-  echo '{}'
-  exit 0
-fi
-
-# Check if transcript is empty (< 3 lines = no real content)
-LINE_COUNT=$(wc -l < "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
-if [ "$LINE_COUNT" -lt 3 ]; then
-  echo '{}'
-  exit 0
-fi
-
-ensure_memory_dir
-
-# Determine today's date and current time
-TODAY=$(date +%Y-%m-%d)
-NOW=$(date +%H:%M)
-MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
-
-# Extract session ID for progressive disclosure anchors
-SESSION_ID=$(_json_val "$INPUT" "session_id" "")
-if [ -z "$SESSION_ID" ]; then
-  SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl | sed 's/^rollout-//')
-fi
-
-# Extract user question and last assistant message before going async
-LAST_MSG=$(_json_val "$INPUT" "last_assistant_message" "")
-
-USER_QUESTION=$(python3 -c "
+  python3 -c "
 import json, sys
-last_q = ''
-with open(sys.argv[1]) as f:
+session_id = sys.argv[1]
+history_file = sys.argv[2]
+latest = ''
+with open(history_file) as f:
     for line in f:
         try:
             obj = json.loads(line)
-            if obj.get('type') == 'event_msg':
-                p = obj.get('payload', {})
-                if p.get('type') == 'user_message':
-                    msg = p.get('message', '').strip()
-                    if msg:
-                        last_q = msg
-        except:
+            if obj.get('session_id') == session_id:
+                text = (obj.get('text') or '').strip()
+                if text:
+                    latest = text
+        except Exception:
             pass
-# Truncate to first line, max 200 chars
-first_line = last_q.split('\n')[0][:200] if last_q else ''
-print(first_line)
-" "$TRANSCRIPT_PATH" 2>/dev/null || true)
+print(latest)
+" "$session_id" "$history_file" 2>/dev/null || true
+}
 
-# Return immediately — summarization runs in background
-echo '{}'
+_load_worker_field() {
+  local work_input="$1"
+  local key="$2"
+  _json_val "$work_input" "$key" ""
+}
 
-# --- Background: summarize with codex exec LLM, fallback to local, write to memory ---
-(
-  # Build content for LLM summarization from parsed rollout
-  CONTENT=""
-  PARSED=$("$SCRIPT_DIR/../scripts/parse-rollout.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)
-
-  if [ -n "$PARSED" ] && [ "$PARSED" != "(empty rollout)" ] && [ "$PARSED" != "(no user message found)" ] && [ "$PARSED" != "(empty turn)" ]; then
-    CONTENT="$PARSED"
-  elif [ -n "$LAST_MSG" ] && [ -n "$USER_QUESTION" ]; then
-    CONTENT="[Human]: ${USER_QUESTION}
-[Codex]: ${LAST_MSG}"
-  elif [ -n "$LAST_MSG" ]; then
-    CONTENT="[Codex]: ${LAST_MSG}"
-  else
-    # No content to summarize
+run_worker() {
+  local work_file="${1:-}"
+  if [ -z "$work_file" ] || [ ! -f "$work_file" ]; then
     exit 0
   fi
 
-  # Truncate content to ~4000 chars for the LLM prompt
-  if [ ${#CONTENT} -gt 4000 ]; then
-    CONTENT="${CONTENT:0:4000}...(truncated)"
+  export MEMSEARCH_SKIP_HOOK_STDIN=1
+  source "$SCRIPT_DIR/common.sh"
+
+  local work_input
+  work_input=$(cat "$work_file" 2>/dev/null || echo "")
+  rm -f "$work_file"
+  if [ -z "$work_input" ]; then
+    exit 0
   fi
 
-  # Try LLM summarization via codex exec with isolated CODEX_HOME
-  SUMMARY=""
-  if command -v codex &>/dev/null; then
-    # Create isolated CODEX_HOME — no hooks.json means no hooks trigger (no recursion)
-    CODEX_ISOLATED="/tmp/codex-no-hooks"
-    mkdir -p "$CODEX_ISOLATED"
-    [ -f "$HOME/.codex/auth.json" ] && ln -sf "$HOME/.codex/auth.json" "$CODEX_ISOLATED/auth.json"
+  local NOW MEMORY_FILE SESSION_ID TRANSCRIPT_PATH CONTENT USER_QUESTION LAST_MSG
+  NOW=$(_load_worker_field "$work_input" "now")
+  MEMORY_FILE=$(_load_worker_field "$work_input" "memory_file")
+  SESSION_ID=$(_load_worker_field "$work_input" "session_id")
+  TRANSCRIPT_PATH=$(_load_worker_field "$work_input" "transcript_path")
+  CONTENT=$(_load_worker_field "$work_input" "content")
+  USER_QUESTION=$(_load_worker_field "$work_input" "user_question")
+  LAST_MSG=$(_load_worker_field "$work_input" "last_msg")
 
+  if [ -z "$MEMORY_FILE" ] || [ -z "$CONTENT" ]; then
+    exit 0
+  fi
+
+  ensure_memory_dir
+
+  local SUMMARY=""
+  if command -v codex &>/dev/null; then
+    local LLM_PROMPT
     LLM_PROMPT="You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and Codex CLI. Tool calls are labeled [Codex calls tool] and their results [Tool output].
 
 Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT Codex, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
@@ -139,17 +99,30 @@ Here is the transcript:
 
 ${CONTENT}"
 
-    SUMMARY=$(CODEX_HOME="$CODEX_ISOLATED" MEMSEARCH_NO_WATCH=1 timeout 30 codex exec \
-      --ephemeral \
-      --skip-git-repo-check \
-      -s read-only \
-      -m gpt-5.1-codex-mini \
-      "$LLM_PROMPT" 2>/dev/null || true)
+    if command -v timeout &>/dev/null; then
+      SUMMARY=$(MEMSEARCH_NO_WATCH=1 timeout 30 codex exec \
+        --ephemeral \
+        --skip-git-repo-check \
+        -s read-only \
+        -c features.codex_hooks=false \
+        -c model_reasoning_effort='"low"' \
+        -m gpt-5.1-codex-mini \
+        "$LLM_PROMPT" 2>/dev/null || true)
+    else
+      SUMMARY=$(MEMSEARCH_NO_WATCH=1 codex exec \
+        --ephemeral \
+        --skip-git-repo-check \
+        -s read-only \
+        -c features.codex_hooks=false \
+        -c model_reasoning_effort='"low"' \
+        -m gpt-5.1-codex-mini \
+        "$LLM_PROMPT" 2>/dev/null || true)
+    fi
   fi
 
-  # Fallback: local summarization if codex exec failed or returned empty
   if [ -z "$SUMMARY" ]; then
     if [ -n "$LAST_MSG" ] && [ -n "$USER_QUESTION" ]; then
+      local TRUNCATED_MSG
       TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | head -c 800)
       if [ ${#LAST_MSG} -gt 800 ]; then
         TRUNCATED_MSG="${TRUNCATED_MSG}..."
@@ -157,6 +130,7 @@ ${CONTENT}"
       SUMMARY="- User asked: ${USER_QUESTION}
 - Codex: ${TRUNCATED_MSG}"
     elif [ -n "$LAST_MSG" ]; then
+      local TRUNCATED_MSG
       TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | head -c 800)
       if [ ${#LAST_MSG} -gt 800 ]; then
         TRUNCATED_MSG="${TRUNCATED_MSG}..."
@@ -167,8 +141,6 @@ ${CONTENT}"
     fi
   fi
 
-  # Append as a sub-heading under the session heading written by SessionStart
-  # Include HTML comment anchor for progressive disclosure (L3 rollout lookup)
   {
     echo "### $NOW"
     if [ -n "$SESSION_ID" ]; then
@@ -178,10 +150,139 @@ ${CONTENT}"
     echo ""
   } >> "$MEMORY_FILE"
 
-  # Only index in stop hook for Server mode — Milvus Lite has file lock issues
-  _uri="${MILVUS_URI:-$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")}"
+  local _uri
+  _uri="${MILVUS_URI:-$(_memsearch config get milvus.uri 2>/dev/null || echo "")}"
   if [[ "$_uri" == http* ]] || [[ "$_uri" == tcp* ]]; then
     kill_orphaned_index
     run_memsearch index "$MEMORY_DIR" >/dev/null
   fi
-) >/dev/null 2>&1 &
+}
+
+if [ "${1:-}" = "--worker" ]; then
+  run_worker "${2:-}"
+  exit 0
+fi
+
+source "$SCRIPT_DIR/common.sh"
+
+# Prevent infinite loop: if this Stop was triggered by a previous Stop hook, bail out
+STOP_HOOK_ACTIVE=$(_json_val "$INPUT" "stop_hook_active" "false")
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Skip summarization when the required API key is missing
+_PROVIDER=$(_memsearch config get embedding.provider 2>/dev/null || echo "onnx")
+_REQ_KEY=$(_required_env_var "$_PROVIDER")
+if [ -n "$_REQ_KEY" ] && [ -z "${!_REQ_KEY:-}" ]; then
+  _CONFIG_API_KEY=""
+  if memsearch_available; then
+    _CONFIG_API_KEY=$(_memsearch config get embedding.api_key 2>/dev/null || echo "")
+  fi
+  if [ -z "$_CONFIG_API_KEY" ]; then
+    echo '{}'
+    exit 0
+  fi
+fi
+
+# Extract transcript path from hook input
+TRANSCRIPT_PATH=$(_json_val "$INPUT" "transcript_path" "")
+
+ensure_memory_dir
+
+# Determine today's date and current time
+TODAY=$(date +%Y-%m-%d)
+NOW=$(date +%H:%M)
+MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
+
+# Extract session ID for progressive disclosure anchors
+SESSION_ID=$(_json_val "$INPUT" "session_id" "")
+if [ -z "$SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ]; then
+  SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl | sed 's/^rollout-//')
+fi
+
+# Extract user question and last assistant message before going async
+LAST_MSG=$(_json_val "$INPUT" "last_assistant_message" "")
+USER_QUESTION=""
+PARSED=""
+
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  LINE_COUNT=$(wc -l < "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+  if [ "$LINE_COUNT" -lt 3 ]; then
+    echo '{}'
+    exit 0
+  fi
+
+  USER_QUESTION=$(python3 -c "
+import json, sys
+last_q = ''
+with open(sys.argv[1]) as f:
+    for line in f:
+        try:
+            obj = json.loads(line)
+            if obj.get('type') == 'event_msg':
+                p = obj.get('payload', {})
+                if p.get('type') == 'user_message':
+                    msg = p.get('message', '').strip()
+                    if msg:
+                        last_q = msg
+        except:
+            pass
+# Truncate to first line, max 200 chars
+first_line = last_q.split('\n')[0][:200] if last_q else ''
+print(first_line)
+" "$TRANSCRIPT_PATH" 2>/dev/null || true)
+
+  # Parse the last turn before returning. Codex may clean up transient rollout
+  # files as soon as the hook completes, so the detached worker should work
+  # from cached content instead of reopening the transcript path later.
+  PARSED=$("$SCRIPT_DIR/../scripts/parse-rollout.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)
+fi
+
+if [ -z "$USER_QUESTION" ]; then
+  USER_QUESTION=$(_latest_user_prompt_from_history "$SESSION_ID")
+fi
+
+CONTENT=""
+if [ -n "$PARSED" ] && [ "$PARSED" != "(empty rollout)" ] && [ "$PARSED" != "(no user message found)" ] && [ "$PARSED" != "(empty turn)" ]; then
+  CONTENT="$PARSED"
+elif [ -n "$LAST_MSG" ] && [ -n "$USER_QUESTION" ]; then
+  CONTENT="[Human]: ${USER_QUESTION}
+[Codex]: ${LAST_MSG}"
+elif [ -n "$LAST_MSG" ]; then
+  CONTENT="[Codex]: ${LAST_MSG}"
+else
+  echo '{}'
+  exit 0
+fi
+
+if [ ${#CONTENT} -gt 4000 ]; then
+  CONTENT="${CONTENT:0:4000}...(truncated)"
+fi
+
+WORK_FILE="$(mktemp "${TMPDIR:-/tmp}/memsearch-stop.XXXXXX.json")"
+python3 - "$WORK_FILE" "$NOW" "$MEMORY_FILE" "$SESSION_ID" "$TRANSCRIPT_PATH" "$CONTENT" "$USER_QUESTION" "$LAST_MSG" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+payload = {
+    "now": sys.argv[2],
+    "memory_file": sys.argv[3],
+    "session_id": sys.argv[4],
+    "transcript_path": sys.argv[5],
+    "content": sys.argv[6],
+    "user_question": sys.argv[7],
+    "last_msg": sys.argv[8],
+}
+Path(sys.argv[1]).write_text(json.dumps(payload))
+PY
+
+echo '{}'
+
+if command -v setsid &>/dev/null; then
+  MEMSEARCH_PROJECT_DIR="$PROJECT_DIR" MEMSEARCH_SKIP_HOOK_STDIN=1 setsid bash "$0" --worker "$WORK_FILE" </dev/null &>/dev/null &
+else
+  MEMSEARCH_PROJECT_DIR="$PROJECT_DIR" MEMSEARCH_SKIP_HOOK_STDIN=1 nohup bash "$0" --worker "$WORK_FILE" </dev/null &>/dev/null &
+fi

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -100,7 +100,7 @@ Here is the transcript:
 ${CONTENT}"
 
     if command -v timeout &>/dev/null; then
-      SUMMARY=$(MEMSEARCH_NO_WATCH=1 timeout 30 codex exec \
+      SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_IN_STOP_WORKER=1 timeout 30 codex exec \
         --ephemeral \
         --skip-git-repo-check \
         -s read-only \
@@ -109,7 +109,7 @@ ${CONTENT}"
         -m gpt-5.1-codex-mini \
         "$LLM_PROMPT" 2>/dev/null || true)
     else
-      SUMMARY=$(MEMSEARCH_NO_WATCH=1 codex exec \
+      SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_IN_STOP_WORKER=1 codex exec \
         --ephemeral \
         --skip-git-repo-check \
         -s read-only \
@@ -165,6 +165,15 @@ fi
 
 source "$SCRIPT_DIR/common.sh"
 
+# Defense-in-depth against recursion: the worker's `codex exec` passes
+# `features.codex_hooks=false`, but if a future build ignores that flag the
+# nested Stop hook would spawn another worker. MEMSEARCH_IN_STOP_WORKER is
+# exported across the exec boundary so the nested invocation no-ops here.
+if [ -n "${MEMSEARCH_IN_STOP_WORKER:-}" ]; then
+  echo '{}'
+  exit 0
+fi
+
 # Prevent infinite loop: if this Stop was triggered by a previous Stop hook, bail out
 STOP_HOOK_ACTIVE=$(_json_val "$INPUT" "stop_hook_active" "false")
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
@@ -204,6 +213,12 @@ fi
 
 # Extract user question and last assistant message before going async
 LAST_MSG=$(_json_val "$INPUT" "last_assistant_message" "")
+# Cap before it flows into sys.argv of the work-file Python payload.
+# Unbounded transcripts risk ARG_MAX overflow on execve; the worker only
+# ever uses the first 800 chars of LAST_MSG as a fallback summary anyway.
+if [ ${#LAST_MSG} -gt 4000 ]; then
+  LAST_MSG="${LAST_MSG:0:4000}...(truncated)"
+fi
 USER_QUESTION=""
 PARSED=""
 

--- a/plugins/codex/hooks/user-prompt-submit.sh
+++ b/plugins/codex/hooks/user-prompt-submit.sh
@@ -13,7 +13,7 @@ if [ -z "$PROMPT" ] || [ "${#PROMPT}" -lt 10 ]; then
 fi
 
 # Need memsearch available
-if [ -z "$MEMSEARCH_CMD" ]; then
+if ! memsearch_available; then
   echo '{}'
   exit 0
 fi


### PR DESCRIPTION
## Summary
- align the Codex hook runtime with git-root collection selection and a safe `uvx --from memsearch[onnx] memsearch` fallback
- stop counting the just-created session file as historical memory on `SessionStart`
- make Stop capture work on current Codex builds where `transcript_path` may be `null`
- detach Stop capture into a worker process so memory writing survives hook teardown
- refresh the Codex docs to describe current hook payloads and best-effort rollout drill-down

## Root cause
The existing Codex hooks assumed an older Stop payload shape that always provided `transcript_path`, relied on shell-split command strings for the `uvx` fallback, and mixed `cwd`-based and git-root-based collection resolution. On current Codex CLI builds that combination can silently drop Stop summaries and split collections when launched from a subdirectory.

## Testing
- [x] `bash -n plugins/codex/hooks/common.sh plugins/codex/hooks/session-start.sh plugins/codex/hooks/stop.sh plugins/codex/hooks/user-prompt-submit.sh plugins/codex/scripts/parse-rollout.sh`
- [x] `shellcheck` on the same scripts (only expected `SC1091` sourced-file info remains)
- [x] Invoked `session-start.sh` from a git subdirectory and confirmed `.memsearch/` resolves at the repo root
- [x] Ran a real `codex exec ... \"Reply with exactly ok.\"` session and confirmed `.memsearch/memory/YYYY-MM-DD.md` gets a Stop entry on current Codex
- [x] Ran `stop.sh` against synthetic transcript-backed payloads and confirmed capture still works when a rollout path is available