### PR TITLE
fix(plugins): respect MEMSEARCH_DIR env var override

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -27,7 +27,7 @@ if [ -n "$_GIT_ROOT" ]; then
 else
   _PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 fi
-MEMSEARCH_DIR="$_PROJECT_DIR/.memsearch"
+MEMSEARCH_DIR="${MEMSEARCH_DIR:-$_PROJECT_DIR/.memsearch}"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
 # Find memsearch binary: prefer PATH, fallback to uvx

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -70,7 +70,7 @@ _json_encode_str() {
 PROJECT_DIR=$(_json_val "$INPUT" "cwd" "$(pwd)")
 
 # Memory directory and memsearch state directory are project-scoped
-MEMSEARCH_DIR="${PROJECT_DIR}/.memsearch"
+MEMSEARCH_DIR="${MEMSEARCH_DIR:-${PROJECT_DIR}/.memsearch}"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
 # Find memsearch binary: prefer PATH, fallback to uvx


### PR DESCRIPTION
## Summary

Both `plugins/claude-code/hooks/common.sh` and `plugins/codex/hooks/common.sh` unconditionally assign `MEMSEARCH_DIR` to `<project>/.memsearch`, so an externally exported `MEMSEARCH_DIR` is silently ignored. This blocks users who want to centralize memory storage globally via the environment variable.

Switch both files to `MEMSEARCH_DIR="${MEMSEARCH_DIR:-...}"` so an existing value wins and the per-project path is only used as a fallback.

Closes #354

## Test plan

- [x] When `MEMSEARCH_DIR` is unset, both plugins resolve to `<project>/.memsearch` (no behavior change)
- [x] When `MEMSEARCH_DIR=/custom/path` is exported, both plugins use `/custom/path` and `MEMORY_DIR` becomes `/custom/path/memory`