### PR TITLE
feat: expose max_chunk_size in index and watch CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,6 +223,7 @@ Scan one or more directories (or files) and index all markdown files (`.md`, `.m
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token (for server or Zilliz Cloud) |
+| `--max-chunk-size` | | config value | Override `chunking.max_chunk_size` for this run |
 | `--force` | | `false` | Re-embed and re-index all chunks, even if unchanged |
 
 ### Examples
@@ -363,6 +364,7 @@ Start a long-running file watcher that monitors directories for markdown file ch
 | `--collection` | `-c` | `memsearch_chunks` | Milvus collection name |
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
+| `--max-chunk-size` | | config value | Override `chunking.max_chunk_size` for this run |
 
 ### Examples
 

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -123,6 +123,7 @@ def cli() -> None:
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--force", is_flag=True, help="Re-index all files.")
+@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def index(
     paths: tuple[str, ...],
@@ -135,6 +136,7 @@ def index(
     milvus_uri: str | None,
     milvus_token: str | None,
     force: bool,
+    max_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Index markdown files from PATHS."""
@@ -150,6 +152,7 @@ def index(
             collection=collection,
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
+            max_chunk_size=max_chunk_size,
         )
     )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
@@ -405,6 +408,7 @@ def _extract_section(
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--debounce-ms", default=None, type=int, help="Debounce delay in ms.")
+@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def watch(
     paths: tuple[str, ...],
@@ -417,6 +421,7 @@ def watch(
     milvus_uri: str | None,
     milvus_token: str | None,
     debounce_ms: int | None,
+    max_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Watch PATHS for markdown changes and auto-index."""
@@ -433,6 +438,7 @@ def watch(
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
             debounce_ms=debounce_ms,
+            max_chunk_size=max_chunk_size,
         )
     )
     ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -123,7 +123,9 @@ def cli() -> None:
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--force", is_flag=True, help="Re-index all files.")
-@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
+@click.option(
+    "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
+)
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def index(
     paths: tuple[str, ...],
@@ -408,7 +410,9 @@ def _extract_section(
 @click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
 @_common_options
 @click.option("--debounce-ms", default=None, type=int, help="Debounce delay in ms.")
-@click.option("--max-chunk-size", default=None, type=int, help="Max chunk size in characters.")
+@click.option(
+    "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
+)
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def watch(
     paths: tuple[str, ...],

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -34,3 +34,12 @@ def test_cli_help_and_version_commands(args: list[str], expected_text: str) -> N
 
     assert result.exit_code == 0
     assert expected_text in result.output
+
+
+@pytest.mark.parametrize("args", [["index", "--help"], ["watch", "--help"]])
+def test_chunk_size_flag_appears_in_help(args: list[str]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == 0
+    assert "--max-chunk-size" in result.output


### PR DESCRIPTION
## Summary
- add `--max-chunk-size` to `memsearch index` and `memsearch watch`
- document the new flag in the CLI reference for both commands
- add a CLI help regression test so the option stays exposed

Supersedes closed PR #295.

## Test plan
- [x] `uv run pytest`
- [x] `uv run python -m memsearch index --help`
- [x] `uv run python -m memsearch watch --help`