### PR TITLE
Expand memory-recall skill description for better trigger coverage

### DIFF
--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-recall
-description: "Search and recall relevant memories from past sessions. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge. Also use when you see '[memsearch] Memory available' hints."
+description: "Search and recall relevant memories from past sessions via memsearch. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge -- especially questions like 'what did I decide about X', 'why did we do Y', or 'have I seen this before'. Also use when you see `[memsearch] Memory available` hints injected via SessionStart or UserPromptSubmit. Typical flow: search for 3-5 chunks, expand the most relevant, optionally deep-drill into original transcripts via the anchor format. Skip when the question is purely about current code state (use Read/Grep), ephemeral (today's task only), or the user has explicitly asked to ignore memory."
 context: fork
 allowed-tools: Bash
 ---

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-recall
-description: "Search and recall relevant memories from past sessions. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge. Also use when you see '[memsearch] Memory available' hints."
+description: "Search and recall relevant memories from past sessions via memsearch. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge -- especially questions like 'what did I decide about X', 'why did we do Y', or 'have I seen this before'. Also use when you see `[memsearch] Memory available` hints injected via SessionStart or UserPromptSubmit. Typical flow: search for 3-5 chunks, expand the most relevant, optionally deep-drill into original transcripts via the anchor format. Skip when the question is purely about current code state (use Read/Grep), ephemeral (today's task only), or the user has explicitly asked to ignore memory."
 ---
 
 You are performing memory retrieval for memsearch. Search past memories and return the most relevant context to the current conversation.

--- a/plugins/openclaw/skills/memory-recall/SKILL.md
+++ b/plugins/openclaw/skills/memory-recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-recall
-description: "Search and recall relevant memories from past sessions. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge."
+description: "Search and recall relevant memories from past sessions via memsearch. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge -- especially questions like 'what did I decide about X', 'why did we do Y', or 'have I seen this before'. Also use when you see `[memsearch] Memory available` hints injected via SessionStart or UserPromptSubmit. Typical flow: search for 3-5 chunks, expand the most relevant, optionally deep-drill into original transcripts via the anchor format. Skip when the question is purely about current code state (use Read/Grep), ephemeral (today's task only), or the user has explicitly asked to ignore memory."
 metadata:
   openclaw:
     emoji: "🧠"

--- a/plugins/opencode/skills/memory-recall/SKILL.md
+++ b/plugins/opencode/skills/memory-recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-recall
-description: "Search and recall relevant memories from past sessions. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge."
+description: "Search and recall relevant memories from past sessions via memsearch. Use when the user's question could benefit from historical context, past decisions, debugging notes, previous conversations, or project knowledge -- especially questions like 'what did I decide about X', 'why did we do Y', or 'have I seen this before'. Also use when you see `[memsearch] Memory available` hints injected via SessionStart or UserPromptSubmit. Typical flow: search for 3-5 chunks, expand the most relevant, optionally deep-drill into original transcripts via the anchor format. Skip when the question is purely about current code state (use Read/Grep), ephemeral (today's task only), or the user has explicitly asked to ignore memory."
 allowed-tools: Bash
 ---
 


### PR DESCRIPTION
## Summary

- Claude Code 2.1.105 raised the skill description cap from 250 to 1,536 chars and warns on truncation. The current `memory-recall` description sits close to the old cap.
- Rewrite the description (~740 chars) to include example trigger phrasings, the search/expand/deep-drill flow, and skip conditions, so the model matches the right situations on first shot.
- Apply the same body across every harness plugin variant for consistent trigger behavior.

## Test plan

- [x] All four `SKILL.md` frontmatters remain valid YAML.
- [x] Description length under the 1,536-char cap.
- [x] No behavioral changes; skill body content unchanged.