### PR TITLE
docs: add Comparison with Alternatives and Embedding Model Evaluation pages

### DIFF
--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -157,28 +157,6 @@ If you are already using OpenClaw's memory directory layout, memsearch works wit
 
 ---
 
-## Comparison with Competitors
+## Comparison with Alternatives
 
-| Feature | **memsearch** | claude-mem | qmd |
-|---------|:---:|:---:|:---:|
-| **Cross-platform** | 4 platforms | Claude Code only | Claude Code + MCP |
-| **Source of truth** | Markdown files | SQLite + ChromaDB | Markdown files |
-| **Search** | Hybrid (dense + BM25 + RRF) | Dense only + FTS5 | Hybrid (dense + BM25 + RRF) + query expansion |
-| **Embedding** | Pluggable (6 providers) | Fixed (MiniLM WASM) | Local GGUF (embeddinggemma / Qwen3) |
-| **Reranking** | Optional cross-encoder (ONNX) | None | Local LLM (qwen3-reranker) |
-| **Progressive disclosure** | L1 → L2 → L3 | Single layer | Single layer |
-| **Context isolation** | Skill in forked subagent | MCP tools in main context | MCP tools in main context |
-| **Storage format** | `.md` (human-readable, git-friendly) | Binary DB | `.md` (human-readable, git-friendly) |
-| **Vector backend** | Milvus (Lite → Server → Cloud) | ChromaDB | SQLite + sqlite-vec |
-| **Memory capture** | Automatic (hooks write daily `.md`) | Automatic | External (read-only search engine) |
-| **API key required** | No (ONNX default) | No (WASM) | No (all local models) |
-| **Language** | Python | TypeScript | TypeScript |
-
-**Key advantages:**
-
-1. **Cross-platform portability.** memsearch works across Claude Code, OpenClaw, OpenCode, and Codex CLI with shared memory.
-2. **Transparent storage.** Markdown files are human-readable and git-friendly. You can inspect, edit, and version-control your agent's memories directly.
-3. **End-to-end memory.** memsearch captures session summaries automatically and writes them to markdown -- it is both a search engine and a memory writer. qmd is read-only and requires external tools to capture memories.
-4. **Search quality.** Hybrid search (dense + BM25 + RRF) catches both semantic matches and exact keyword matches that pure-dense solutions miss.
-5. **Scale path.** Milvus Lite for dev, Milvus Server for teams, Zilliz Cloud for production -- same API throughout.
-6. **Context efficiency.** Progressive disclosure and forked subagent recall minimize context window usage.
+A side-by-side comparison of memsearch with claude-mem, qmd, [mem0](https://github.com/mem0ai/mem0), [MemPalace](https://github.com/milla-jovovich/mempalace), and [Letta (MemGPT)](https://github.com/letta-ai/letta) lives on its own page: **[Comparison with Alternatives](home/comparison.md)**.

--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -1,0 +1,143 @@
+# Comparison with Alternatives
+
+This page compares **memsearch** with other open-source memory solutions for LLMs and AI agents. Each project solves a real problem, and the right choice depends on *what kind of agent you are building* and *how you want memory to be stored*.
+
+We group the projects below into two categories:
+
+- **Coding-CLI memory plugins** — attach to an existing agent CLI (Claude Code, Codex, OpenCode, OpenClaw, Cursor, …) and give it persistent memory: memsearch, [claude-mem](https://github.com/thedotmack/claude-mem), [qmd](https://github.com/nomenclator-ninja/qmd), [MemPalace](https://github.com/milla-jovovich/mempalace).
+- **General-purpose agent memory systems** — memory libraries or agent runtimes you build applications on top of: [mem0](https://github.com/mem0ai/mem0), [Letta / MemGPT](https://github.com/letta-ai/letta).
+
+---
+
+## TL;DR
+
+| | memsearch | claude-mem | qmd | MemPalace | mem0 | Letta (MemGPT) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Category** | Coding-CLI plugin | Coding-CLI plugin | Coding-CLI plugin | Coding-CLI plugin | General memory library | Agent framework / runtime |
+| **Integration** | Native hooks + skills (4 CLIs) | Native hooks (Claude Code) | MCP | MCP | Python / JS SDK, REST, MCP | Rewrite agent on Letta runtime |
+| **Source of truth** | Plain `.md` files | SQLite + ChromaDB | `.md` files | ChromaDB | Vector DB (+ optional graph DB) | Postgres (memory blocks + archival) |
+| **Write strategy** | Append-only daily logs | LLM-summarized transcripts | External (read-only search engine) | Store-everything raw | LLM extracts facts, LLM decides add/update/delete | LLM self-edits memory (`memory_replace`, `memory_insert`, …) |
+| **Search** | Hybrid: dense + BM25 + RRF | Dense + FTS5 | Hybrid: dense + BM25 + RRF + query expansion | Dense (ChromaDB) | Dense (+ optional graph traversal) | Dense archival + conversation search |
+| **Local-first default** | ONNX bge-m3 (no API key) | WASM MiniLM | Local GGUF | Local ChromaDB + Llama | Requires LLM API for every write | Depends on configured backend |
+| **Scale path** | Milvus Lite → Server → Zilliz Cloud (same API) | Single machine | Single machine | Single machine | Depends on chosen vector DB | Postgres / pgvector |
+
+> None of the benchmark numbers published by individual projects (LOCOMO, LongMemEval, etc.) are directly comparable because the evaluation setups differ. We do not claim a benchmark win here — the comparison is about *architectural shape*, not accuracy numbers.
+
+---
+
+## Quick orientation
+
+### memsearch
+
+A cross-platform semantic memory plugin for coding-CLI agents. Ships **native plugins** for Claude Code, OpenClaw, OpenCode, and Codex CLI (not MCP adapters — actual per-platform hooks and skills). Stores memory as plain markdown daily logs; Milvus is a derived hybrid-search index rebuildable from the markdown at any time.
+
+### claude-mem
+
+Memory for Claude Code only. Hooks compress session transcripts using an LLM and store the result in ChromaDB + SQLite. Storage is opaque (binary DB), Claude Code–specific.
+
+### qmd
+
+Local-first MCP search engine for markdown notes. Read-only — it searches existing markdown; capture is left to the user or external tools. Share the same markdown-as-source-of-truth philosophy as memsearch.
+
+### MemPalace
+
+A memory server organized around the *method of loci* ("wings → halls → rooms"). Stores conversations raw in ChromaDB without LLM extraction, then exposes them to chat clients (Claude Code, ChatGPT, Cursor) via MCP. Runs fully offline with local Llama + ChromaDB.
+
+### mem0
+
+A general-purpose memory layer for LLM applications (not tied to any specific coding CLI). Every write goes through an LLM that extracts entities and relationships, decides whether to add / update / delete existing memories, and stores the results in a configurable vector DB — optionally mirrored to a graph DB (Neo4j, Memgraph, Neptune, Kuzu, AGE). Published as a Python/JS SDK, REST API, hosted platform, and (via OpenMemory) an MCP server.
+
+### Letta (formerly MemGPT)
+
+A full **agent framework and server** built around the "LLM as an operating system" idea. Memory is hierarchical — a small in-context *core memory*, plus *archival memory* and *recall memory* stored in Postgres — and the agent itself edits its own memory at runtime through dedicated tools (`memory_replace`, `memory_insert`, `archival_memory_insert`, `conversation_search`, …). Letta is not a plugin you bolt onto an existing CLI; you build your agent on the Letta runtime.
+
+---
+
+## Detailed feature matrix
+
+### Integration surface
+
+| | memsearch | mem0 | MemPalace | Letta |
+|---|:---:|:---:|:---:|:---:|
+| Claude Code native plugin | ✅ (hooks + skills) | ❌ (MCP only) | ❌ (MCP only) | ❌ (runtime, not plugin) |
+| OpenClaw native plugin | ✅ | ❌ | ❌ | ❌ |
+| OpenCode native plugin | ✅ | ❌ | ❌ | ❌ |
+| Codex CLI native plugin | ✅ | ❌ | ❌ | ❌ |
+| Generic MCP | Not shipped | ✅ (OpenMemory) | ✅ | ❌ |
+| Library / SDK | Python | Python, JS | Python | Python |
+
+"Native plugin" means memsearch participates in the CLI's own lifecycle events (SessionStart, UserPromptSubmit, Stop, SessionEnd, …) with collection naming, per-project isolation, and skill registration. Generic MCP integrations only expose tools to the LLM — they cannot write daily memory notes at the end of a session, or inject cold-start context at session start.
+
+### Memory write semantics
+
+| | memsearch | mem0 | MemPalace | Letta |
+|---|---|---|---|---|
+| Who decides what to store? | Session-end hook summarizes the last turn as third-person notes | An LLM extracts "salient facts" on every write | Nobody — raw transcript is stored as-is | The agent itself, via tool calls during the reasoning loop |
+| Updates to prior memories? | Append-only (never mutates history) | LLM may update or delete prior memories during the update phase | Append-only | Agent can rewrite core memory blocks at any time |
+| LLM cost per write | One small Haiku call per turn (async, non-blocking) | LLM extraction call(s) per write | None (no LLM on the write path) | Depends on the agent loop — each self-edit is an LLM tool call |
+| Auditability | `git log` on `memory/YYYY-MM-DD.md` | Inspect rows in the vector/graph DB | Inspect ChromaDB | Inspect Postgres tables |
+
+**Append-only vs. self-editing** is the key philosophical split. memsearch treats memory like a commit log: once written, always auditable. mem0 and Letta treat memory like a mutable KV store that the LLM maintains — which can converge on cleaner facts, but also means prior writes can be silently rewritten or deleted by a later LLM call.
+
+### Search & retrieval
+
+| | memsearch | mem0 | MemPalace | Letta |
+|---|---|---|---|---|
+| Dense vectors | ✅ | ✅ | ✅ | ✅ (archival memory) |
+| BM25 / sparse | ✅ (RRF fused with dense) | ❌ by default | ❌ | ❌ |
+| Reranking | Optional cross-encoder (ONNX) | ❌ | ❌ | ❌ |
+| Graph traversal | ❌ | ✅ (optional graph backend) | ❌ | ❌ |
+| Progressive disclosure | L1 search → L2 expand section → L3 drill into original transcript JSONL | Single top-K retrieval | Four-layer context loading (L0–L3) | Core memory always in context; archival pulled on-demand |
+
+---
+
+## Where memsearch is actually different
+
+We try to keep this list honest — only things that are real consequences of the current architecture, not marketing claims.
+
+### 1. Native plugins for four coding CLIs, not just an MCP adapter
+
+memsearch ships first-class plugins for Claude Code, OpenClaw, OpenCode, and Codex CLI. Each plugin hooks into that CLI's lifecycle (session start / prompt submit / stop / session end) to capture memory automatically and inject cold-start context. None of mem0, MemPalace, or Letta ship native integrations for these coding CLIs — they expose memory tools over MCP or a REST API, which is a thinner integration.
+
+### 2. Plain markdown is the canonical store; the vector DB is derived
+
+Your memory lives in `memory/YYYY-MM-DD.md` and `MEMORY.md`. You can `cat`, `grep`, `git diff`, and `git blame` it. If you lose the Milvus index, you rebuild it from the markdown. mem0 and Letta both store memory inside a database (vector DB / Postgres) — their storage is opaque by design. MemPalace stores in ChromaDB only.
+
+### 3. Writes are cheap and append-only
+
+A memsearch write is: extract the last turn → one Haiku summarization call → append a bullet to today's `.md`. No LLM "decides what to forget." No self-editing. No entity extraction pipeline. This makes writes cheap, predictable, and fully auditable — at the cost of not auto-compressing redundant memories (you can run `memsearch compact` on demand if you want that).
+
+mem0 and Letta are on the other end of the spectrum: they rely on LLMs to curate memory on the write path, which is more powerful but introduces cost, latency, and the possibility of silent data loss.
+
+### 4. Hybrid search with BM25 fused via RRF, out of the box
+
+memsearch indexes every chunk with both a dense vector and a BM25 sparse vector, and fuses them at query time with Reciprocal Rank Fusion. Exact keyword hits (function names, file paths, error strings) and semantic matches both surface. mem0, MemPalace, and Letta archival are dense-only by default.
+
+### 5. A clear scale path on one API
+
+Milvus Lite (a single local file, zero deps) → Milvus Server (self-hosted Docker/K8s) → Zilliz Cloud (fully managed). Same Python API, same collection format, you just change a URI. MemPalace is ChromaDB-only; claude-mem is ChromaDB + SQLite; Letta is Postgres + pgvector; mem0 is pluggable but you wire the backend yourself.
+
+### 6. Context isolation via forked subagents
+
+On Claude Code, memory recall runs inside a skill with `context: fork` — the subagent does search, expansion, and transcript drill-down in its own context window, and only returns a curated summary to the main conversation. Retrieval never pollutes the main context with raw search hits.
+
+---
+
+## When another project is the better fit
+
+A few cases where memsearch is *not* what you want:
+
+- **You are building a general-purpose LLM application, not wiring memory into a coding CLI.** mem0 is designed for this — its SDK, hosted service, and graph-memory features assume you control the whole application.
+- **You want the LLM to actively maintain memory (summarize, deduplicate, forget).** Letta's self-editing memory and mem0's LLM-driven extraction/update do this by design. memsearch deliberately does not.
+- **You want a pre-built stateful-agent runtime (personas, tool loops, long-running agents).** Letta is a full agent framework; memsearch is only the memory layer.
+- **You only use Cursor or ChatGPT Desktop via MCP and don't need per-CLI hooks.** MemPalace's MCP-first model fits cleanly there, and its "store everything raw" philosophy is close to memsearch's append-only writes.
+
+---
+
+## References
+
+- mem0 — [github.com/mem0ai/mem0](https://github.com/mem0ai/mem0), [docs.mem0.ai/graph-memory](https://docs.mem0.ai/open-source/features/graph-memory), paper: [arxiv.org/abs/2504.19413](https://arxiv.org/html/2504.19413v1)
+- Letta (MemGPT) — [github.com/letta-ai/letta](https://github.com/letta-ai/letta), [docs.letta.com/concepts/memgpt](https://docs.letta.com/concepts/memgpt/)
+- MemPalace — [github.com/milla-jovovich/mempalace](https://github.com/milla-jovovich/mempalace)
+- claude-mem — [github.com/thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)
+- qmd — [github.com/nomenclator-ninja/qmd](https://github.com/nomenclator-ninja/qmd)

--- a/docs/home/embedding-evaluation.md
+++ b/docs/home/embedding-evaluation.md
@@ -1,0 +1,133 @@
+# Embedding Model Evaluation
+
+The Claude Code plugin ships with **ONNX bge-m3 int8** as the default embedding model. This page documents the benchmark we ran to pick it — which models we tested, what dataset we used, and why this one won.
+
+If you just want the answer: on our real-world memory-retrieval benchmark (955 chunks / 2172 bilingual queries), `gpahal/bge-m3-onnx-int8` lost only ~1% recall to the full-precision PyTorch model while cutting the on-disk model size from 2.2 GB to 558 MB and dropping the `torch` dependency entirely. It also outperforms OpenAI `text-embedding-3-small` on Chinese retrieval (Recall@5 0.776 vs 0.717), so we can ship a zero-config default that is better than the old API-key default on real user data.
+
+---
+
+## Goal
+
+Pick a default embedding model for the memsearch Claude Code plugin that is:
+
+- **Good at bilingual retrieval** — memsearch users write memory in both Chinese and English; a model that crashes on one language is unusable.
+- **Local and zero-config** — no API key, no GPU requirement, no `torch` install.
+- **Small enough to auto-download** on first use without scaring users.
+- **Cheap on a loaded CPU** — embedding happens on every file write via the watcher.
+
+## Dataset
+
+We built the evaluation set from real memsearch memory logs (`.memsearch/memory/*.md`) collected across 12 projects, so the domain matches what users actually index.
+
+1. **Collect** — Scan markdown memory files, chunk by heading using memsearch's `chunk_markdown()`.
+2. **Clean** — Remove HTML comments, drop short chunks (<50 chars), sanitize sensitive data (paths, IPs, tokens).
+3. **Annotate** with `gpt-4o-mini`:
+    - **Simple** (1 per chunk) — straightforward factual questions.
+    - **Complex** (1 per substantial chunk) — reasoning-required questions.
+    - **Multi-hop** (group related chunks by project + date) — questions needing 2+ chunks to answer.
+4. **Translate** — Chinese ↔ English for bilingual coverage.
+
+Final dataset: **955 chunks × 2172 queries** (955 simple + 926 complex + 291 multi-hop), available in both Chinese and English.
+
+## Models evaluated
+
+12 models across four categories, plus two ONNX variants of bge-m3:
+
+| # | Provider | Model | Size |
+|---|----------|-------|------|
+| 1 | openai | `text-embedding-3-small` | API |
+| 2 | openai | `text-embedding-3-large` | API |
+| 3 | local | `BAAI/bge-m3` (PyTorch) | 1.7 GB |
+| 4 | local | `sentence-transformers/all-MiniLM-L6-v2` | 91 MB |
+| 5 | local | `intfloat/multilingual-e5-small` | 471 MB |
+| 6 | local | `intfloat/multilingual-e5-base` | 1.1 GB |
+| 7 | local | `Qwen/Qwen3-Embedding-0.6B` | ~1.2 GB |
+| 8 | local | `paraphrase-multilingual-MiniLM-L12-v2` | 471 MB |
+| 9 | local | `paraphrase-multilingual-mpnet-base-v2` | 1.1 GB |
+| 10 | ollama | `nomic-embed-text` | 274 MB |
+| 11 | ollama | `mxbai-embed-large` | 669 MB |
+| 12 | ollama | `dengcao/Qwen3-Embedding-8B` (Q5_K_M) | 5.4 GB |
+| — | onnx | `bge-m3` ONNX fp32 | 2.2 GB |
+| — | onnx | `gpahal/bge-m3-onnx-int8` | 558 MB |
+
+## Metrics
+
+For each model we measured retrieval quality using:
+
+- **Recall@K** (K = 1, 5, 10) — does the correct chunk appear in the top-K results?
+- **MRR** — Mean Reciprocal Rank; average position of the first correct result.
+- **NDCG@10** — normalized discounted cumulative gain.
+
+For the Claude Code plugin use case (the skill surfaces ~top 3–5 chunks), **Recall@5** is the primary metric and MRR is secondary.
+
+## Results
+
+Ranked by Chinese Recall@5 (our primary metric — English is easy mode for most multilingual models):
+
+| Rank | Model | Size | zh R@5 | en R@5 | zh MRR | en MRR |
+|------|-------|------|--------|--------|--------|--------|
+| 1 | **BAAI/bge-m3** (PyTorch) | 1.7 GB | **0.783** | **0.815** | 0.637 | 0.661 |
+| 2 | **bge-m3 ONNX int8** | 558 MB | **0.776** | 0.814 | 0.642 | — |
+| 3 | `text-embedding-3-large` | API | 0.750 | 0.797 | 0.603 | 0.636 |
+| 4 | `Qwen3-Embedding-0.6B` | ~1.2 GB | 0.739 | 0.733 | 0.588 | 0.573 |
+| 5 | `text-embedding-3-small` | API | 0.717 | 0.767 | 0.574 | 0.615 |
+| 6 | `multilingual-e5-small` | 471 MB | 0.653 | 0.741 | 0.520 | 0.586 |
+| 7 | `multilingual-e5-base` | 1.1 GB | 0.644 | 0.733 | 0.512 | 0.586 |
+| 8 | `paraphrase-multilingual-mpnet` | 1.1 GB | 0.548 | 0.672 | 0.413 | 0.519 |
+| 9 | `paraphrase-multilingual-MiniLM` | 471 MB | 0.550 | 0.640 | 0.412 | 0.498 |
+| 10 | `nomic-embed-text` | 274 MB | 0.402 | 0.756 | 0.287 | 0.608 |
+| 11 | `mxbai-embed-large` | 669 MB | 0.377 | 0.743 | 0.269 | 0.597 |
+| 12 | `all-MiniLM-L6-v2` | 91 MB | 0.203 | 0.651 | 0.129 | 0.503 |
+| 13 | `Qwen3-Embedding-8B` (Q5) | 5.4 GB | 0.201 | 0.230 | 0.140 | 0.166 |
+
+### ONNX vs PyTorch, same bge-m3 weights
+
+| Variant | Model size | zh R@5 | Quality vs PyTorch baseline | Runtime deps |
+|---------|-----------|--------|------------------------------|--------------|
+| PyTorch fp32 (GPU) | 2.2 GB | 0.783 | baseline | `torch` + `sentence-transformers` (~2 GB+) |
+| ONNX fp32 (CPU) | 2.2 GB | 0.791 | +1.1 % | `onnxruntime` (~200 MB) |
+| ONNX int8 (CPU) | 558 MB | 0.776 | −1.1 % | `onnxruntime` (~200 MB) |
+
+## Key findings
+
+1. **bge-m3 is the best model overall** — it beats all 12 competitors on both Chinese and English.
+2. **ONNX int8 quantization costs only ~1 %** while shrinking the model from 2.2 GB to 558 MB and the runtime deps from ~2 GB to ~200 MB.
+3. **CPU is enough** — no GPU required, so any development machine can run it.
+4. **Ollama English-centric models collapse on Chinese** — `nomic-embed-text` and `mxbai-embed-large` score well on English but zh R@5 < 0.40. Not safe as a bilingual default.
+5. **Q5 quantization destroys embedding quality.** `Qwen3-Embedding-8B` at Q5 ranked last despite being 5.4 GB. Quantization is not free at the 5-bit level for embeddings.
+6. **OpenAI large is barely better than small** — +3–4 % at double the cost. Not worth it for memory retrieval.
+
+## Why we switched to ONNX bge-m3
+
+The previous Claude Code plugin default was OpenAI `text-embedding-3-small`, which required every new user to obtain an API key before the plugin would work and incurred per-token cost forever after. We switched to ONNX bge-m3 int8 because:
+
+- **No API key required** — truly zero-config; the plugin works immediately after install.
+- **CPU-only** — no GPU needed, accessible on every laptop.
+- **Small enough to auto-download** — 558 MB on first use, cached at `~/.cache/huggingface/hub/`.
+- **Comparable or better quality** — roughly equal to OpenAI `text-embedding-3-small` on English, and **meaningfully better on Chinese** (0.776 vs 0.717 Recall@5 on our data).
+- **Completely free** — no per-token API cost; everything runs locally.
+- **Lightweight deps** — `onnxruntime` + `tokenizers` + `huggingface-hub` (~200 MB) instead of `torch` + `sentence-transformers` (~2 GB+).
+
+## Backward compatibility
+
+- **Python API users are not affected.** The Python API default remains `openai` / `text-embedding-3-small`. Only the Claude Code plugin hooks changed.
+- **Existing plugin users with OpenAI-indexed memory** need to re-index after switching, because the embedding dimensions differ (1024 vs 1536):
+
+  ```bash
+  memsearch config set embedding.provider onnx
+  memsearch index .memsearch/memory/ --force
+  ```
+
+- **Users with an explicit `embedding.provider` in `.memsearch.toml` or `~/.memsearch/config.toml` are unaffected** — your config still wins.
+
+To pre-download the ONNX model instead of waiting for the first-use download:
+
+```bash
+uvx --from 'memsearch[onnx]' memsearch search --provider onnx "warmup" 2>/dev/null || true
+```
+
+## Conclusion
+
+`gpahal/bge-m3-onnx-int8` is the Claude Code plugin default because it is the only model on our benchmark that simultaneously hits **top-tier bilingual quality, zero-config install, CPU-only execution, a <600 MB on-disk footprint, and no `torch` dependency**. Every other model in the evaluation failed on at least one of those axes.
+
+The raw data, annotation scripts, and reproduction steps live in the `evaluation/` directory at the repo root.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
     - Configuration: home/configuration.md
     - Architecture: architecture.md
     - Design Philosophy: design-philosophy.md
+    - Comparison with Alternatives: home/comparison.md
+    - Embedding Model Evaluation: home/embedding-evaluation.md
     - Quickstart: getting-started.md
   - Claude Code Plugin:
     - Overview: platforms/claude-code/index.md

--- a/uv.lock
+++ b/uv.lock
@@ -1433,7 +1433,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.2.2"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Two new docs pages under **Home**, parallel to Design Philosophy.

### 1. Comparison with Alternatives (`docs/home/comparison.md`)

Moved the competitor comparison out of `design-philosophy.md` into its own page, and extended it to cover three additional projects alongside the existing claude-mem / qmd entries:

- **mem0** — general-purpose memory library; LLM-driven extraction + update, configurable vector DB, optional graph backend.
- **MemPalace** — ChromaDB + local Llama, method-of-loci structure, MCP-only integration.
- **Letta (formerly MemGPT)** — full stateful-agent framework with hierarchical core / archival / recall memory and LLM self-editing.

The matrix is reorganized around **integration surface**, **write semantics**, and **search**, instead of the old feature-dump table. A final section honestly flags cases where a different project is a better fit (e.g. building a generic LLM app → mem0; building a stateful agent from scratch → Letta).

### 2. Embedding Model Evaluation (`docs/home/embedding-evaluation.md`)

Mirror of `evaluation/README.md`, adapted for docs:

- Dataset: 955 chunks × 2172 bilingual queries from real memsearch logs across 12 projects.
- 13 embedding models benchmarked across OpenAI / local / ollama / ONNX categories.
- Recall@K, MRR, NDCG@10 results with bge-m3 winning overall and ONNX int8 losing only ~1% vs PyTorch fp32.
- Explains why the Claude Code plugin default switched from OpenAI `text-embedding-3-small` to `gpahal/bge-m3-onnx-int8` (zero-config, CPU-only, 558 MB, no `torch` dep, better Chinese recall).

### Other

- `docs/design-philosophy.md` — old comparison table replaced with a short pointer to the new page.
- `mkdocs.yml` — two new nav entries under Home between Design Philosophy and Quickstart.
- `uv.lock` — sync version marker to 0.2.4 (matches pyproject).

## Test plan

- [x] `uv run mkdocs build --strict` passes with no warnings or broken links.
- [x] All new links in the comparison page resolve to real upstream repos.
- [x] Benchmark numbers match `evaluation/README.md` exactly.