### PR TITLE
feat: add Jina and Mistral embedding providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Markdown files → Scanner → Chunker → Embedder → MilvusStore
 - **`core.py`** — `MemSearch` class: the public Python API that orchestrates everything. Entry point for `index()`, `search()`, `compact()`, `watch()`.
 - **`store.py`** — `MilvusStore`: Milvus wrapper handling collection creation, upsert, hybrid search (dense cosine + BM25 sparse + RRF reranking), and cleanup. The `chunk_hash` (composite ID of source+lines+content+model) is the VARCHAR primary key.
 - **`chunker.py`** — Splits markdown by headings into `Chunk` dataclasses. SHA-256 content hash enables dedup. `compute_chunk_id()` generates composite IDs matching OpenClaw's format.
-- **`embeddings/__init__.py`** — `EmbeddingProvider` protocol + lazy-loading factory (`get_provider()`). Providers: openai (default), google, voyage, ollama, local, onnx.
+- **`embeddings/__init__.py`** — `EmbeddingProvider` protocol + lazy-loading factory (`get_provider()`). Providers: openai (default), google, voyage, jina, mistral, ollama, local, onnx.
 - **`scanner.py`** — Walks directories to find `.md`/`.markdown` files, returns `ScannedFile` list.
 - **`config.py`** — Layered TOML config: dataclass defaults → `~/.memsearch/config.toml` → `.memsearch.toml` → CLI flags.
 - **`cli.py`** — Click CLI wrapping the Python API. All commands resolve config via `resolve_config()` then instantiate `MemSearch`.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ uv add memsearch
 pip install "memsearch[onnx]"    # Local ONNX (recommended, no API key)
 # or: uv add "memsearch[onnx]"
 
-# Other options: [openai], [google], [voyage], [ollama], [local], [all]
+# Other options: [openai], [google], [voyage], [jina], [mistral], [ollama], [local], [all]
 ```
 
 </details>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -360,7 +360,7 @@ graph LR
 The entire memsearch pipeline runs locally by default:
 
 - **Milvus Lite** stores data in a local `.db` file on your filesystem.
-- **Local embedding providers** (`memsearch[local]` with sentence-transformers, or `memsearch[ollama]` with a local Ollama server) process text without any network calls.
+- **Local embedding providers** (`memsearch[onnx]` with ONNX Runtime, `memsearch[local]` with sentence-transformers, or `memsearch[ollama]` with a local Ollama server) process text without any network calls.
 
 In a fully local configuration, your data never leaves your machine.
 
@@ -371,12 +371,12 @@ Data is transmitted externally only when you explicitly choose a remote componen
 | Component | Local Option | Remote Option |
 |-----------|-------------|---------------|
 | Vector store | Milvus Lite (default) | Milvus Server, Zilliz Cloud |
-| Embeddings | `local`, `ollama` | `openai`, `google`, `voyage` |
+| Embeddings | `onnx`, `local`, `ollama` | `openai`, `google`, `voyage`, `jina`, `mistral` |
 | Compact LLM | Ollama (local) | OpenAI, Anthropic, Gemini |
 
 ### API Key Handling
 
-API keys are read from standard environment variables (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `ANTHROPIC_API_KEY`). They are never written to config files by memsearch, never logged, and never stored in the vector database.
+API keys are read from standard environment variables (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`, `ANTHROPIC_API_KEY`). They are never written to config files by memsearch, never logged, and never stored in the vector database.
 
 ### Filesystem Access
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,7 +76,7 @@ Writing to: /home/user/.memsearch/config.toml
   Collection name [memsearch_chunks]:
 
 -- Embedding --
-  Provider (openai/google/voyage/ollama/local) [openai]:
+  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
   Model (empty for provider default) []:
 
 -- Chunking --
