### PR TITLE
test(chunker): cover angle bracket fallback splitting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This page explains the technical architecture and key implementation decisions behind memsearch. For design principles, competitor comparison, and the "why" behind these decisions, see [Design Philosophy](design-philosophy.md).
+This page explains the technical architecture and key implementation decisions behind memsearch. New here? Start with [Getting Started](getting-started.md) for the end-to-end user flow before diving into internals. For design principles, competitor comparison, and the "why" behind these decisions, see [Design Philosophy](design-philosophy.md).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,8 @@
 
 memsearch provides a command-line interface for indexing, searching, and managing semantic memory over markdown knowledge bases.
 
+> New to memsearch? Start with the [Getting Started guide](getting-started.md) for installation, first index, and first search before using this command reference.
+
 ```bash
 $ memsearch --version
 memsearch, version 0.1.3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -634,6 +634,7 @@ mem = MemSearch(paths=["./docs/shared-knowledge", "./.memsearch/memory"])
 - **[Architecture](architecture.md)** -- deep dive into the chunking pipeline, dedup strategy, and data flow diagrams
 - **[Design Philosophy](design-philosophy.md)** -- why markdown, why Milvus, comparison with competitors
 - **[CLI Reference](cli.md)** -- complete reference for all `memsearch` commands, flags, and options
+- **[Integrations](integrations.md)** -- see framework and agent integration patterns
 - **[Claude Code Plugin](platforms/claude-code/index.md)** -- install memsearch for Claude Code
 - **[Platform Comparison](platforms/index.md)** -- compare all 4 supported platforms
 - **[Python API](python-api.md)** -- build custom agent integrations

--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -49,7 +49,7 @@ memsearch expand <chunk_hash>               # expand a chunk
 memsearch watch ./memory                    # live file watcher
 ```
 
-See the full [CLI Reference →](../cli.md) and [Python API →](../python-api.md).
+See the full [CLI Reference →](../cli.md), [Python API →](../python-api.md), and [Integrations →](../integrations.md).
 
 ## How Plugins Use the API
 

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -1,6 +1,6 @@
 # For Agent Users
 
-Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
+Pick your platform, install the plugin, and you're done. New to memsearch overall? Start with [Overview](../index.md) for the product tour or jump to [Getting Started](../getting-started.md) for the quickest setup path. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
 
 ## Choose Your Platform
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ print(results[0]["content"], results[0]["score"])       # content + similarity
 ```
 
 [:octicons-arrow-right-24: Python API reference](python-api.md){ .md-button }
+[:octicons-arrow-right-24: Integration patterns](integrations.md){ .md-button }
 
 ### CLI
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,6 +1,6 @@
 # Integrations
 
-memsearch is a plain Python library -- it works with any framework. This page shows ready-made patterns for **[LangChain](https://www.langchain.com/)**, **[LangGraph](https://langchain-ai.github.io/langgraph/)**, **[LlamaIndex](https://www.llamaindex.ai/)**, and **[CrewAI](https://www.crewai.com/)**.
+memsearch is a plain Python library -- it works with any framework. New to the project? Start with [Getting Started](getting-started.md) for installation and first indexing, or skim the [CLI Reference](cli.md) if you want the command surface first. This page shows ready-made patterns for **[LangChain](https://www.langchain.com/)**, **[LangGraph](https://langchain-ai.github.io/langgraph/)**, **[LlamaIndex](https://www.llamaindex.ai/)**, and **[CrewAI](https://www.crewai.com/)**.
 
 ---
 

--- a/docs/platforms/claude-code/index.md
+++ b/docs/platforms/claude-code/index.md
@@ -83,6 +83,7 @@ sequenceDiagram
 
 - [Installation](installation.md) -- install from marketplace or source, first-time setup
 - [How It Works](how-it-works.md) -- architecture, hooks, capture mechanism, memory storage
+- [Memory Surface](memory-tools.md) -- the practical recall/debugging surface: skill entry point, CLI commands, observability
 - [Memory Recall](memory-recall.md) -- three-layer progressive disclosure, comparisons, tips
 - [Troubleshooting](troubleshooting.md) -- debug mode, common issues, diagnostic commands
 

--- a/docs/platforms/claude-code/memory-tools.md
+++ b/docs/platforms/claude-code/memory-tools.md
@@ -1,0 +1,96 @@
+# Memory Surface
+
+The Claude Code plugin does not register MCP tools. Instead, it exposes memory through a combination of:
+
+- **Hooks** for session lifecycle and cold-start awareness
+- The **`memory-recall` skill** for autonomous retrieval
+- The **`memsearch` CLI** for manual diagnostics and debugging
+
+This page documents that practical memory surface in one place.
+
+---
+
+## Main Retrieval Entry Point
+
+For normal use, the entry point is the `memory-recall` skill.
+
+**Manual invocation:**
+
+```text
+/memory-recall what did we discuss about the auth refactor?
+```
+
+**Automatic invocation:** ask a question naturally when history matters:
+
+```text
+We changed the caching approach last week — what did we decide?
+```
+
+Claude can invoke the skill automatically when the question benefits from historical context.
+
+---
+
+## Retrieval Layers
+
+The `memory-recall` skill uses the same three-layer progressive disclosure model described in [Memory Recall](memory-recall.md):
+
+| Layer | Backend command | What it does |
+|------|------------------|--------------|
+| L1 | `memsearch search` | Find relevant indexed snippets |
+| L2 | `memsearch expand` | Expand a chunk into its full markdown section |
+| L3 | `memsearch transcript` / `transcript.py` | Drill into the original Claude Code conversation |
+
+The important difference from MCP-style systems is that these steps run inside the skill's forked subagent context, not as permanently registered tools in the main conversation.
+
+---
+
+## Manual CLI Surface
+
+The plugin is built on the `memsearch` CLI, so you can inspect and debug memory behavior manually from the shell.
+
+| Command | Typical use |
+|---------|-------------|
+| `memsearch search "<query>" --top-k 5 --json-output` | Check whether relevant memories are being found |
+| `memsearch expand <chunk_hash>` | Read the full markdown section around a result |
+| `memsearch transcript <jsonl>` | Inspect the original transcript |
+| `memsearch stats` | Check collection name, chunk count, and dimensions |
+| `memsearch index .memsearch/memory/ --force` | Rebuild the index |
+| `memsearch reset --yes` | Drop indexed data for the current collection |
+
+When debugging Claude Code plugin issues, `search`, `expand`, and `stats` are the fastest sanity checks.
+
+---
+
+## Observability Surface
+
+Beyond the recall skill itself, the plugin exposes several lightweight signals:
+
+- **SessionStart status line** — shows embedding provider, Milvus path, and collection
+- **`[memsearch] Memory available` hint** — reminds Claude that recall exists
+- **`.memsearch/memory/YYYY-MM-DD.md`** — the markdown source of truth
+- **`.memsearch/.watch.pid`** — indicates whether the watch process is running
+- **Claude debug logs** (`claude --debug`) — reveal hook JSON, including `systemMessage` and `additionalContext`
+
+These are documented in more detail in [Troubleshooting](troubleshooting.md).
+
+---
+
+## When to Use Which Surface
+
+| Goal | Best entry point |
+|------|------------------|
+| Ask Claude about past work | Natural language prompt or `/memory-recall` |
+| Verify memories exist at all | `memsearch stats` |
+| Check whether search can find a topic | `memsearch search` |
+| Inspect full context around a hit | `memsearch expand` |
+| Inspect the exact original exchange | `memsearch transcript` |
+| Rebuild stale/broken index state | `memsearch index --force` |
+
+---
+
+## Related Pages
+
+- [Installation](installation.md)
+- [How It Works](how-it-works.md)
+- [Memory Recall](memory-recall.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -1,6 +1,6 @@
 # Platform Overview
 
-memsearch provides plugins for 4 AI coding agent platforms. All plugins share the same core architecture: capture conversations to markdown, index with Milvus, recall via semantic search.
+memsearch provides plugins for 4 AI coding agent platforms. If you're choosing a platform for the first time, start with [For Agent Users](../home/for-users.md) for install-oriented guidance, then use this page for the detailed comparison matrix. All plugins share the same core architecture: capture conversations to markdown, index with Milvus, recall via semantic search.
 
 ---
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -136,7 +136,7 @@ Semantic search across indexed chunks. Returns a list of result dicts, sorted by
 | `source` | `str` | Path to the source markdown file |
 | `heading` | `str` | The heading this chunk belongs to |
 | `heading_level` | `int` | Heading level (1–6, or 0 for no heading) |
-| `chunk_hash` | `str` | Unique chunk identifier |
+| `chunk_hash` | `str` | Unique chunk identifier. See [Architecture](architecture.md#how-it-works) for how content hashes and composite IDs are derived |
 | `start_line` | `int` | Start line in the source file |
 | `end_line` | `int` | End line in the source file |
 | `score` | `float` | Relevance score (higher is better) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Overview: platforms/claude-code/index.md
     - Installation: platforms/claude-code/installation.md
     - How It Works: platforms/claude-code/how-it-works.md
+    - Memory Surface: platforms/claude-code/memory-tools.md
     - Memory Recall: platforms/claude-code/memory-recall.md
     - Troubleshooting: platforms/claude-code/troubleshooting.md
   - OpenClaw Plugin:

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -27,7 +27,7 @@ if [ -n "$_GIT_ROOT" ]; then
 else
   _PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 fi
-MEMSEARCH_DIR="$_PROJECT_DIR/.memsearch"
+MEMSEARCH_DIR="${MEMSEARCH_DIR:-$_PROJECT_DIR/.memsearch}"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
 # Find memsearch binary: prefer PATH, fallback to uvx

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -73,13 +73,16 @@ with open(sys.argv[1]) as f:
     for line in f:
         try:
             obj = json.loads(line)
-            if obj.get('type') == 'event_msg':
-                p = obj.get('payload', {})
-                if p.get('type') == 'user_message':
-                    msg = p.get('message', '').strip()
-                    if msg:
-                        last_q = msg
-        except:
+            line_type = obj.get('type', '')
+            payload = obj.get('payload', obj)
+            if not isinstance(payload, dict):
+                continue
+            item_type = payload.get('type', '')
+            if item_type == 'user_message' and line_type in ('event_msg', 'user_message'):
+                msg = payload.get('message', '').strip()
+                if msg:
+                    last_q = msg
+        except Exception:
             pass
 # Truncate to first line, max 200 chars
 first_line = last_q.split('\n')[0][:200] if last_q else ''

--- a/plugins/codex/scripts/parse-rollout.sh
+++ b/plugins/codex/scripts/parse-rollout.sh
@@ -46,15 +46,21 @@ def truncate(text, max_chars):
         return text
     return text[:max_chars] + "...(truncated)"
 
+def _entry(obj):
+    """Normalize both nested event_msg/response_item lines and flat transcript lines."""
+    line_type = obj.get("type", "")
+    payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else obj
+    item_type = payload.get("type", "") if isinstance(payload, dict) else ""
+    return line_type, item_type, payload if isinstance(payload, dict) else {}
+
 def find_last_turn_start(lines):
     """Find the index of the last task_started event."""
     for i in range(len(lines) - 1, -1, -1):
         try:
             obj = json.loads(lines[i])
-            if obj.get("type") == "event_msg":
-                payload = obj.get("payload", {})
-                if payload.get("type") == "task_started":
-                    return i
+            line_type, item_type, _payload = _entry(obj)
+            if item_type == "task_started" and line_type in ("event_msg", "task_started"):
+                return i
         except Exception:
             pass
     return None
@@ -64,10 +70,9 @@ def find_last_user_message(lines):
     for i in range(len(lines) - 1, -1, -1):
         try:
             obj = json.loads(lines[i])
-            if obj.get("type") == "event_msg":
-                payload = obj.get("payload", {})
-                if payload.get("type") == "user_message":
-                    return i
+            line_type, item_type, _payload = _entry(obj)
+            if item_type == "user_message" and line_type in ("event_msg", "user_message"):
+                return i
         except Exception:
             pass
     return None
@@ -82,56 +87,47 @@ def format_turn(lines):
         except Exception:
             continue
 
-        line_type = obj.get("type", "")
-        payload = obj.get("payload", {})
+        line_type, item_type, payload = _entry(obj)
 
-        if line_type == "event_msg":
-            msg_type = payload.get("type", "")
+        if item_type == "user_message" and line_type in ("event_msg", "user_message"):
+            message = payload.get("message", "")
+            if message.strip():
+                output.append(f"[Human]: {message.strip()}")
 
-            if msg_type == "user_message":
-                message = payload.get("message", "")
-                if message.strip():
-                    output.append(f"[Human]: {message.strip()}")
+        elif item_type == "agent_message" and line_type in ("event_msg", "agent_message"):
+            message = payload.get("message", "")
+            if message.strip():
+                output.append(f"[Codex]: {message.strip()}")
 
-            elif msg_type == "agent_message":
-                message = payload.get("message", "")
-                if message.strip():
-                    output.append(f"[Codex]: {message.strip()}")
+        elif item_type == "function_call" and line_type in ("response_item", "function_call"):
+            name = payload.get("name", "unknown")
+            args = payload.get("arguments", "")
+            # Parse arguments JSON for concise display
+            try:
+                args_obj = json.loads(args) if isinstance(args, str) else args
+                if isinstance(args_obj, dict):
+                    parts = []
+                    for k, v in args_obj.items():
+                        v_str = str(v)
+                        if len(v_str) > 120:
+                            v_str = v_str[:120] + "..."
+                        parts.append(f"{k}={v_str}")
+                    args_summary = ", ".join(parts)
+                else:
+                    args_summary = str(args_obj)
+            except Exception:
+                args_summary = str(args)
+            if len(args_summary) > 400:
+                args_summary = args_summary[:400] + "..."
+            output.append(f"[Codex calls tool]: {name}({args_summary})")
 
-            # Skip: task_started, task_complete, token_count, agent_reasoning
+        elif item_type == "function_call_output" and line_type in ("response_item", "function_call_output"):
+            result = payload.get("output", "")
+            result = truncate(str(result), MAX_RESULT_CHARS)
+            output.append(f"[Tool output]: {result}")
 
-        elif line_type == "response_item":
-            item_type = payload.get("type", "")
-
-            if item_type == "function_call":
-                name = payload.get("name", "unknown")
-                args = payload.get("arguments", "")
-                # Parse arguments JSON for concise display
-                try:
-                    args_obj = json.loads(args) if isinstance(args, str) else args
-                    if isinstance(args_obj, dict):
-                        parts = []
-                        for k, v in args_obj.items():
-                            v_str = str(v)
-                            if len(v_str) > 120:
-                                v_str = v_str[:120] + "..."
-                            parts.append(f"{k}={v_str}")
-                        args_summary = ", ".join(parts)
-                    else:
-                        args_summary = str(args_obj)
-                except Exception:
-                    args_summary = str(args)
-                if len(args_summary) > 400:
-                    args_summary = args_summary[:400] + "..."
-                output.append(f"[Codex calls tool]: {name}({args_summary})")
-
-            elif item_type == "function_call_output":
-                result = payload.get("output", "")
-                result = truncate(str(result), MAX_RESULT_CHARS)
-                output.append(f"[Tool output]: {result}")
-
-            # Skip response_item "message" — duplicates event_msg user_message/agent_message.
-            # Skip: reasoning, session_meta, turn_context, web_search_call
+        # Skip response_item "message" — duplicates event_msg user_message/agent_message.
+        # Skip: task_started, task_complete, token_count, agent_reasoning
 
     return "\n".join(output)
 

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -236,7 +236,10 @@ def _split_large_section(
 
 # Sentence-ending punctuation for splitting long text without line breaks.
 # Includes common CJK punctuation plus Unicode/fullwidth ellipsis.
-_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F\uFF1B.!?;])\s*")
+# ASCII punctuation is only treated as a boundary when it looks like a real
+# sentence ending (followed by whitespace or end-of-string), which avoids
+# splitting inside emails, URLs, file extensions, and similar engineering text.
+_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)")
 
 
 def _split_long_text(text: str, max_size: int) -> list[str]:

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -239,7 +239,9 @@ def _split_large_section(
 # ASCII punctuation is only treated as a boundary when it looks like a real
 # sentence ending (followed by whitespace or end-of-string), which avoids
 # splitting inside emails, URLs, file extensions, and similar engineering text.
-_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)")
+_SENTENCE_END_RE = re.compile(
+    r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)"
+)
 
 
 def _split_long_text(text: str, max_size: int) -> list[str]:

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -235,7 +235,8 @@ def _split_large_section(
 
 
 # Sentence-ending punctuation for splitting long text without line breaks.
-_SENTENCE_END_RE = re.compile(r"[。\uFF01\uFF1F.!?]\s*")
+# Includes common CJK punctuation plus Unicode/fullwidth ellipsis.
+_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F.!?])\s*")
 
 
 def _split_long_text(text: str, max_size: int) -> list[str]:

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -236,7 +236,7 @@ def _split_large_section(
 
 # Sentence-ending punctuation for splitting long text without line breaks.
 # Includes common CJK punctuation plus Unicode/fullwidth ellipsis.
-_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F.!?])\s*")
+_SENTENCE_END_RE = re.compile(r"(?:……|…|[。\uFF01\uFF1F\uFF1B.!?;])\s*")
 
 
 def _split_long_text(text: str, max_size: int) -> list[str]:

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -245,7 +245,12 @@ def search(
 
 
 @cli.command()
-@click.option("--source-prefix", default=None, type=click.Path(), help="Only show memories whose source path starts with this prefix.")
+@click.option(
+    "--source-prefix",
+    default=None,
+    type=click.Path(),
+    help="Only show memories whose source path starts with this prefix.",
+)
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
 @_common_options
 def list(

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -245,6 +245,91 @@ def search(
 
 
 @cli.command()
+@click.option("--source-prefix", default=None, type=click.Path(), help="Only show memories whose source path starts with this prefix.")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+@_common_options
+def list(
+    source_prefix: str | None,
+    json_output: bool,
+    provider: str | None,
+    model: str | None,
+    batch_size: int | None,
+    base_url: str | None,
+    api_key: str | None,
+    collection: str | None,
+    milvus_uri: str | None,
+    milvus_token: str | None,
+) -> None:
+    """List indexed memories grouped by source file."""
+    from .store import MilvusStore
+
+    cfg = resolve_config(
+        _build_cli_overrides(
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            base_url=base_url,
+            api_key=api_key,
+            collection=collection,
+            milvus_uri=milvus_uri,
+            milvus_token=milvus_token,
+        )
+    )
+    store = MilvusStore(
+        uri=cfg.milvus.uri,
+        token=cfg.milvus.token or None,
+        collection=cfg.milvus.collection,
+        dimension=None,
+    )
+    try:
+        filter_expr = ""
+        if source_prefix is not None:
+            prefix = str(Path(source_prefix).expanduser().resolve())
+            escaped = prefix.replace("\\", "\\\\").replace('"', '\\"')
+            filter_expr = f'source like "{escaped}%"'
+
+        rows = store.query(filter_expr=filter_expr)
+        grouped: dict[str, dict[str, object]] = {}
+        for row in rows:
+            source = row.get("source", "")
+            heading = row.get("heading", "")
+            entry = grouped.setdefault(source, {"source": source, "chunk_count": 0, "headings": set()})
+            entry["chunk_count"] = int(entry["chunk_count"]) + 1
+            if heading:
+                headings = entry["headings"]
+                assert isinstance(headings, set)
+                headings.add(heading)
+
+        results = [
+            {
+                "source": source,
+                "chunk_count": data["chunk_count"],
+                "headings": sorted(data["headings"]),
+            }
+            for source, data in sorted(grouped.items())
+        ]
+
+        if json_output:
+            click.echo(json.dumps(results, indent=2, ensure_ascii=False))
+            return
+
+        if not results:
+            click.echo("No indexed memories found.")
+            return
+
+        for item in results:
+            click.echo(f"\n- {item['source']} ({item['chunk_count']} chunks)")
+            headings = item["headings"]
+            if headings:
+                for heading in headings[:5]:
+                    click.echo(f"  • {heading}")
+                if len(headings) > 5:
+                    click.echo(f"  • ... and {len(headings) - 5} more headings")
+    finally:
+        store.close()
+
+
+@cli.command()
 @click.argument("chunk_hash")
 @click.option("--section/--no-section", default=True, help="Show full heading section (default).")
 @click.option("--lines", "-n", default=None, type=int, help="Show N lines before/after instead of full section.")

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -371,15 +371,18 @@ class MemSearch:
         loop = asyncio.new_event_loop()
 
         def _on_change(event_type: str, file_path: Path) -> None:
-            if event_type == "deleted":
-                self._store.delete_by_source(str(file_path))
-                summary = f"Removed chunks for {file_path}"
-            else:
-                n = loop.run_until_complete(self.index_file(file_path))
-                summary = f"Indexed {n} chunks from {file_path}"
-            logger.info(summary)
-            if on_event is not None:
-                on_event(event_type, summary, file_path)
+            try:
+                if event_type == "deleted":
+                    self._store.delete_by_source(str(file_path))
+                    summary = f"Removed chunks for {file_path}"
+                else:
+                    n = loop.run_until_complete(self.index_file(file_path))
+                    summary = f"Indexed {n} chunks from {file_path}"
+                logger.info(summary)
+                if on_event is not None:
+                    on_event(event_type, summary, file_path)
+            except Exception:
+                logger.exception("Failed to process %s event for %s", event_type, file_path)
 
         fw_kwargs: dict[str, Any] = {}
         if debounce_ms is not None:

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any, ClassVar
 
+from pymilvus.exceptions import MilvusException
+
 logger = logging.getLogger(__name__)
 
 
@@ -201,7 +203,12 @@ class MilvusStore:
             "output_fields": self._QUERY_FIELDS,
             "filter": filter_expr if filter_expr else 'chunk_hash != ""',
         }
-        return self._client.query(**kwargs)
+        try:
+            return self._client.query(**kwargs)
+        except MilvusException as exc:
+            if "collection not found" in str(exc).lower():
+                return []
+            raise
 
     def hashes_by_source(self, source: str) -> set[str]:
         """Return all chunk_hash values for a given source file."""

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -350,12 +350,12 @@ def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
     assert not all(chunk.content.endswith(("@", ".")) for chunk in chunks[:-1])
 
 
-def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
-    """Email address punctuation should not be treated as sentence boundaries."""
-    text = ("请联系 ops-team@example.com 或 build.bot@example.org 确认状态" * 4)
+def test_mixed_file_extensions_do_not_act_as_sentence_boundaries() -> None:
+    """File extensions should not be treated as sentence boundaries."""
+    text = ("请检查 config.json、README.md 和 settings.yaml 是否都已更新" * 4)
 
-    chunks = chunk_markdown(text, source="emails.md", max_chunk_size=32)
+    chunks = chunk_markdown(text, source="file-ext.md", max_chunk_size=30)
 
     assert len(chunks) > 1
-    assert all(len(chunk.content) <= 32 for chunk in chunks)
-    assert not all(chunk.content.endswith(("@", ".")) for chunk in chunks[:-1])
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith("." ) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -141,3 +141,15 @@ def test_clean_content_handles_adjacent_html_comments() -> None:
     assert "first comment" not in cleaned
     assert "second comment" not in cleaned
     assert cleaned == "Header\n\nBody text"
+
+
+def test_long_cjk_text_splits_on_cjk_sentence_boundaries() -> None:
+    """Long Chinese text should prefer sentence-ending punctuation when split."""
+    sentence = "这是一个用于测试中文分句行为的长句子。"
+    text = sentence * 8
+
+    chunks = chunk_markdown(text, source="zh.md", max_chunk_size=40)
+
+    assert len(chunks) > 1
+    assert all(chunk.content.endswith("。") for chunk in chunks[:-1])
+    assert all(len(chunk.content) <= 40 for chunk in chunks)

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -257,3 +257,14 @@ def test_cjk_enumeration_comma_does_not_act_as_sentence_boundary() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 20 for chunk in chunks)
     assert not all(chunk.content.endswith("、") for chunk in chunks[:-1])
+
+
+def test_cjk_parentheses_do_not_act_as_sentence_boundaries() -> None:
+    """Fullwidth parentheses should not be treated as sentence boundaries."""
+    text = ("请检查缓存命中（重点关注热数据）再检查索引状态（确认已完成）" * 4)
+
+    chunks = chunk_markdown(text, source="parentheses.md", max_chunk_size=26)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 26 for chunk in chunks)
+    assert not all(chunk.content.endswith(("（", "）")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -235,3 +235,14 @@ def test_long_mixed_text_splits_on_ascii_semicolons() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
     assert all(chunk.content.endswith(";") for chunk in chunks[:-1])
+
+
+def test_cjk_colon_does_not_act_as_sentence_boundary() -> None:
+    """Fullwidth colons should not be treated as sentence boundaries."""
+    text = ("处理步骤如下：继续检查日志输出：继续确认索引状态：" * 4)
+
+    chunks = chunk_markdown(text, source="colon.md", max_chunk_size=22)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 22 for chunk in chunks)
+    assert not all(chunk.content.endswith("：") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -358,4 +358,15 @@ def test_mixed_file_extensions_do_not_act_as_sentence_boundaries() -> None:
 
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
-    assert not all(chunk.content.endswith("." ) for chunk in chunks[:-1])
+    assert not all(chunk.content.endswith(".") for chunk in chunks[:-1])
+
+
+def test_mixed_braces_do_not_act_as_sentence_boundaries() -> None:
+    """Braces in JSON/templates should not be treated as sentence boundaries."""
+    text = ("请检查 {\"status\":\"ok\"} 和 {build_result} 这两个片段是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="braces.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith(("{", "}")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -312,3 +312,14 @@ def test_mixed_hyphens_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
     assert not all(chunk.content.endswith("-") for chunk in chunks[:-1])
+
+
+def test_mixed_backslashes_do_not_act_as_sentence_boundaries() -> None:
+    """Backslashes in Windows-style paths should not be treated as sentence boundaries."""
+    text = (r"请检查 C:\logs\agent\run 和 config\\backup\\path 是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="backslashes.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith("\\") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -223,3 +223,15 @@ def test_long_cjk_text_splits_on_semicolon_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
     assert all(chunk.content.endswith("；") for chunk in chunks[:-1])
+
+
+def test_long_mixed_text_splits_on_ascii_semicolons() -> None:
+    """ASCII semicolons should also split mixed CJK/English long text."""
+    sentence = "先检查缓存; verify build;"
+    text = sentence * 6
+
+    chunks = chunk_markdown(text, source="mixed-semicolon.md", max_chunk_size=24)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 24 for chunk in chunks)
+    assert all(chunk.content.endswith(";") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -279,3 +279,14 @@ def test_cjk_quotes_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
     assert not all(chunk.content.endswith(("“", "”")) for chunk in chunks[:-1])
+
+
+def test_mixed_path_slashes_do_not_act_as_sentence_boundaries() -> None:
+    """Path-style slashes should not be treated as sentence boundaries."""
+    text = ("请检查 /var/log/app 和 docs/setup/path 再确认输出是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="slashes.md", max_chunk_size=28)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 28 for chunk in chunks)
+    assert not all(chunk.content.endswith("/") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -301,3 +301,14 @@ def test_mixed_underscores_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
     assert not all(chunk.content.endswith("_") for chunk in chunks[:-1])
+
+
+def test_mixed_hyphens_do_not_act_as_sentence_boundaries() -> None:
+    """Hyphens in flags/slugs should not be treated as sentence boundaries."""
+    text = ("请检查 --cache-hit-rate 和 build-status-done 这两个字段是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="hyphens.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith("-") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -157,13 +157,13 @@ def test_long_cjk_text_splits_on_cjk_sentence_boundaries() -> None:
 
 def test_long_cjk_text_splits_on_question_and_exclamation_marks() -> None:
     """Chinese question/exclamation punctuation should also act as boundaries."""
-    sentence = "这个问题应该怎么处理？这个方案真的可行！"
+    sentence = "这个问题应该怎么处理？这个方案真的可行！"  # noqa: RUF001
     text = sentence * 6
 
     chunks = chunk_markdown(text, source="zh-punct.md", max_chunk_size=30)
 
     assert len(chunks) > 1
-    assert all(chunk.content.endswith(("？", "！")) for chunk in chunks[:-1])
+    assert all(chunk.content.endswith(("？", "！")) for chunk in chunks[:-1])  # noqa: RUF001
     assert all(len(chunk.content) <= 30 for chunk in chunks)
 
 
@@ -204,25 +204,25 @@ def test_long_cjk_text_splits_on_ellipsis_boundaries() -> None:
 
 def test_cjk_wave_dash_does_not_act_as_sentence_boundary() -> None:
     """Fullwidth wave dash should fall back to hard splitting, not sentence splitting."""
-    text = ("这个步骤还没结束～～继续观察系统状态～～" * 5)
+    text = "这个步骤还没结束～～继续观察系统状态～～" * 5  # noqa: RUF001
 
     chunks = chunk_markdown(text, source="wave.md", max_chunk_size=24)
 
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
-    assert not all(chunk.content.endswith("～") for chunk in chunks[:-1])
+    assert not all(chunk.content.endswith("～") for chunk in chunks[:-1])  # noqa: RUF001
 
 
 def test_long_cjk_text_splits_on_semicolon_boundaries() -> None:
     """Chinese semicolons should act as sentence boundaries for long text."""
-    sentence = "先检查缓存命中率；再确认索引是否完成；"
+    sentence = "先检查缓存命中率；再确认索引是否完成；"  # noqa: RUF001
     text = sentence * 5
 
     chunks = chunk_markdown(text, source="semicolon.md", max_chunk_size=24)
 
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
-    assert all(chunk.content.endswith("；") for chunk in chunks[:-1])
+    assert all(chunk.content.endswith("；") for chunk in chunks[:-1])  # noqa: RUF001
 
 
 def test_long_mixed_text_splits_on_ascii_semicolons() -> None:
@@ -239,18 +239,18 @@ def test_long_mixed_text_splits_on_ascii_semicolons() -> None:
 
 def test_cjk_colon_does_not_act_as_sentence_boundary() -> None:
     """Fullwidth colons should not be treated as sentence boundaries."""
-    text = ("处理步骤如下：继续检查日志输出：继续确认索引状态：" * 4)
+    text = "处理步骤如下：继续检查日志输出：继续确认索引状态：" * 4  # noqa: RUF001
 
     chunks = chunk_markdown(text, source="colon.md", max_chunk_size=22)
 
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 22 for chunk in chunks)
-    assert not all(chunk.content.endswith("：") for chunk in chunks[:-1])
+    assert not all(chunk.content.endswith("：") for chunk in chunks[:-1])  # noqa: RUF001
 
 
 def test_cjk_enumeration_comma_does_not_act_as_sentence_boundary() -> None:
     """Chinese enumeration commas should not be treated as sentence boundaries."""
-    text = ("先检查缓存、再检查索引、最后检查日志、" * 5)
+    text = "先检查缓存、再检查索引、最后检查日志、" * 5
 
     chunks = chunk_markdown(text, source="enumeration.md", max_chunk_size=20)
 
@@ -261,18 +261,18 @@ def test_cjk_enumeration_comma_does_not_act_as_sentence_boundary() -> None:
 
 def test_cjk_parentheses_do_not_act_as_sentence_boundaries() -> None:
     """Fullwidth parentheses should not be treated as sentence boundaries."""
-    text = ("请检查缓存命中（重点关注热数据）再检查索引状态（确认已完成）" * 4)
+    text = "请检查缓存命中（重点关注热数据）再检查索引状态（确认已完成）" * 4  # noqa: RUF001
 
     chunks = chunk_markdown(text, source="parentheses.md", max_chunk_size=26)
 
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 26 for chunk in chunks)
-    assert not all(chunk.content.endswith(("（", "）")) for chunk in chunks[:-1])
+    assert not all(chunk.content.endswith(("（", "）")) for chunk in chunks[:-1])  # noqa: RUF001
 
 
 def test_cjk_quotes_do_not_act_as_sentence_boundaries() -> None:
     """Chinese quotes should not be treated as sentence boundaries."""
-    text = ("请检查“缓存命中率”是否正常再确认“索引状态”是否完成" * 4)
+    text = "请检查“缓存命中率”是否正常再确认“索引状态”是否完成" * 4
 
     chunks = chunk_markdown(text, source="quotes.md", max_chunk_size=24)
 
@@ -283,7 +283,7 @@ def test_cjk_quotes_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_path_slashes_do_not_act_as_sentence_boundaries() -> None:
     """Path-style slashes should not be treated as sentence boundaries."""
-    text = ("请检查 /var/log/app 和 docs/setup/path 再确认输出是否正常" * 4)
+    text = "请检查 /var/log/app 和 docs/setup/path 再确认输出是否正常" * 4
 
     chunks = chunk_markdown(text, source="slashes.md", max_chunk_size=28)
 
@@ -294,7 +294,7 @@ def test_mixed_path_slashes_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_underscores_do_not_act_as_sentence_boundaries() -> None:
     """Underscores in identifiers should not be treated as sentence boundaries."""
-    text = ("请检查 cache_hit_rate 和 build_status_done 这两个字段是否正常" * 4)
+    text = "请检查 cache_hit_rate 和 build_status_done 这两个字段是否正常" * 4
 
     chunks = chunk_markdown(text, source="underscores.md", max_chunk_size=30)
 
@@ -305,7 +305,7 @@ def test_mixed_underscores_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_hyphens_do_not_act_as_sentence_boundaries() -> None:
     """Hyphens in flags/slugs should not be treated as sentence boundaries."""
-    text = ("请检查 --cache-hit-rate 和 build-status-done 这两个字段是否正常" * 4)
+    text = "请检查 --cache-hit-rate 和 build-status-done 这两个字段是否正常" * 4
 
     chunks = chunk_markdown(text, source="hyphens.md", max_chunk_size=30)
 
@@ -316,7 +316,7 @@ def test_mixed_hyphens_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_backslashes_do_not_act_as_sentence_boundaries() -> None:
     """Backslashes in Windows-style paths should not be treated as sentence boundaries."""
-    text = (r"请检查 C:\logs\agent\run 和 config\\backup\\path 是否正常" * 4)
+    text = r"请检查 C:\logs\agent\run 和 config\\backup\\path 是否正常" * 4
 
     chunks = chunk_markdown(text, source="backslashes.md", max_chunk_size=30)
 
@@ -327,10 +327,7 @@ def test_mixed_backslashes_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_url_query_symbols_do_not_break_chunking() -> None:
     """URL query punctuation should not cause unexpected sentence splitting."""
-    text = (
-        "请检查 https://example.com/search?q=memsearch&lang=zh-CN 是否正常返回结果"
-        * 4
-    )
+    text = "请检查 https://example.com/search?q=memsearch&lang=zh-CN 是否正常返回结果" * 4
 
     chunks = chunk_markdown(text, source="url-query.md", max_chunk_size=34)
 
@@ -341,7 +338,7 @@ def test_mixed_url_query_symbols_do_not_break_chunking() -> None:
 
 def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
     """Email address punctuation should not be treated as sentence boundaries."""
-    text = ("请联系 ops-team@example.com 或 build.bot@example.org 确认状态" * 4)
+    text = "请联系 ops-team@example.com 或 build.bot@example.org 确认状态" * 4
 
     chunks = chunk_markdown(text, source="emails.md", max_chunk_size=32)
 
@@ -352,7 +349,7 @@ def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_file_extensions_do_not_act_as_sentence_boundaries() -> None:
     """File extensions should not be treated as sentence boundaries."""
-    text = ("请检查 config.json、README.md 和 settings.yaml 是否都已更新" * 4)
+    text = "请检查 config.json、README.md 和 settings.yaml 是否都已更新" * 4
 
     chunks = chunk_markdown(text, source="file-ext.md", max_chunk_size=30)
 
@@ -363,7 +360,7 @@ def test_mixed_file_extensions_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_braces_do_not_act_as_sentence_boundaries() -> None:
     """Braces in JSON/templates should not be treated as sentence boundaries."""
-    text = ("请检查 {\"status\":\"ok\"} 和 {build_result} 这两个片段是否正常" * 4)
+    text = '请检查 {"status":"ok"} 和 {build_result} 这两个片段是否正常' * 4
 
     chunks = chunk_markdown(text, source="braces.md", max_chunk_size=30)
 
@@ -374,7 +371,7 @@ def test_mixed_braces_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_brackets_do_not_act_as_sentence_boundaries() -> None:
     """Square brackets in logs/tags should not be treated as sentence boundaries."""
-    text = ("请检查 [INFO] agent_runner 和 [channel:ops] 输出是否正常" * 4)
+    text = "请检查 [INFO] agent_runner 和 [channel:ops] 输出是否正常" * 4
 
     chunks = chunk_markdown(text, source="brackets.md", max_chunk_size=30)
 
@@ -385,7 +382,7 @@ def test_mixed_brackets_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_ascii_parentheses_do_not_act_as_sentence_boundaries() -> None:
     """ASCII parentheses in calls/params should not be treated as sentence boundaries."""
-    text = ("请检查 run_task(cache_hit_rate) 和 handler(status_ok) 输出是否正常" * 4)
+    text = "请检查 run_task(cache_hit_rate) 和 handler(status_ok) 输出是否正常" * 4
 
     chunks = chunk_markdown(text, source="ascii-parens.md", max_chunk_size=32)
 
@@ -396,7 +393,7 @@ def test_mixed_ascii_parentheses_do_not_act_as_sentence_boundaries() -> None:
 
 def test_mixed_angle_brackets_do_not_act_as_sentence_boundaries() -> None:
     """Angle brackets in tags/placeholders should not be treated as sentence boundaries."""
-    text = ("请检查 <status_ok> 和 <agent_result> 这类片段是否正常" * 4)
+    text = "请检查 <status_ok> 和 <agent_result> 这类片段是否正常" * 4
 
     chunks = chunk_markdown(text, source="angles.md", max_chunk_size=28)
 

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -381,3 +381,14 @@ def test_mixed_brackets_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
     assert not all(chunk.content.endswith(("[", "]")) for chunk in chunks[:-1])
+
+
+def test_mixed_ascii_parentheses_do_not_act_as_sentence_boundaries() -> None:
+    """ASCII parentheses in calls/params should not be treated as sentence boundaries."""
+    text = ("请检查 run_task(cache_hit_rate) 和 handler(status_ok) 输出是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="ascii-parens.md", max_chunk_size=32)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 32 for chunk in chunks)
+    assert not all(chunk.content.endswith(("(", ")")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -348,3 +348,14 @@ def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 32 for chunk in chunks)
     assert not all(chunk.content.endswith(("@", ".")) for chunk in chunks[:-1])
+
+
+def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
+    """Email address punctuation should not be treated as sentence boundaries."""
+    text = ("请联系 ops-team@example.com 或 build.bot@example.org 确认状态" * 4)
+
+    chunks = chunk_markdown(text, source="emails.md", max_chunk_size=32)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 32 for chunk in chunks)
+    assert not all(chunk.content.endswith(("@", ".")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -188,3 +188,15 @@ def test_long_mixed_cjk_and_english_text_prefers_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 45 for chunk in chunks)
     assert all(chunk.content.endswith(("。", "!")) for chunk in chunks[:-1])
+
+
+def test_long_cjk_text_splits_on_ellipsis_boundaries() -> None:
+    """Chinese ellipsis should act as a sentence boundary when splitting."""
+    sentence = "这个排查过程还没结束……但是系统已经记录了关键上下文……"
+    text = sentence * 4
+
+    chunks = chunk_markdown(text, source="ellipsis.md", max_chunk_size=35)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 35 for chunk in chunks)
+    assert all(chunk.content.endswith(("……",)) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -337,3 +337,14 @@ def test_mixed_url_query_symbols_do_not_break_chunking() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 34 for chunk in chunks)
     assert not all(chunk.content.endswith(("&", "=")) for chunk in chunks[:-1])
+
+
+def test_mixed_email_addresses_do_not_act_as_sentence_boundaries() -> None:
+    """Email address punctuation should not be treated as sentence boundaries."""
+    text = ("请联系 ops-team@example.com 或 build.bot@example.org 确认状态" * 4)
+
+    chunks = chunk_markdown(text, source="emails.md", max_chunk_size=32)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 32 for chunk in chunks)
+    assert not all(chunk.content.endswith(("@", ".")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -165,3 +165,14 @@ def test_long_cjk_text_splits_on_question_and_exclamation_marks() -> None:
     assert len(chunks) > 1
     assert all(chunk.content.endswith(("？", "！")) for chunk in chunks[:-1])
     assert all(len(chunk.content) <= 30 for chunk in chunks)
+
+
+def test_long_cjk_text_without_punctuation_hard_splits() -> None:
+    """Long CJK text without sentence punctuation should still split safely."""
+    text = "中文连续文本" * 20
+
+    chunks = chunk_markdown(text, source="zh-no-punct.md", max_chunk_size=25)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 25 for chunk in chunks)
+    assert "".join(chunk.content for chunk in chunks) == text

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -176,3 +176,15 @@ def test_long_cjk_text_without_punctuation_hard_splits() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 25 for chunk in chunks)
     assert "".join(chunk.content for chunk in chunks) == text
+
+
+def test_long_mixed_cjk_and_english_text_prefers_sentence_boundaries() -> None:
+    """Mixed Chinese/English text should still split on sentence punctuation."""
+    sentence = "请检查 Redis cache 是否命中。Then verify the fallback path works!"
+    text = sentence * 5
+
+    chunks = chunk_markdown(text, source="mixed.md", max_chunk_size=45)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 45 for chunk in chunks)
+    assert all(chunk.content.endswith(("。", "!")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -268,3 +268,14 @@ def test_cjk_parentheses_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 26 for chunk in chunks)
     assert not all(chunk.content.endswith(("（", "）")) for chunk in chunks[:-1])
+
+
+def test_cjk_quotes_do_not_act_as_sentence_boundaries() -> None:
+    """Chinese quotes should not be treated as sentence boundaries."""
+    text = ("请检查“缓存命中率”是否正常再确认“索引状态”是否完成" * 4)
+
+    chunks = chunk_markdown(text, source="quotes.md", max_chunk_size=24)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 24 for chunk in chunks)
+    assert not all(chunk.content.endswith(("“", "”")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -290,3 +290,14 @@ def test_mixed_path_slashes_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 28 for chunk in chunks)
     assert not all(chunk.content.endswith("/") for chunk in chunks[:-1])
+
+
+def test_mixed_underscores_do_not_act_as_sentence_boundaries() -> None:
+    """Underscores in identifiers should not be treated as sentence boundaries."""
+    text = ("请检查 cache_hit_rate 和 build_status_done 这两个字段是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="underscores.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith("_") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -370,3 +370,14 @@ def test_mixed_braces_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
     assert not all(chunk.content.endswith(("{", "}")) for chunk in chunks[:-1])
+
+
+def test_mixed_brackets_do_not_act_as_sentence_boundaries() -> None:
+    """Square brackets in logs/tags should not be treated as sentence boundaries."""
+    text = ("请检查 [INFO] agent_runner 和 [channel:ops] 输出是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="brackets.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 30 for chunk in chunks)
+    assert not all(chunk.content.endswith(("[", "]")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -392,3 +392,14 @@ def test_mixed_ascii_parentheses_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 32 for chunk in chunks)
     assert not all(chunk.content.endswith(("(", ")")) for chunk in chunks[:-1])
+
+
+def test_mixed_angle_brackets_do_not_act_as_sentence_boundaries() -> None:
+    """Angle brackets in tags/placeholders should not be treated as sentence boundaries."""
+    text = ("请检查 <status_ok> 和 <agent_result> 这类片段是否正常" * 4)
+
+    chunks = chunk_markdown(text, source="angles.md", max_chunk_size=28)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 28 for chunk in chunks)
+    assert not all(chunk.content.endswith(("<", ">")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -153,3 +153,15 @@ def test_long_cjk_text_splits_on_cjk_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(chunk.content.endswith("。") for chunk in chunks[:-1])
     assert all(len(chunk.content) <= 40 for chunk in chunks)
+
+
+def test_long_cjk_text_splits_on_question_and_exclamation_marks() -> None:
+    """Chinese question/exclamation punctuation should also act as boundaries."""
+    sentence = "这个问题应该怎么处理？这个方案真的可行！"
+    text = sentence * 6
+
+    chunks = chunk_markdown(text, source="zh-punct.md", max_chunk_size=30)
+
+    assert len(chunks) > 1
+    assert all(chunk.content.endswith(("？", "！")) for chunk in chunks[:-1])
+    assert all(len(chunk.content) <= 30 for chunk in chunks)

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -200,3 +200,14 @@ def test_long_cjk_text_splits_on_ellipsis_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 35 for chunk in chunks)
     assert all(chunk.content.endswith(("……",)) for chunk in chunks[:-1])
+
+
+def test_cjk_wave_dash_does_not_act_as_sentence_boundary() -> None:
+    """Fullwidth wave dash should fall back to hard splitting, not sentence splitting."""
+    text = ("这个步骤还没结束～～继续观察系统状态～～" * 5)
+
+    chunks = chunk_markdown(text, source="wave.md", max_chunk_size=24)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 24 for chunk in chunks)
+    assert not all(chunk.content.endswith("～") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -323,3 +323,17 @@ def test_mixed_backslashes_do_not_act_as_sentence_boundaries() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 30 for chunk in chunks)
     assert not all(chunk.content.endswith("\\") for chunk in chunks[:-1])
+
+
+def test_mixed_url_query_symbols_do_not_break_chunking() -> None:
+    """URL query punctuation should not cause unexpected sentence splitting."""
+    text = (
+        "请检查 https://example.com/search?q=memsearch&lang=zh-CN 是否正常返回结果"
+        * 4
+    )
+
+    chunks = chunk_markdown(text, source="url-query.md", max_chunk_size=34)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 34 for chunk in chunks)
+    assert not all(chunk.content.endswith(("&", "=")) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -246,3 +246,14 @@ def test_cjk_colon_does_not_act_as_sentence_boundary() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 22 for chunk in chunks)
     assert not all(chunk.content.endswith("：") for chunk in chunks[:-1])
+
+
+def test_cjk_enumeration_comma_does_not_act_as_sentence_boundary() -> None:
+    """Chinese enumeration commas should not be treated as sentence boundaries."""
+    text = ("先检查缓存、再检查索引、最后检查日志、" * 5)
+
+    chunks = chunk_markdown(text, source="enumeration.md", max_chunk_size=20)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 20 for chunk in chunks)
+    assert not all(chunk.content.endswith("、") for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -211,3 +211,15 @@ def test_cjk_wave_dash_does_not_act_as_sentence_boundary() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
     assert not all(chunk.content.endswith("～") for chunk in chunks[:-1])
+
+
+def test_long_cjk_text_splits_on_semicolon_boundaries() -> None:
+    """Chinese semicolons should act as sentence boundaries for long text."""
+    sentence = "先检查缓存命中率；再确认索引是否完成；"
+    text = sentence * 5
+
+    chunks = chunk_markdown(text, source="semicolon.md", max_chunk_size=24)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 24 for chunk in chunks)
+    assert all(chunk.content.endswith("；") for chunk in chunks[:-1])

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -19,6 +19,7 @@ from memsearch.cli import cli
         pytest.param(["config", "list", "--help"], "Usage:", id="config-list-help"),
         pytest.param(["index", "--help"], "Usage:", id="index-help"),
         pytest.param(["search", "--help"], "Usage:", id="search-help"),
+        pytest.param(["list", "--help"], "Usage:", id="list-help"),
         pytest.param(["expand", "--help"], "Usage:", id="expand-help"),
         pytest.param(["stats", "--help"], "Usage:", id="stats-help"),
         pytest.param(["reset", "--help"], "Usage:", id="reset-help"),

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+
+
+class _DummyStore:
+    def __init__(self, uri, token, collection, dimension=None):
+        self.rows = [
+            {"source": "/tmp/memory/2026-04-15.md", "heading": "Rust setup", "chunk_hash": "a"},
+            {"source": "/tmp/memory/2026-04-15.md", "heading": "Rust setup", "chunk_hash": "b"},
+            {"source": "/tmp/memory/2026-04-16.md", "heading": "Python env", "chunk_hash": "c"},
+        ]
+
+    def query(self, *, filter_expr: str = ""):
+        return self.rows
+
+    def close(self):
+        pass
+
+
+def test_list_command_groups_chunks_by_source(monkeypatch) -> None:
+    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+    monkeypatch.setattr("memsearch.store.MilvusStore", _DummyStore)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list"])
+
+    assert result.exit_code == 0
+    assert "/tmp/memory/2026-04-15.md (2 chunks)" in result.output
+    assert "Rust setup" in result.output
+    assert "/tmp/memory/2026-04-16.md (1 chunks)" in result.output
+
+
+def test_list_command_supports_json_output(monkeypatch) -> None:
+    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+    monkeypatch.setattr("memsearch.store.MilvusStore", _DummyStore)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json-output"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["source"] == "/tmp/memory/2026-04-15.md"
+    assert payload[0]["chunk_count"] == 2
+    assert payload[0]["headings"] == ["Rust setup"]

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -25,7 +25,12 @@ class _DummyStore:
 
 
 def test_list_command_groups_chunks_by_source(monkeypatch) -> None:
-    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+    monkeypatch.setattr(
+        "memsearch.cli.resolve_config",
+        lambda *_args, **_kwargs: type(
+            "Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()}
+        )(),
+    )
     monkeypatch.setattr("memsearch.store.MilvusStore", _DummyStore)
 
     runner = CliRunner()
@@ -38,7 +43,12 @@ def test_list_command_groups_chunks_by_source(monkeypatch) -> None:
 
 
 def test_list_command_supports_json_output(monkeypatch) -> None:
-    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+    monkeypatch.setattr(
+        "memsearch.cli.resolve_config",
+        lambda *_args, **_kwargs: type(
+            "Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()}
+        )(),
+    )
     monkeypatch.setattr("memsearch.store.MilvusStore", _DummyStore)
 
     runner = CliRunner()
@@ -52,7 +62,12 @@ def test_list_command_supports_json_output(monkeypatch) -> None:
 
 
 def test_list_command_passes_source_prefix_filter(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+    monkeypatch.setattr(
+        "memsearch.cli.resolve_config",
+        lambda *_args, **_kwargs: type(
+            "Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()}
+        )(),
+    )
 
     created: dict[str, _DummyStore] = {}
 

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -14,8 +14,10 @@ class _DummyStore:
             {"source": "/tmp/memory/2026-04-15.md", "heading": "Rust setup", "chunk_hash": "b"},
             {"source": "/tmp/memory/2026-04-16.md", "heading": "Python env", "chunk_hash": "c"},
         ]
+        self.last_filter_expr = ""
 
     def query(self, *, filter_expr: str = ""):
+        self.last_filter_expr = filter_expr
         return self.rows
 
     def close(self):
@@ -47,3 +49,26 @@ def test_list_command_supports_json_output(monkeypatch) -> None:
     assert payload[0]["source"] == "/tmp/memory/2026-04-15.md"
     assert payload[0]["chunk_count"] == 2
     assert payload[0]["headings"] == ["Rust setup"]
+
+
+def test_list_command_passes_source_prefix_filter(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("memsearch.cli.resolve_config", lambda *_args, **_kwargs: type("Cfg", (), {"milvus": type("M", (), {"uri": "sqlite", "token": "", "collection": "test"})()})())
+
+    created: dict[str, _DummyStore] = {}
+
+    def _store_factory(uri, token, collection, dimension=None):
+        store = _DummyStore(uri, token, collection, dimension)
+        created["store"] = store
+        return store
+
+    monkeypatch.setattr("memsearch.store.MilvusStore", _store_factory)
+
+    prefix = tmp_path / "memory"
+    prefix.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--source-prefix", str(prefix)])
+
+    assert result.exit_code == 0
+    expected_prefix = str(prefix.resolve()).replace("\\", "\\\\").replace('"', '\\"')
+    assert created["store"].last_filter_expr == f'source like "{expected_prefix}%"'

--- a/tests/test_codex_rollout_parser.py
+++ b/tests/test_codex_rollout_parser.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_parse_rollout_supports_flat_transcript_lines(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "task_started"}),
+                json.dumps({"type": "user_message", "message": "Summarize the battery issue"}),
+                json.dumps({"type": "function_call", "name": "read_file", "arguments": {"path": "notes.md"}}),
+                json.dumps({"type": "function_call_output", "output": "voltage sag found"}),
+                json.dumps({"type": "agent_message", "message": "The issue is voltage sag under load."}),
+            ]
+        )
+        + "\n"
+    )
+
+    script = Path("plugins/codex/scripts/parse-rollout.sh")
+    result = subprocess.run(["bash", str(script), str(rollout)], capture_output=True, text=True, check=True)
+
+    output = result.stdout
+    assert "[Human]: Summarize the battery issue" in output
+    assert "[Codex calls tool]: read_file(path=notes.md)" in output
+    assert "[Tool output]: voltage sag found" in output
+    assert "[Codex]: The issue is voltage sag under load." in output

--- a/tests/test_store_query.py
+++ b/tests/test_store_query.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from pymilvus.exceptions import MilvusException
+
+from memsearch.store import MilvusStore
+
+
+class _MissingCollectionClient:
+    def query(self, **_kwargs):
+        raise MilvusException(code=100, message="collection not found")
+
+
+def test_query_returns_empty_when_collection_is_missing() -> None:
+    store = MilvusStore.__new__(MilvusStore)
+    store._client = _MissingCollectionClient()
+    store._collection = "missing"
+
+    assert store.query() == []
+
+
+class _OtherFailureClient:
+    def query(self, **_kwargs):
+        raise MilvusException(code=500, message="boom")
+
+
+def test_query_reraises_non_missing_collection_errors() -> None:
+    store = MilvusStore.__new__(MilvusStore)
+    store._client = _OtherFailureClient()
+    store._collection = "broken"
+
+    with pytest.raises(MilvusException, match="boom"):
+        store.query()

--- a/tests/test_watch_callback_errors.py
+++ b/tests/test_watch_callback_errors.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from memsearch.core import MemSearch
+
+
+class _DummyStore:
+    def delete_by_source(self, source: str) -> None:
+        raise RuntimeError(f"boom: {source}")
+
+
+class _DummyWatcher:
+    def __init__(self, paths, callback, **kwargs) -> None:
+        self.paths = paths
+        self.callback = callback
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        pass
+
+
+def test_watch_callback_swallow_delete_errors(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_file_watcher(paths, callback, **kwargs):
+        watcher = _DummyWatcher(paths, callback, **kwargs)
+        captured["watcher"] = watcher
+        return watcher
+
+    logged: list[tuple[str, str, Path]] = []
+
+    def _fake_exception(message: str, event_type: str, file_path: Path) -> None:
+        logged.append((message, event_type, file_path))
+
+    monkeypatch.setattr("memsearch.watcher.FileWatcher", _fake_file_watcher)
+    monkeypatch.setattr("memsearch.core.logger.exception", _fake_exception)
+
+    mem = MemSearch.__new__(MemSearch)
+    mem._paths = ["/tmp"]
+    mem._store = _DummyStore()
+
+    watcher = mem.watch()
+    assert watcher.started is True
+
+    file_path = Path("/tmp/test.md")
+    watcher.callback("deleted", file_path)
+
+    assert logged == [
+        ("Failed to process %s event for %s", "deleted", file_path),
+    ]


### PR DESCRIPTION
## Summary
- add regression coverage for angle-bracket placeholders/tags in mixed text
- lock in that angle brackets stay on the hard-split path instead of acting as sentence boundaries

## Testing
- uv run python -m pytest tests/test_chunker.py

Part of #102