### PR TITLE
docs: add OpenClaw troubleshooting page

### DIFF
--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -24,7 +24,7 @@ Codex CLI runs in a sandboxed environment by default. The memsearch plugin requi
 - **Install option**: The `install.sh` script configures `hooks.json` which works in any mode
 - **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only` with an isolated `CODEX_HOME` to prevent sandbox conflicts during summarization
 
-If you experience issues with the Stop hook in strict sandbox mode, see [Troubleshooting](../../platforms/claude-code/troubleshooting.md) for diagnostic steps.
+If you experience issues with the Stop hook in strict sandbox mode, see the [Codex troubleshooting guide](troubleshooting.md) for diagnostic steps.
 
 ---
 
@@ -54,3 +54,4 @@ If you experience issues with the Stop hook in strict sandbox mode, see [Trouble
 - [Installation](installation.md) -- prerequisites, install, pre-cache, uninstall, updating
 - [How It Works](how-it-works.md) -- hook architecture, capture mechanism, memory files, Milvus Lite handling
 - [Memory Recall](memory-recall.md) -- three-layer progressive disclosure, comparison with Claude Code, manual invocation
+- [Troubleshooting](troubleshooting.md) -- hook install issues, sandbox failures, recall diagnostics

--- a/docs/platforms/codex/troubleshooting.md
+++ b/docs/platforms/codex/troubleshooting.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+Common issues when using the memsearch Codex CLI plugin.
+
+---
+
+## Stop hook does not seem to capture anything
+
+### Checks
+
+- Confirm the plugin was installed with `plugins/codex/scripts/install.sh`
+- Verify Codex is actually running with hooks enabled
+- Check that `.memsearch/memory/` exists in the project root after a few turns
+
+### Why this happens
+
+Codex capture depends on hook execution plus the summarization command. If hooks are not installed, or the hook command cannot run, no memory file will be written.
+
+---
+
+## Strict sandbox mode blocks summarization
+
+### Symptoms
+
+- The Stop hook runs, but summarization fails
+- You see permission-related errors around Codex sandboxing
+
+### Checks
+
+- Reinstall the plugin so `hooks.json` is refreshed
+- Verify the hook is invoking `codex exec --ephemeral -s read-only`
+- Retry in a normal project directory with write access to `.memsearch/`
+
+### Why this happens
+
+The plugin isolates summarization to avoid contaminating the main Codex session, but the hook still needs enough filesystem access to write memory output.
+
+---
+
+## Memory recall does not trigger
+
+### Checks
+
+- Confirm the skill file was installed correctly
+- Ask a history-dependent question rather than a fresh factual question
+- Make sure `.memsearch/memory/` already contains prior summaries
+
+### Why this happens
+
+The recall path is skill-driven. If the skill is missing, or there is no prior memory to search, Codex will behave like a stateless assistant.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -11,7 +11,7 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
 | **Capture method** | Stop hook (async) | llm_output debounce | SQLite daemon | Stop hook (async) |
 | **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
-| **Recall mechanism** | SKILL.md (context: fork) | memory_search tool | memory_search tool | SKILL.md |
+| **Recall mechanism** | SKILL.md (context: fork) | memory tools (search/get/transcript) | memory tools (search/get/transcript) | SKILL.md |
 | **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |
 | **Isolation** | Per-project collection | Per-workspace collection | Per-project collection | Per-project collection |
 | **Install method** | Plugin marketplace | `openclaw plugins install` | npm + opencode.json | `install.sh` |

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -9,7 +9,7 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | Feature | [Claude Code](claude-code/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) | [Codex CLI](codex/index.md) |
 |---------|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
-| **Capture method** | Stop hook (async) | llm_output debounce | SQLite daemon | Stop hook (async) |
+| **Capture method** | Stop hook (async) | agent_end hook | SQLite daemon | Stop hook (async) |
 | **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
 | **Recall mechanism** | SKILL.md (context: fork) | memory tools (search/get/transcript) | memory tools (search/get/transcript) | SKILL.md |
 | **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -76,3 +76,4 @@ This means agents with different workspaces have isolated memories, while agents
 - [Installation](installation.md) -- prerequisites, install, uninstall
 - [How It Works](how-it-works.md) -- capture architecture, cold-start, memory files, multi-agent isolation
 - [Memory Tools](memory-tools.md) -- three registered tools, progressive recall, comparisons
+- [Troubleshooting](troubleshooting.md) -- plugin loading, missing captures, weak recall, workspace mix-ups

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -54,7 +54,7 @@ This means agents with different workspaces have isolated memories, while agents
 ## When Is This Useful?
 
 - **Multi-agent workflows.** You use OpenClaw's main agent for general coding and a work agent for devops. Each needs its own context -- memsearch isolates them automatically.
-- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures every turn with debounced llm_output hooks, so nothing is lost even in marathon sessions.
+- **Long-running agent sessions.** OpenClaw agents can run for extended periods in TUI mode. memsearch captures completed turns through the plugin lifecycle and falls back to `agent_end`, so context is preserved even across long sessions and non-interactive runs.
 - **Cross-platform memory.** You use OpenClaw for some projects and Claude Code for others. memsearch's markdown-based storage means memories are portable -- the same `.md` files work with any plugin.
 - **Auditing agent behavior.** memsearch's three-layer drill-down lets you trace from a summary back to the original JSONL transcript, useful for understanding what the agent actually did.
 
@@ -62,7 +62,7 @@ This means agents with different workspaces have isolated memories, while agents
 
 ## Key Features
 
-- **Automatic capture** -- conversations summarized and saved after each LLM response via debounced `llm_output` hook
+- **Automatic capture** -- completed turns are summarized through the plugin lifecycle, with `agent_end` providing a reliable fallback for non-interactive runs
 - **Three-layer progressive recall** -- search, expand, and drill into original transcripts ([details](memory-tools.md))
 - **Multi-agent isolation** -- each agent gets its own memory directory and Milvus collection
 - **Cold-start context** -- recent memories injected on agent start via `before_agent_start` hook

--- a/docs/platforms/openclaw/troubleshooting.md
+++ b/docs/platforms/openclaw/troubleshooting.md
@@ -1,0 +1,157 @@
+# Troubleshooting
+
+Common issues when using the memsearch OpenClaw plugin.
+
+---
+
+## Plugin installed but memory tools do not appear
+
+### Symptoms
+
+- `memory_search`, `memory_get`, or `memory_transcript` are missing
+- OpenClaw starts normally, but memsearch seems inactive
+
+### Checks
+
+1. Confirm `memsearch` itself is installed:
+
+```bash
+memsearch --help
+```
+
+2. Confirm the plugin is installed:
+
+```bash
+openclaw plugins list
+```
+
+3. Restart the gateway after installation or config changes:
+
+```bash
+openclaw gateway restart
+```
+
+### Why this happens
+
+The plugin is loaded by the OpenClaw gateway. If the package was installed but the gateway was not restarted, OpenClaw may still be running an older plugin state.
+
+---
+
+## Conversations are not being captured into `.memsearch/memory/`
+
+### Symptoms
+
+- The plugin loads, but no daily markdown files appear
+- Recall tools return little or no history after several conversations
+
+### Checks
+
+For the main agent workspace:
+
+```bash
+ls ~/.openclaw/workspace/.memsearch/memory/
+```
+
+For a custom agent, check that agent's workspace instead.
+
+### Things to verify
+
+- `autoCapture` is enabled in `openclaw plugins config memsearch`
+- You have completed at least one normal conversation turn
+- The OpenClaw workspace is writable
+
+### Why this happens
+
+The plugin captures memory from OpenClaw lifecycle hooks and writes summaries into the current agent workspace. If capture is disabled or you are checking the wrong workspace, it can look like memory is missing.
+
+---
+
+## Recall is weak or returns the wrong memories
+
+### Symptoms
+
+- Relevant memories are missing from results
+- Keyword-heavy queries do not show the expected entries
+
+### Checks
+
+1. Make sure memory files actually exist:
+
+```bash
+find ~/.openclaw -path '*/.memsearch/memory/*.md' | head
+```
+
+2. Rebuild the index if you imported or edited markdown files manually:
+
+```bash
+memsearch index ~/.openclaw/workspace/.memsearch/memory
+```
+
+3. Confirm your embedding backend is configured correctly:
+
+```bash
+memsearch config get embedding.provider
+```
+
+### Why this happens
+
+memsearch stores memories as markdown and indexes them into Milvus. If markdown changed without re-indexing, or the embedding backend is misconfigured, retrieval quality will drop.
+
+---
+
+## The plugin is using the wrong memory set for a different agent
+
+### Symptoms
+
+- `main` and `work` seem to share context unexpectedly
+- A custom agent cannot find memories you expected
+
+### Why this happens
+
+memsearch isolates OpenClaw memory by **workspace directory**, not by agent name alone. Different agents only share memory when they point to the same workspace path.
+
+### Fix
+
+Check the workspace configured for each agent and make sure it matches your intended isolation model.
+
+If you want separate memories, use separate workspaces. If you want shared memories across platforms, point the agent workspace at the same project directory used elsewhere.
+
+---
+
+## Cold-start memory injection does not show recent context
+
+### Symptoms
+
+- A new session starts without visible recent-memory context
+- The agent seems unaware of recent work until tools are called manually
+
+### Checks
+
+- Ensure `autoRecall` is enabled in plugin config
+- Verify recent memory files contain bullet-point entries
+- Start a fresh agent session after enabling the plugin
+
+### Why this happens
+
+The plugin injects recent context during `before_agent_start`. If there is no recent captured memory yet, there may be little to inject.
+
+---
+
+## Install from source works, but local changes do not seem to apply
+
+### Symptoms
+
+- You edited `plugins/openclaw/`, but behavior did not change
+
+### Fix
+
+Reinstall the local plugin path and restart the gateway:
+
+```bash
+openclaw plugins install ./plugins/openclaw
+openclaw gateway restart
+```
+
+### Why this happens
+
+The gateway loads the installed plugin, not your editor buffer. Local file changes only take effect after reinstalling and restarting the gateway.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Installation: platforms/codex/installation.md
     - How It Works: platforms/codex/how-it-works.md
     - Memory Recall: platforms/codex/memory-recall.md
+    - Troubleshooting: platforms/codex/troubleshooting.md
   - For Agent Developers:
     - CLI Reference: cli.md
     - Python API: python-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - Installation: platforms/openclaw/installation.md
     - How It Works: platforms/openclaw/how-it-works.md
     - Memory Tools: platforms/openclaw/memory-tools.md
+    - Troubleshooting: platforms/openclaw/troubleshooting.md
   - OpenCode Plugin:
     - Overview: platforms/opencode/index.md
     - Installation: platforms/opencode/installation.md


### PR DESCRIPTION
$## Summary\n- add a dedicated OpenClaw troubleshooting page covering plugin loading, missing captures, weak recall, workspace mix-ups, and source installs\n- expose the page in MkDocs navigation\n- make the existing OpenClaw overview link resolve to a real page\n\nPart of #91\n\n## Validation\n- uv run mkdocs build