### PR TITLE
fix: show user-facing CLI errors for config and Milvus

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -21,10 +21,24 @@ from .config import (
     set_config_value,
 )
 
+try:
+    from pymilvus.exceptions import MilvusException
+except ImportError:
+    MilvusException = Exception
+
 
 def _run(coro):
     """Run an async coroutine synchronously."""
     return asyncio.run(coro)
+
+
+def _safe_resolve_config(overrides: dict | None = None):
+    """Resolve config with user-friendly error for missing env vars."""
+    try:
+        return resolve_config(overrides)
+    except KeyError as e:
+        click.echo(f"Configuration error: {e}", err=True)
+        raise SystemExit(1) from None
 
 
 # -- CLI param name → dotted config key mapping --
@@ -140,7 +154,7 @@ def index(
     """Index markdown files from PATHS."""
     from .core import MemSearch
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
             model=model,
@@ -152,12 +166,17 @@ def index(
             milvus_token=milvus_token,
         )
     )
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
+    ms = None
     try:
+        ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
         n = _run(ms.index(force=force))
         click.echo(f"Indexed {n} chunks.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -190,7 +209,7 @@ def search(
     """Search indexed memory for QUERY."""
     from .core import MemSearch
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
             model=model,
@@ -203,8 +222,9 @@ def search(
             reranker_model=reranker_model,
         )
     )
-    ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
+    ms = None
     try:
+        ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
         results = _run(ms.search(query, top_k=top_k or 5, source_prefix=source_prefix))
         if json_output:
             click.echo(json.dumps(results, indent=2, ensure_ascii=False))
