### PR TITLE
docs: link OpenClaw troubleshooting from overview

### DIFF
--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -24,7 +24,7 @@ Codex CLI runs in a sandboxed environment by default. The memsearch plugin requi
 - **Install option**: The `install.sh` script configures `hooks.json` which works in any mode
 - **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only` with an isolated `CODEX_HOME` to prevent sandbox conflicts during summarization
 
-If you experience issues with the Stop hook in strict sandbox mode, see [Troubleshooting](../../platforms/claude-code/troubleshooting.md) for diagnostic steps.
+If you experience issues with the Stop hook in strict sandbox mode, see the [Codex troubleshooting guide](troubleshooting.md) for diagnostic steps.
 
 ---
 
@@ -54,3 +54,4 @@ If you experience issues with the Stop hook in strict sandbox mode, see [Trouble
 - [Installation](installation.md) -- prerequisites, install, pre-cache, uninstall, updating
 - [How It Works](how-it-works.md) -- hook architecture, capture mechanism, memory files, Milvus Lite handling
 - [Memory Recall](memory-recall.md) -- three-layer progressive disclosure, comparison with Claude Code, manual invocation
+- [Troubleshooting](troubleshooting.md) -- hook install issues, sandbox failures, recall diagnostics

--- a/docs/platforms/codex/troubleshooting.md
+++ b/docs/platforms/codex/troubleshooting.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+Common issues when using the memsearch Codex CLI plugin.
+
+---
+
+## Stop hook does not seem to capture anything
+
+### Checks
+
+- Confirm the plugin was installed with `plugins/codex/scripts/install.sh`
+- Verify Codex is actually running with hooks enabled
+- Check that `.memsearch/memory/` exists in the project root after a few turns
+
+### Why this happens
+
+Codex capture depends on hook execution plus the summarization command. If hooks are not installed, or the hook command cannot run, no memory file will be written.
+
+---
+
+## Strict sandbox mode blocks summarization
+
+### Symptoms
+
+- The Stop hook runs, but summarization fails
+- You see permission-related errors around Codex sandboxing
+
+### Checks
+
+- Reinstall the plugin so `hooks.json` is refreshed
+- Verify the hook is invoking `codex exec --ephemeral -s read-only`
+- Retry in a normal project directory with write access to `.memsearch/`
+
+### Why this happens
+
+The plugin isolates summarization to avoid contaminating the main Codex session, but the hook still needs enough filesystem access to write memory output.
+
+---
+
+## Memory recall does not trigger
+
+### Checks
+
+- Confirm the skill file was installed correctly
+- Ask a history-dependent question rather than a fresh factual question
+- Make sure `.memsearch/memory/` already contains prior summaries
+
+### Why this happens
+
+The recall path is skill-driven. If the skill is missing, or there is no prior memory to search, Codex will behave like a stateless assistant.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -11,7 +11,7 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
 | **Capture method** | Stop hook (async) | llm_output debounce | SQLite daemon | Stop hook (async) |
 | **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
-| **Recall mechanism** | SKILL.md (context: fork) | memory_search tool | memory_search tool | SKILL.md |
+| **Recall mechanism** | SKILL.md (context: fork) | memory tools (search/get/transcript) | memory tools (search/get/transcript) | SKILL.md |
 | **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |
 | **Isolation** | Per-project collection | Per-workspace collection | Per-project collection | Per-project collection |
 | **Install method** | Plugin marketplace | `openclaw plugins install` | npm + opencode.json | `install.sh` |

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -9,7 +9,7 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | Feature | [Claude Code](claude-code/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) | [Codex CLI](codex/index.md) |
 |---------|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
-| **Capture method** | Stop hook (async) | llm_output debounce | SQLite daemon | Stop hook (async) |
+| **Capture method** | Stop hook (async) | agent_end hook | SQLite daemon | Stop hook (async) |
 | **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
 | **Recall mechanism** | SKILL.md (context: fork) | memory tools (search/get/transcript) | memory tools (search/get/transcript) | SKILL.md |
 | **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -76,3 +76,4 @@ This means agents with different workspaces have isolated memories, while agents
 - [Installation](installation.md) -- prerequisites, install, uninstall
 - [How It Works](how-it-works.md) -- capture architecture, cold-start, memory files, multi-agent isolation
 - [Memory Tools](memory-tools.md) -- three registered tools, progressive recall, comparisons
+- [Troubleshooting](troubleshooting.md) -- plugin loading, missing captures, weak recall, workspace mix-ups

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -54,7 +54,7 @@ This means agents with different workspaces have isolated memories, while agents
 ## When Is This Useful?
 
 - **Multi-agent workflows.** You use OpenClaw's main agent for general coding and a work agent for devops. Each needs its own context -- memsearch isolates them automatically.
-- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures every turn with debounced llm_output hooks, so nothing is lost even in marathon sessions.
+- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures completed turns through the plugin lifecycle and falls back to `agent_end`, so context is preserved even across long sessions and non-interactive runs.
 - **Cross-platform memory.** You use OpenClaw for some projects and Claude Code for others. memsearch's markdown-based storage means memories are portable -- the same `.md` files work with any plugin.
 - **Auditing agent behavior.** memsearch's three-layer drill-down lets you trace from a summary back to the original JSONL transcript, useful for understanding what the agent actually did.
 
@@ -62,7 +62,7 @@ This means agents with different workspaces have isolated memories, while agents
 
 ## Key Features
 
-- **Automatic capture** -- conversations summarized and saved after each LLM response via debounced `llm_output` hook
+- **Automatic capture** -- completed turns are summarized through the plugin lifecycle, with `agent_end` providing a reliable fallback for non-interactive runs
 - **Three-layer progressive recall** -- search, expand, and drill into original transcripts ([details](memory-tools.md))
 - **Multi-agent isolation** -- each agent gets its own memory directory and Milvus collection
 - **Cold-start context** -- recent memories injected on agent start via `before_agent_start` hook

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Installation: platforms/codex/installation.md
     - How It Works: platforms/codex/how-it-works.md
     - Memory Recall: platforms/codex/memory-recall.md
+    - Troubleshooting: platforms/codex/troubleshooting.md
   - For Agent Developers:
     - CLI Reference: cli.md
     - Python API: python-api.md


### PR DESCRIPTION
$## Summary\n- add the missing troubleshooting link to the OpenClaw overview page\n- point readers to the existing OpenClaw troubleshooting guide from the page index\n- keep the rest of the OpenClaw documentation structure unchanged\n\nPart of #91\n\n## Validation\n- uv run mkdocs build