@@ -216,7 +216,7 @@ Scan one or more directories (or files) and index all markdown files (`.md`, `.m
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `PATHS` | | *(required)* | One or more directories or files to index |
-| `--provider` | `-p` | `openai` | Embedding provider (`openai`, `google`, `voyage`, `ollama`, `local`) |
+| `--provider` | `-p` | `openai` | Embedding provider (`openai`, `google`, `voyage`, `jina`, `mistral`, `ollama`, `local`, `onnx`) |
 | `--model` | `-m` | provider default | Override the embedding model name |
 | `--base-url` | | *(none)* | OpenAI-compatible API base URL |
 | `--api-key` | | *(none)* | API key for the embedding provider |
@@ -711,6 +711,8 @@ memsearch reads API keys from environment variables by default. You can also con
 | `OPENAI_BASE_URL` | *(optional)* | Override the OpenAI API base URL (for proxies or compatible APIs) |
 | `GOOGLE_API_KEY` | `google` embedding provider, `gemini` LLM compact provider | Google AI API key |
 | `VOYAGE_API_KEY` | `voyage` embedding provider | Voyage AI API key |
+| `JINA_API_KEY` | `jina` embedding provider | Jina AI API key |
+| `MISTRAL_API_KEY` | `mistral` embedding provider | Mistral AI API key |
 | `ANTHROPIC_API_KEY` | `anthropic` LLM compact provider | Anthropic API key |
 | `OLLAMA_HOST` | `ollama` embedding provider *(optional)* | Ollama server URL (default: `http://localhost:11434`) |
 
@@ -736,8 +738,11 @@ $ memsearch compact --llm-provider anthropic
 | `openai` | included by default | `text-embedding-3-small` | 1536 | `OPENAI_API_KEY` |
 | `google` | `pip install "memsearch[google]"` | `gemini-embedding-001` | 768 | `GOOGLE_API_KEY` |
 | `voyage` | `pip install "memsearch[voyage]"` | `voyage-3-lite` | 512 | `VOYAGE_API_KEY` |
+| `jina` | `pip install "memsearch[jina]"` | `jina-embeddings-v4` | 2048 | `JINA_API_KEY` |
+| `mistral` | `pip install "memsearch[mistral]"` | `mistral-embed` | 1024 | `MISTRAL_API_KEY` |
 | `ollama` | `pip install "memsearch[ollama]"` | `nomic-embed-text` | 768 | *(none, local)* |
 | `local` | `pip install "memsearch[local]"` | `all-MiniLM-L6-v2` | 384 | *(none, local)* |
+| `onnx` | `pip install "memsearch[onnx]"` | `gpahal/bge-m3-onnx-int8` | 1024 | *(none, local)* |
 
 Install all optional providers at once:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ Each optional extra pulls in the provider SDK you need:
 $ pip install "memsearch[onnx]"        # ONNX Runtime — bge-m3 int8, CPU, no API key
 $ pip install "memsearch[google]"      # Google Gemini embeddings
 $ pip install "memsearch[voyage]"      # Voyage AI embeddings
+$ pip install "memsearch[jina]"        # Jina AI embeddings
+$ pip install "memsearch[mistral]"     # Mistral AI embeddings
 $ pip install "memsearch[ollama]"      # Ollama (local, no API key)
 $ pip install "memsearch[local]"       # sentence-transformers (local, no API key)
 $ pip install "memsearch[anthropic]"   # Anthropic (for compact/summarization LLM)
@@ -295,6 +297,8 @@ Set the environment variable for your chosen embedding provider. memsearch reads
 | OpenAI-compatible proxy | `OPENAI_BASE_URL` | For Azure OpenAI, vLLM, LiteLLM, etc. |
 | Google Gemini | `GOOGLE_API_KEY` | Requires `memsearch[google]` |
 | Voyage AI | `VOYAGE_API_KEY` | Requires `memsearch[voyage]` |
+| Jina AI | `JINA_API_KEY` | Requires `memsearch[jina]` |
+| Mistral AI | `MISTRAL_API_KEY` | Requires `memsearch[mistral]` |
 | Ollama | `OLLAMA_HOST` (optional) | Defaults to `http://localhost:11434` |
 | Local (sentence-transformers) | -- | No API key needed |
 | Anthropic | `ANTHROPIC_API_KEY` | Used by `compact` summarization only |
@@ -303,6 +307,8 @@ Set the environment variable for your chosen embedding provider. memsearch reads
 $ export OPENAI_API_KEY="sk-..."         # OpenAI embeddings (default)
 $ export GOOGLE_API_KEY="..."            # Google Gemini embeddings
 $ export VOYAGE_API_KEY="..."            # Voyage AI embeddings
+$ export JINA_API_KEY="jina_..."         # Jina AI embeddings
+$ export MISTRAL_API_KEY="..."           # Mistral AI embeddings
 $ export ANTHROPIC_API_KEY="..."         # Anthropic (for compact summarization)
 ```
 
@@ -475,7 +481,7 @@ Writing to: /home/user/.memsearch/config.toml
   Collection name [memsearch_chunks]:
 
 ── Embedding ──
-  Provider (openai/google/voyage/ollama/local) [openai]:
+  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
   Model (empty for provider default) []:
 
 ── Chunking ──

--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -34,7 +34,7 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 | On-demand retrieval (not full-file reload) | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Hybrid BM25 + dense | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | RRF fusion inside the vector DB | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Pluggable embedding providers | ✅ (6: openai / google / voyage / ollama / local / onnx) | — | ❌ | ✅ | ❌ | ✅ | ✅ |
+| Pluggable embedding providers | ✅ (8: openai / google / voyage / jina / mistral / ollama / local / onnx) | — | ❌ | ✅ | ❌ | ✅ | ✅ |
 | Optional cross-encoder reranker | ✅ | ❌ | ❌ | ✅ (LLM rerank) | ❌ | ✅ | ❌ |
 | Progressive disclosure: search → expand → transcript | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Forked-subagent recall (isolated context) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -27,6 +27,8 @@ memsearch config set milvus.uri http://localhost:19530
 | openai | `pip install memsearch[openai]` | `OPENAI_API_KEY` | Best quality |
 | google | `pip install memsearch[google]` | `GOOGLE_API_KEY` | Gemini embeddings |
 | voyage | `pip install memsearch[voyage]` | `VOYAGE_API_KEY` | High quality |
+| jina | `pip install memsearch[jina]` | `JINA_API_KEY` | jina-embeddings-v4, multilingual, long context |
+| mistral | `pip install memsearch[mistral]` | `MISTRAL_API_KEY` | EU-based, GDPR-friendly |
 | ollama | `pip install memsearch[ollama]` | No | Local, any model |
 
 ```bash

--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -19,7 +19,7 @@ uv add memsearch
 pip install "memsearch[onnx]"    # Local ONNX (recommended, no API key)
 # or: uv add "memsearch[onnx]"
 
-# Other options: [openai], [google], [voyage], [ollama], [local], [all]
+# Other options: [openai], [google], [voyage], [jina], [mistral], [ollama], [local], [all]
 ```
 
 </details>

--- a/docs/home/why.md
+++ b/docs/home/why.md
@@ -29,4 +29,4 @@ See the [Architecture](../architecture.md) deep dive and [Design Philosophy](../
 - **Smart Dedup** — SHA-256 content hashing skips unchanged content on re-index
 - **Live Sync** — file watcher auto-indexes changes in real time
 - **Progressive Disclosure** — 3-layer recall: search → expand → transcript
-- **Pluggable Embeddings** — ONNX (local, free), OpenAI, Google, Voyage, Ollama
+- **Pluggable Embeddings** — ONNX (local, free), OpenAI, Google, Voyage, Jina, Mistral, Ollama

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,8 @@ graph LR
 | OpenAI | `memsearch` (included) | `text-embedding-3-small` |
 | Google | `memsearch[google]` | `gemini-embedding-001` |
 | Voyage | `memsearch[voyage]` | `voyage-3-lite` |
+| Jina | `memsearch[jina]` | `jina-embeddings-v4` |
+| Mistral | `memsearch[mistral]` | `mistral-embed` |
 | Ollama | `memsearch[ollama]` | `nomic-embed-text` |
 | Local | `memsearch[local]` | `all-MiniLM-L6-v2` |
 

--- a/docs/platforms/claude-code/index.md
+++ b/docs/platforms/claude-code/index.md
@@ -98,7 +98,7 @@ sequenceDiagram
 | **Memory recall** | Skill in forked subagent -- intermediate results stay isolated | Skill + MCP hybrid -- tool definitions permanently consume context tokens |
 | **Session capture** | 1 async `claude -p --model haiku` call at session end | AI observation compression on every tool use (`PostToolUse` hook) |
 | **Vector backend** | [Milvus](https://milvus.io/) -- [hybrid search](../../architecture.md#hybrid-search) (dense + BM25 + RRF) | [ChromaDB](https://www.trychroma.com/) -- dense only; SQLite FTS5 for keyword search (separate, not fused) |
-| **Embedding model** | Pluggable: OpenAI, Google, Voyage, Ollama, ONNX (default: bge-m3 int8) | Fixed: all-MiniLM-L6-v2 (384-dim, WASM backend) |
+| **Embedding model** | Pluggable: OpenAI, Google, Voyage, Jina, Mistral, Ollama, ONNX (default: bge-m3 int8) | Fixed: all-MiniLM-L6-v2 (384-dim, WASM backend) |
 | **Storage format** | Transparent `.md` files -- human-readable, git-friendly | SQLite database + ChromaDB binary |
 | **Data portability** | Copy `.memsearch/memory/*.md` and rebuild index | Export from SQLite + ChromaDB |
 | **Runtime dependency** | Python (`memsearch` CLI) + `claude` CLI | Node.js / Bun + Express worker service |

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -15,7 +15,7 @@ OpenClaw ships with **memory-core**, a built-in memory plugin backed by SQLite +
 | **Storage format** | SQLite database (opaque) | Plain `.md` files (human-readable, git-friendly, editable) |
 | **Multi-agent isolation** | Shared database | Per-agent directory + per-agent Milvus collection |
 | **Progressive disclosure** | Single-layer (search only) | Three-layer: search → expand → transcript drill-down |
-| **Embedding model** | Depends on configuration | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Ollama |
+| **Embedding model** | Depends on configuration | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Jina, Mistral, Ollama |
 | **Data portability** | Locked in SQLite | Copy `.md` files, rebuild index anywhere |
 | **Cross-platform** | OpenClaw only | Same memories accessible from Claude Code, Codex, OpenCode |
 

--- a/docs/platforms/opencode/index.md
+++ b/docs/platforms/opencode/index.md
@@ -16,7 +16,7 @@ OpenCode does not ship with a built-in memory system. Several third-party option
 | **Cross-platform** | Same memories accessible from Claude Code, OpenClaw, Codex | OpenCode only | Single platform |
 | **Capture method** | Background daemon polls SQLite | Hook-based | Varies |
 | **Progressive disclosure** | Three-layer: search → expand → transcript | Typically single-layer | Typically single-layer |
-| **Embedding model** | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Ollama | Typically fixed | Varies |
+| **Embedding model** | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Jina, Mistral, Ollama | Typically fixed | Varies |
 
 ### The Cross-Platform Advantage
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -40,7 +40,7 @@ MemSearch(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `paths` | `list[str \| Path]` | `[]` | Directories or files to index |
-| `embedding_provider` | `str` | `"openai"` | Embedding backend (`"openai"`, `"google"`, `"voyage"`, `"ollama"`, `"local"`) |
+| `embedding_provider` | `str` | `"openai"` | Embedding backend (`"openai"`, `"google"`, `"voyage"`, `"jina"`, `"mistral"`, `"ollama"`, `"local"`, `"onnx"`) |
 | `embedding_model` | `str \| None` | `None` | Override the default model for the chosen provider |
 | `embedding_batch_size` | `int` | `0` | Max texts per embedding API call (0 = provider default) |
 | `embedding_base_url` | `str \| None` | `None` | OpenAI-compatible API base URL. Overrides `OPENAI_BASE_URL` env var |

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -156,7 +156,7 @@ stateDiagram-v2
 
 Fires once when a Claude Code session begins. This hook:
 
-1. **Reads config and checks API key.** Runs `memsearch config get` to read the configured embedding provider, model, and Milvus URI. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
+1. **Reads config and checks API key.** Runs `memsearch config get` to read the configured embedding provider, model, and Milvus URI. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
 2. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce. Milvus Lite falls back to a one-time `memsearch index` at session start.
 3. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
 4. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
@@ -388,7 +388,7 @@ Each file contains session summaries in plain markdown:
 | **Progressive disclosure** | **3-layer in subagent**: search → expand → transcript, all in forked context — only curated summary reaches main conversation | **3-layer**: `mem-search` skill for auto-recall; MCP tools for explicit drill-down |
 | **Session capture** | 1 async `claude -p --model haiku` call at session end | AI observation compression on every tool use (`PostToolUse` hook) + session summary |
 | **Vector backend** | [Milvus](https://milvus.io/) — hybrid search (dense + [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) + RRF), scales from embedded to distributed cluster | [ChromaDB](https://www.trychroma.com/) — dense only; SQLite FTS5 for keyword search (separate, not fused) |
-| **Embedding model** | Pluggable: OpenAI, Google, Voyage, Ollama, local, ONNX (default: bge-m3 int8) | Fixed: all-MiniLM-L6-v2 (384-dim, WASM backend) |
+| **Embedding model** | Pluggable: OpenAI, Google, Voyage, Jina, Mistral, Ollama, local, ONNX (default: bge-m3 int8) | Fixed: all-MiniLM-L6-v2 (384-dim, WASM backend) |
 | **Storage format** | Transparent `.md` files — human-readable, git-friendly | SQLite database + ChromaDB binary |
 | **Data portability** | Copy `.memsearch/memory/*.md` and rebuild index | Export from SQLite + ChromaDB |
 | **Runtime dependency** | Python (`memsearch` CLI) + `claude` CLI | Node.js / Bun + Express worker service |
@@ -556,6 +556,8 @@ The plugin checks for the required API key at session start. If missing, memory 
 | `openai` (Python API default) | `OPENAI_API_KEY` |
 | `google` | `GOOGLE_API_KEY` |
 | `voyage` | `VOYAGE_API_KEY` |
+| `jina` | `JINA_API_KEY` |
+| `mistral` | `MISTRAL_API_KEY` |
 | `ollama` | None (local) |
 | `local` | None (local) |
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -47,6 +47,8 @@ _required_env_var() {
     openai) echo "OPENAI_API_KEY" ;;
     google) echo "GOOGLE_API_KEY" ;;
     voyage) echo "VOYAGE_API_KEY" ;;
+    jina) echo "JINA_API_KEY" ;;
+    mistral) echo "MISTRAL_API_KEY" ;;
     *) echo "" ;;  # onnx, ollama, local — no API key needed
   esac
 }

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -18,6 +18,8 @@ _required_env_var() {
     openai) echo "OPENAI_API_KEY" ;;
     google) echo "GOOGLE_API_KEY" ;;
     voyage) echo "VOYAGE_API_KEY" ;;
+    jina) echo "JINA_API_KEY" ;;
+    mistral) echo "MISTRAL_API_KEY" ;;
     *) echo "" ;;  # onnx, ollama, local — no API key needed
   esac
 }

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -45,6 +45,8 @@ _required_env_var() {
     openai) echo "OPENAI_API_KEY" ;;
     google) echo "GOOGLE_API_KEY" ;;
     voyage) echo "VOYAGE_API_KEY" ;;
+    jina) echo "JINA_API_KEY" ;;
+    mistral) echo "MISTRAL_API_KEY" ;;
     *) echo "" ;;  # onnx, ollama, local — no API key needed
   esac
 }

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -19,6 +19,8 @@ _required_env_var() {
     openai) echo "OPENAI_API_KEY" ;;
     google) echo "GOOGLE_API_KEY" ;;
     voyage) echo "VOYAGE_API_KEY" ;;
+    jina) echo "JINA_API_KEY" ;;
+    mistral) echo "MISTRAL_API_KEY" ;;
     *) echo "" ;;  # onnx, ollama, local — no API key needed
   esac
 }

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -94,7 +94,7 @@ Optional settings via `openclaw plugins config memsearch`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `provider` | `onnx` | Embedding provider (onnx, openai, google, voyage, ollama) |
+| `provider` | `onnx` | Embedding provider (onnx, openai, google, voyage, jina, mistral, ollama) |
 | `autoCapture` | `true` | Auto-capture conversation summaries after each turn |
 | `autoRecall` | `true` | Auto-inject recent memories at agent start |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
 [project.optional-dependencies]
 google = ["google-genai>=1.0"]
 voyage = ["voyageai>=0.3"]
+jina = ["httpx>=0.27"]
+mistral = ["mistralai>=1.0"]
 ollama = [
     "ollama>=0.4",
 ]
@@ -43,7 +45,7 @@ onnx = [
     "tokenizers>=0.15",
     "huggingface-hub>=0.20",
 ]
-all = ["memsearch[google,voyage,ollama,local,anthropic,onnx]"]
+all = ["memsearch[google,voyage,jina,mistral,ollama,local,anthropic,onnx]"]
 
 [project.scripts]
 memsearch = "memsearch.cli:cli"

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -652,11 +652,14 @@ def config_init(project: bool) -> None:
         "openai": "text-embedding-3-small",
         "google": "gemini-embedding-001",
         "voyage": "voyage-3-lite",
+        "jina": "jina-embeddings-v4",
+        "mistral": "mistral-embed",
         "ollama": "nomic-embed-text",
         "local": "all-MiniLM-L6-v2",
+        "onnx": "gpahal/bge-m3-onnx-int8",
     }
     result["embedding"]["provider"] = click.prompt(
-        "  Provider (openai/google/voyage/ollama/local)",
+        "  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx)",
         default=current.embedding.provider,
     )
     _emb_provider = result["embedding"]["provider"]

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -23,6 +23,8 @@ _PROVIDERS: dict[str, tuple[str, str]] = {
     "openai": ("memsearch.embeddings.openai", "OpenAIEmbedding"),
     "google": ("memsearch.embeddings.google", "GoogleEmbedding"),
     "voyage": ("memsearch.embeddings.voyage", "VoyageEmbedding"),
+    "jina": ("memsearch.embeddings.jina", "JinaEmbedding"),
+    "mistral": ("memsearch.embeddings.mistral", "MistralEmbedding"),
     "ollama": ("memsearch.embeddings.ollama", "OllamaEmbedding"),
     "local": ("memsearch.embeddings.local", "LocalEmbedding"),
     "onnx": ("memsearch.embeddings.onnx", "OnnxEmbedding"),
@@ -34,6 +36,8 @@ DEFAULT_MODELS: dict[str, str] = {
     "openai": "text-embedding-3-small",
     "google": "gemini-embedding-001",
     "voyage": "voyage-3-lite",
+    "jina": "jina-embeddings-v4",
+    "mistral": "mistral-embed",
     "ollama": "nomic-embed-text",
     "local": "all-MiniLM-L6-v2",
     "onnx": "gpahal/bge-m3-onnx-int8",
@@ -43,6 +47,8 @@ _INSTALL_HINTS: dict[str, str] = {
     "openai": "pip install memsearch  (or: uv add memsearch)",
     "google": 'pip install "memsearch[google]"  (or: uv add "memsearch[google]")',
     "voyage": 'pip install "memsearch[voyage]"  (or: uv add "memsearch[voyage]")',
+    "jina": 'pip install "memsearch[jina]"  (or: uv add "memsearch[jina]")',
+    "mistral": 'pip install "memsearch[mistral]"  (or: uv add "memsearch[mistral]")',
     "ollama": 'pip install "memsearch[ollama]"  (or: uv add "memsearch[ollama]")',
     "local": 'pip install "memsearch[local]"  (or: uv add "memsearch[local]")',
     "onnx": 'pip install "memsearch[onnx]"  (or: uv add "memsearch[onnx]")',
@@ -96,6 +102,8 @@ def get_provider(
             kwargs["base_url"] = base_url
         if api_key:
             kwargs["api_key"] = api_key
+    elif name in ("jina", "mistral") and api_key:
+        kwargs["api_key"] = api_key
     return cls(**kwargs)
 
 

--- a/src/memsearch/embeddings/jina.py
+++ b/src/memsearch/embeddings/jina.py
@@ -1,0 +1,96 @@
+"""Jina AI embedding provider.
+
+Requires: ``pip install 'memsearch[jina]'`` or ``uv add 'memsearch[jina]'``
+Environment variables:
+    JINA_API_KEY — required
+
+Jina does not publish a dedicated Python SDK for its embedding REST API, so
+this provider talks to ``https://api.jina.ai/v1/embeddings`` directly via
+httpx. The default model is the latest ``jina-embeddings-v4`` (2048-dim,
+Matryoshka-truncatable between 256 and 2048).
+
+The ``task`` parameter activates a task-specific LoRA adapter. memsearch
+embeds stored chunks and user queries through the same ``embed()`` call, so
+we default to ``retrieval.passage`` — the common case for indexing a memory
+corpus. Override via the constructor if you need query- or code-specific
+behavior.
+"""
+
+from __future__ import annotations
+
+import os
+
+_API_URL = "https://api.jina.ai/v1/embeddings"
+
+# Native output dimensions for well-known Jina models. v4 additionally
+# supports Matryoshka truncation between 256 and 2048; callers can override
+# by passing ``dimensions=`` to the constructor.
+_KNOWN_DIMENSIONS: dict[str, int] = {
+    "jina-embeddings-v4": 2048,
+    "jina-embeddings-v3": 1024,
+    "jina-embeddings-v2-base-en": 768,
+    "jina-embeddings-v2-base-code": 768,
+}
+
+
+class JinaEmbedding:
+    """Jina AI embedding provider (REST)."""
+
+    _DEFAULT_BATCH_SIZE = 128
+    _TIMEOUT_SECONDS = 60.0
+
+    def __init__(
+        self,
+        model: str = "jina-embeddings-v4",
+        *,
+        batch_size: int = 0,
+        task: str = "retrieval.passage",
+        dimensions: int | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        import httpx
+
+        self._api_key = api_key or os.environ.get("JINA_API_KEY")
+        if not self._api_key:
+            raise RuntimeError("JINA_API_KEY is required for the Jina embedding provider")
+
+        self._model = model
+        self._task = task
+        self._dimensions = dimensions if dimensions is not None else _KNOWN_DIMENSIONS.get(model, 2048)
+        self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE
+        self._client = httpx.AsyncClient(timeout=self._TIMEOUT_SECONDS)
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def dimension(self) -> int:
+        return self._dimensions
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        from .utils import batched_embed
+
+        return await batched_embed(texts, self._embed_batch, self._batch_size)
+
+    async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        body: dict = {
+            "model": self._model,
+            "input": texts,
+        }
+        if self._task:
+            body["task"] = self._task
+        if self._dimensions:
+            body["dimensions"] = self._dimensions
+
+        resp = await self._client.post(
+            _API_URL,
+            json=body,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        return [item["embedding"] for item in payload["data"]]

--- a/src/memsearch/embeddings/mistral.py
+++ b/src/memsearch/embeddings/mistral.py
@@ -1,0 +1,74 @@
+"""Mistral AI embedding provider.
+
+Requires: ``pip install 'memsearch[mistral]'`` or ``uv add 'memsearch[mistral]'``
+Environment variables:
+    MISTRAL_API_KEY — required
+
+Uses the official ``mistralai`` Python SDK. The default model is
+``mistral-embed`` — Mistral's general-purpose text embedding model
+(1024-dim, 8K context). Code-heavy corpora may prefer ``codestral-embed``.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Known output dimensions for Mistral embedding models.
+_KNOWN_DIMENSIONS: dict[str, int] = {
+    "mistral-embed": 1024,
+    "codestral-embed": 1536,
+    "codestral-embed-2505": 1536,
+}
+
+
+class MistralEmbedding:
+    """Mistral AI embedding provider."""
+
+    _DEFAULT_BATCH_SIZE = 64
+
+    def __init__(
+        self,
+        model: str = "mistral-embed",
+        *,
+        batch_size: int = 0,
+        api_key: str | None = None,
+    ) -> None:
+        from mistralai.client import Mistral
+
+        self._api_key = api_key or os.environ.get("MISTRAL_API_KEY")
+        if not self._api_key:
+            raise RuntimeError("MISTRAL_API_KEY is required for the Mistral embedding provider")
+
+        self._client = Mistral(api_key=self._api_key)
+        self._model = model
+        self._dimension = _detect_dimension(self._client, model)
+        self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        from .utils import batched_embed
+
+        return await batched_embed(texts, self._embed_batch, self._batch_size)
+
+    async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        resp = await self._client.embeddings.create_async(model=self._model, inputs=texts)
+        return [item.embedding for item in resp.data]
+
+
+def _detect_dimension(client, model: str) -> int:
+    """Return the embedding dimension for *model*.
+
+    Uses a lookup table for well-known Mistral models. For unknown models,
+    a sync trial embed is performed to discover the dimension.
+    """
+    if model in _KNOWN_DIMENSIONS:
+        return _KNOWN_DIMENSIONS[model]
+    trial = client.embeddings.create(model=model, inputs=["dim"])
+    return len(trial.data[0].embedding)

--- a/uv.lock
+++ b/uv.lock
@@ -731,6 +731,15 @@ wheels = [
 ]
 
 [[package]]
+name = "eval-type-backport"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a3/cafafb4558fd638aadfe4121dc6cefb8d743368c085acb2f521df0f3d9d7/eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed", size = 9445, upload-time = "2025-12-02T11:51:42.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/22/fdc2e30d43ff853720042fa15baa3e6122722be1a7950a98233ebb55cd71/eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8", size = 6063, upload-time = "2025-12-02T11:51:41.665Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1139,6 +1148,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,6 +1296,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpath-python"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/db/2f4ecc24da35c6142b39c353d5b7c16eef955cc94b35a48d3fa47996d7c3/jsonpath_python-1.1.5.tar.gz", hash = "sha256:ceea2efd9e56add09330a2c9631ea3d55297b9619348c1055e5bfb9cb0b8c538", size = 87352, upload-time = "2026-03-17T06:16:40.597Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/50/1a313fb700526b134c71eb8a225d8b83be0385dbb0204337b4379c698cef/jsonpath_python-1.1.5-py3-none-any.whl", hash = "sha256:a60315404d70a65e76c9a782c84e50600480221d94a58af47b7b4d437351cb4b", size = 14090, upload-time = "2026-03-17T06:16:39.152Z" },
 ]
 
 [[package]]
@@ -1451,7 +1481,9 @@ all = [
     { name = "anthropic" },
     { name = "einops" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "huggingface-hub" },
+    { name = "mistralai" },
     { name = "ollama" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1465,9 +1497,15 @@ anthropic = [
 google = [
     { name = "google-genai" },
 ]
+jina = [
+    { name = "httpx" },
+]
 local = [
     { name = "einops" },
     { name = "sentence-transformers" },
+]
+mistral = [
+    { name = "mistralai" },
 ]
 ollama = [
     { name = "ollama" },
@@ -1502,9 +1540,11 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "einops", marker = "extra == 'local'", specifier = ">=0.8.2" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.0" },
+    { name = "httpx", marker = "extra == 'jina'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'onnx'", specifier = ">=0.20" },
-    { name = "memsearch", extras = ["google", "voyage", "ollama", "local", "anthropic", "onnx"], marker = "extra == 'all'" },
+    { name = "memsearch", extras = ["google", "voyage", "jina", "mistral", "ollama", "local", "anthropic", "onnx"], marker = "extra == 'all'" },
     { name = "milvus-lite", marker = "sys_platform != 'win32'", specifier = ">=2.5.0" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
     { name = "onnxruntime", marker = "python_full_version == '3.10.*' and extra == 'onnx'", specifier = ">=1.17,<1.24" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.17" },
@@ -1518,7 +1558,7 @@ requires-dist = [
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3" },
     { name = "watchdog", specifier = ">=4.0" },
 ]
-provides-extras = ["google", "voyage", "ollama", "local", "anthropic", "onnx", "all"]
+provides-extras = ["google", "voyage", "jina", "mistral", "ollama", "local", "anthropic", "onnx", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1555,6 +1595,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
     { url = "https://files.pythonhosted.org/packages/2e/cf/3d1fee5c16c7661cf53977067a34820f7269ed8ba99fe9cf35efc1700866/milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9", size = 45337093, upload-time = "2025-06-30T04:24:06.706Z" },
     { url = "https://files.pythonhosted.org/packages/d3/82/41d9b80f09b82e066894d9b508af07b7b0fa325ce0322980674de49106a0/milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c", size = 55263911, upload-time = "2025-06-30T04:24:19.434Z" },
+]
+
+[[package]]
+name = "mistralai"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eval-type-backport" },
+    { name = "httpx" },
+    { name = "jsonpath-python" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/08/f8fed64eab35ad1ded82f92bf834160302db19f5bbda5a904df7d4dbf3c4/mistralai-2.3.2.tar.gz", hash = "sha256:a02c7e90ac165e8680c849551ff5fe9788e9fc10b7dbe71817443dc63cc5e9c9", size = 394665, upload-time = "2026-04-10T14:05:36.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e0/9f246d18f8fe6e815f7cae88c437c986b342d3ff568607c8e0d53f4710d0/mistralai-2.3.2-py3-none-any.whl", hash = "sha256:dec05f446502289b76add9796d75465c070fc539b3c01d6f7d3297833bb64981", size = 935914, upload-time = "2026-04-10T14:05:37.845Z" },
 ]
 
 [[package]]
@@ -2247,6 +2306,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/a2/677f22c4b487effb8a09439fb6134034b5f0a39ca27df8b95fac23a93720/openai-2.17.0.tar.gz", hash = "sha256:47224b74bd20f30c6b0a6a329505243cb2f26d5cf84d9f8d0825ff8b35e9c999", size = 631445, upload-time = "2026-02-05T16:27:40.953Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/97/284535aa75e6e84ab388248b5a323fc296b1f70530130dee37f7f4fbe856/openai-2.17.0-py3-none-any.whl", hash = "sha256:4f393fd886ca35e113aac7ff239bcd578b81d8f104f5aedc7d3693eb2af1d338", size = 1069524, upload-time = "2026-02-05T16:27:38.941Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
 ]
 
 [[package]]
@@ -4332,6 +4417,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds two new optional embedding providers:

- **Jina** (`jina-embeddings-v4`, 2048-dim, Matryoshka-truncatable) — REST API via httpx, task-adapter aware (default `retrieval.passage`).
- **Mistral** (`mistral-embed`, 1024-dim, 8K context) — via official `mistralai` SDK; `codestral-embed` pre-registered for code corpora.

Both are gated behind optional extras (`memsearch[jina]` / `memsearch[mistral]`) and read standard SDK env vars (`JINA_API_KEY` / `MISTRAL_API_KEY`).

## Changes

- `src/memsearch/embeddings/jina.py`, `mistral.py` — new providers
- `src/memsearch/embeddings/__init__.py` — registry + install hints + `api_key` passthrough
- `src/memsearch/cli.py` — `config init` prompt now lists all 8 providers (fixed previously missing `onnx` too)
- `pyproject.toml` — new `[jina]` / `[mistral]` extras, included in `[all]`
- Plugin hooks (`plugins/{claude-code,codex}/hooks/{session-start,stop}.sh`) — extended the API-key detection switch so Jina/Mistral misconfigurations are properly surfaced instead of silently skipped
- Docs — updated every page that enumerates providers: index / getting-started / architecture / cli / python-api / comparison / configuration / why / for-developers / platform index pages + plugin READMEs + `CLAUDE.md`. The historical `docs/home/embedding-evaluation.md` is intentionally left unchanged (it records a past benchmark run, not the current provider list).

## Test plan

- [x] `uv run python -m pytest` — 108 tests pass
- [x] `uv run mkdocs build --strict` — docs build clean
- [x] `uv run ruff check` — lint clean
- [x] Smoke test: `get_provider("jina")` / `get_provider("mistral")` instantiate with expected dimensions (2048 / 1024)
- [ ] Live API round-trip (blocked by network sandbox on dev machine; reviewer to confirm with real keys if desired)