### PR TITLE
chore: bump memsearch 0.3.0 and claude-code plugin 0.3.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.2.4"
+version = "0.3.0"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Version bumps for release after PR #346 (Jina + Mistral embedding providers):

- **memsearch** (PyPI): 0.2.4 → **0.3.0** — minor bump; new optional providers (`[jina]`, `[mistral]`).
- **Claude Code plugin**: 0.3.4 → **0.3.5** — patch; `_required_env_var()` in `session-start.sh` / `stop.sh` now recognizes `jina` / `mistral` providers so missing keys are surfaced instead of silently ignored.
- **marketplace.json** also re-synced to 0.3.5 (was stale at 0.3.3 while `plugin.json` was 0.3.4).

## Test plan

- [x] `uv lock` regenerated
- [ ] After merge: tag `v0.3.0`, push to `official`, GitHub Actions auto-publishes to PyPI
- [ ] Marketplace picks up new plugin version on next `/plugin marketplace update`