@@ -227,8 +247,12 @@ def search(
                     click.echo(f"  ... [truncated, run 'memsearch expand {chunk_hash}' for full content]")
                 else:
                     click.echo(content)
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 # ======================================================================
@@ -273,7 +297,7 @@ def expand(
     """
     from .store import MilvusStore
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
             model=model,
@@ -285,13 +309,14 @@ def expand(
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         chunks = store.query(filter_expr=f'chunk_hash == "{chunk_hash}"')
         if not chunks:
             click.echo(f"Chunk not found: {chunk_hash}", err=True)
@@ -361,8 +386,12 @@ def expand(
                 click.echo(f"Session: {anchor['session']}  Turn: {anchor['turn']}")
                 click.echo(f"Transcript: {anchor['transcript']}")
             click.echo(f"\n{expanded}")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 def _extract_section(
@@ -422,7 +451,7 @@ def watch(
     """Watch PATHS for markdown changes and auto-index."""
     from .core import MemSearch
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
             model=model,
@@ -435,28 +464,35 @@ def watch(
             debounce_ms=debounce_ms,
         )
     )
-    ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
-
-    # Initial index: ensure existing files are indexed before watching
-    n = _run(ms.index())
-    if n:
-        click.echo(f"Indexed {n} chunks.")
-
-    def _on_event(event_type: str, summary: str, file_path) -> None:
-        click.echo(summary)
-
-    click.echo(f"Watching {len(paths)} path(s) for changes... (Ctrl+C to stop)")
-    watcher = ms.watch(on_event=_on_event, debounce_ms=cfg.watch.debounce_ms)
+    ms = None
+    watcher = None
     try:
+        ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
+
+        # Initial index: ensure existing files are indexed before watching
+        n = _run(ms.index())
+        if n:
+            click.echo(f"Indexed {n} chunks.")
+
+        def _on_event(event_type: str, summary: str, file_path) -> None:
+            click.echo(summary)
+
+        click.echo(f"Watching {len(paths)} path(s) for changes... (Ctrl+C to stop)")
+        watcher = ms.watch(on_event=_on_event, debounce_ms=cfg.watch.debounce_ms)
         while True:
             import time
 
             time.sleep(1)
     except KeyboardInterrupt:
         click.echo("\nStopping watcher.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        watcher.stop()
-        ms.close()
+        if watcher is not None:
+            watcher.stop()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -492,7 +528,7 @@ def compact(
     """Compress stored memories into a summary."""
     from .core import MemSearch
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
             model=model,
@@ -516,8 +552,9 @@ def compact(
 
     normalized_source = _normalize_compact_source(source)
 
-    ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
+    ms = None
     try:
+        ms = MemSearch(**_cfg_to_memsearch_kwargs(cfg))
         summary = _run(
             ms.compact(
                 source=normalized_source,
@@ -536,8 +573,12 @@ def compact(
             click.echo(f"No chunks matched source: {normalized_source}")
         else:
             click.echo("No chunks to compact.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        ms.close()
+        if ms is not None:
+            ms.close()
 
 
 @cli.command()
@@ -552,24 +593,29 @@ def stats(
     """Show statistics about the index."""
     from .store import MilvusStore
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             collection=collection,
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         count = store.count()
         click.echo(f"Total indexed chunks: {count}")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 @cli.command()
@@ -585,24 +631,29 @@ def reset(
     """Drop all indexed data."""
     from .store import MilvusStore
 
-    cfg = resolve_config(
+    cfg = _safe_resolve_config(
         _build_cli_overrides(
             collection=collection,
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
         )
     )
-    store = MilvusStore(
-        uri=cfg.milvus.uri,
-        token=cfg.milvus.token or None,
-        collection=cfg.milvus.collection,
-        dimension=None,
-    )
+    store = None
     try:
+        store = MilvusStore(
+            uri=cfg.milvus.uri,
+            token=cfg.milvus.token or None,
+            collection=cfg.milvus.collection,
+            dimension=None,
+        )
         store.drop()
         click.echo("Dropped collection.")
+    except MilvusException as e:
+        click.echo(f"Milvus error: {e}", err=True)
+        raise SystemExit(1) from None
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
 
 # ======================================================================

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -12,6 +12,7 @@ import click
 from .config import (
     GLOBAL_CONFIG_PATH,
     PROJECT_CONFIG_PATH,
+    ConfigEnvVarError,
     MemSearchConfig,
     config_to_dict,
     get_config_value,
@@ -36,7 +37,7 @@ def _safe_resolve_config(overrides: dict | None = None):
     """Resolve config with user-friendly error for missing env vars."""
     try:
         return resolve_config(overrides)
-    except KeyError as e:
+    except ConfigEnvVarError as e:
         click.echo(f"Configuration error: {e}", err=True)
         raise SystemExit(1) from None
 
@@ -172,7 +173,7 @@ def index(
         n = _run(ms.index(force=force))
         click.echo(f"Indexed {n} chunks.")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if ms is not None:
@@ -248,7 +249,7 @@ def search(
                 else:
                     click.echo(content)
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if ms is not None:
@@ -387,7 +388,7 @@ def expand(
                 click.echo(f"Transcript: {anchor['transcript']}")
             click.echo(f"\n{expanded}")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if store is not None:
@@ -486,7 +487,7 @@ def watch(
     except KeyboardInterrupt:
         click.echo("\nStopping watcher.")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if watcher is not None:
@@ -574,7 +575,7 @@ def compact(
         else:
             click.echo("No chunks to compact.")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if ms is not None:
@@ -611,7 +612,7 @@ def stats(
         count = store.count()
         click.echo(f"Total indexed chunks: {count}")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if store is not None:
@@ -649,7 +650,7 @@ def reset(
         store.drop()
         click.echo("Dropped collection.")
     except MilvusException as e:
-        click.echo(f"Milvus error: {e}", err=True)
+        click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
     finally:
         if store is not None:

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -94,19 +94,29 @@ _SECTION_CLASSES: dict[str, type] = {
 _ENV_PREFIX = "env:"
 
 
+class ConfigEnvVarError(KeyError):
+    """Raised when an ``env:VAR_NAME`` reference points at an unset variable.
+
+    Subclasses ``KeyError`` so any existing `except KeyError` still catches it,
+    but allows the CLI layer to distinguish env-ref failures from unrelated
+    dict-lookup bugs that should not be reported as configuration errors.
+    """
+
+
 def resolve_env_ref(value: str) -> str:
     """Resolve an ``env:VAR_NAME`` reference to its environment variable value.
 
     If *value* starts with ``env:``, the remainder is used as an environment
-    variable name.  Returns the variable's value, or raises ``KeyError`` if
-    the variable is not set.  Non-prefixed strings are returned unchanged.
+    variable name.  Returns the variable's value, or raises
+    :class:`ConfigEnvVarError` if the variable is not set.  Non-prefixed
+    strings are returned unchanged.
     """
     if not isinstance(value, str) or not value.startswith(_ENV_PREFIX):
         return value
     var_name = value[len(_ENV_PREFIX) :]
     env_val = os.environ.get(var_name)
     if env_val is None:
-        raise KeyError(f"Environment variable {var_name!r} referenced in config (via {value!r}) is not set")
+        raise ConfigEnvVarError(f"Environment variable {var_name!r} referenced in config (via {value!r}) is not set")
     return env_val
 
 

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -371,15 +371,20 @@ class MemSearch:
         loop = asyncio.new_event_loop()
 
         def _on_change(event_type: str, file_path: Path) -> None:
-            if event_type == "deleted":
-                self._store.delete_by_source(str(file_path))
-                summary = f"Removed chunks for {file_path}"
-            else:
-                n = loop.run_until_complete(self.index_file(file_path))
-                summary = f"Indexed {n} chunks from {file_path}"
-            logger.info(summary)
-            if on_event is not None:
-                on_event(event_type, summary, file_path)
+            from pymilvus.exceptions import MilvusException
+
+            try:
+                if event_type == "deleted":
+                    self._store.delete_by_source(str(file_path))
+                    summary = f"Removed chunks for {file_path}"
+                else:
+                    n = loop.run_until_complete(self.index_file(file_path))
+                    summary = f"Indexed {n} chunks from {file_path}"
+                logger.info(summary)
+                if on_event is not None:
+                    on_event(event_type, summary, file_path)
+            except MilvusException as e:
+                logger.warning("Milvus error during watch callback: %s", e)
 
         fw_kwargs: dict[str, Any] = {}
         if debounce_ms is not None:

--- a/tests/test_cli_error_handling.py
+++ b/tests/test_cli_error_handling.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+from pymilvus.exceptions import MilvusException
+
+from memsearch import cli as cli_module
+from memsearch.cli import cli
+from memsearch.config import MemSearchConfig
+from memsearch import store as store_module
+
+
+def test_stats_shows_friendly_config_error(monkeypatch) -> None:
+    def fake_resolve_config(_overrides=None):
+        raise KeyError("Environment variable 'MISSING_KEY' referenced in config is not set")
+
+    monkeypatch.setattr(cli_module, "resolve_config", fake_resolve_config)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stats"])
+
+    assert result.exit_code == 1
+    assert "Configuration error:" in result.output
+    assert "MISSING_KEY" in result.output
+
+
+def test_stats_shows_friendly_milvus_error(monkeypatch) -> None:
+    class BrokenStore:
+        def __init__(self, **_kwargs):
+            raise MilvusException(code=2, message="server unavailable")
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda _overrides=None: MemSearchConfig())
+    monkeypatch.setattr(store_module, "MilvusStore", BrokenStore)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stats"])
+
+    assert result.exit_code == 1
+    assert "Milvus error:" in result.output
+    assert "server unavailable" in result.output

--- a/tests/test_cli_error_handling.py
+++ b/tests/test_cli_error_handling.py
@@ -4,14 +4,14 @@ from click.testing import CliRunner
 from pymilvus.exceptions import MilvusException
 
 from memsearch import cli as cli_module
-from memsearch.cli import cli
-from memsearch.config import MemSearchConfig
 from memsearch import store as store_module
+from memsearch.cli import cli
+from memsearch.config import ConfigEnvVarError, MemSearchConfig
 
 
 def test_stats_shows_friendly_config_error(monkeypatch) -> None:
     def fake_resolve_config(_overrides=None):
-        raise KeyError("Environment variable 'MISSING_KEY' referenced in config is not set")
+        raise ConfigEnvVarError("Environment variable 'MISSING_KEY' referenced in config is not set")
 
     monkeypatch.setattr(cli_module, "resolve_config", fake_resolve_config)
 
@@ -19,8 +19,8 @@ def test_stats_shows_friendly_config_error(monkeypatch) -> None:
     result = runner.invoke(cli, ["stats"])
 
     assert result.exit_code == 1
-    assert "Configuration error:" in result.output
-    assert "MISSING_KEY" in result.output
+    assert "Configuration error:" in result.stderr
+    assert "MISSING_KEY" in result.stderr
 
 
 def test_stats_shows_friendly_milvus_error(monkeypatch) -> None:
@@ -35,5 +35,45 @@ def test_stats_shows_friendly_milvus_error(monkeypatch) -> None:
     result = runner.invoke(cli, ["stats"])
 
     assert result.exit_code == 1
-    assert "Milvus error:" in result.output
-    assert "server unavailable" in result.output
+    assert "Milvus error (code 2):" in result.stderr
+    assert "server unavailable" in result.stderr
+
+
+def test_unrelated_key_error_is_not_swallowed(monkeypatch) -> None:
+    """A bare KeyError from config resolution (e.g. a programming bug) must
+    surface as a traceback, not be misreported as a user config error."""
+
+    def fake_resolve_config(_overrides=None):
+        raise KeyError("internal_lookup_bug")
+
+    monkeypatch.setattr(cli_module, "resolve_config", fake_resolve_config)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stats"])
+
+    assert result.exit_code != 0
+    assert "Configuration error:" not in (result.stderr or "")
+    assert isinstance(result.exception, KeyError)
+    assert not isinstance(result.exception, ConfigEnvVarError)
+
+
+def test_missing_env_var_in_real_resolve(monkeypatch) -> None:
+    """End-to-end: a real env:VAR config with an unset var produces a
+    friendly error, exercising ConfigEnvVarError through resolve_config."""
+    monkeypatch.delenv("DEFINITELY_NOT_SET_MEMSEARCH_API_KEY", raising=False)
+
+    def fake_load(_path):
+        return {"embedding": {"api_key": "env:DEFINITELY_NOT_SET_MEMSEARCH_API_KEY"}}
+
+    monkeypatch.setattr(cli_module, "resolve_config", cli_module.resolve_config)
+    # Patch the loader inside the real resolve_config pipeline.
+    from memsearch import config as config_module
+
+    monkeypatch.setattr(config_module, "load_config_file", fake_load)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stats"])
+
+    assert result.exit_code == 1
+    assert "Configuration error:" in result.stderr
+    assert "DEFINITELY_NOT_SET_MEMSEARCH_API_KEY" in result.stderr


### PR DESCRIPTION
## Summary
- catch unresolved `env:VAR` config references at the CLI boundary and print a user-facing error instead of a traceback
- catch Milvus connection failures in CLI commands and print a user-facing error instead of a raw `pymilvus` traceback
- add regression tests covering both error paths in `memsearch stats`

Supersedes the narrower closed PRs #291 and #290.

## Test plan
- [x] `uv run pytest`
- [x] manual: `memsearch stats` with `api_key = \"env:NONEXISTENT_MEMSEARCH_KEY\"` prints `Configuration error: ...`
- [x] manual: `memsearch stats --milvus-uri http://127.0.0.1:19531` prints `Milvus error: ...`