### PR TITLE
fix(watch): broaden _on_change catch to Exception

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -371,8 +371,6 @@ class MemSearch:
         loop = asyncio.new_event_loop()
 
         def _on_change(event_type: str, file_path: Path) -> None:
-            from pymilvus.exceptions import MilvusException
-
             try:
                 if event_type == "deleted":
                     self._store.delete_by_source(str(file_path))
@@ -383,8 +381,11 @@ class MemSearch:
                 logger.info(summary)
                 if on_event is not None:
                     on_event(event_type, summary, file_path)
-            except MilvusException as e:
-                logger.warning("Milvus error during watch callback: %s", e)
+            except Exception:
+                # Watch is a long-running daemon callback — swallow any failure
+                # (network blips, provider 500s, malformed embeddings, disk
+                # errors, etc.) so a single bad file cannot crash the watcher.
+                logger.exception("Failed to process %s event for %s", event_type, file_path)
 
         fw_kwargs: dict[str, Any] = {}
         if debounce_ms is not None:


### PR DESCRIPTION
## Summary

Follow-up to #336. The `_on_change` watch callback is a long-running daemon loop, so an uncaught exception there crashes the entire watcher and forces the user to manually restart it.

#336 added a `try/except MilvusException` around the callback body, but the scope is too narrow for the original bug report: #352 was triggered by an **Ollama embedding provider** returning a NaN JSON payload — that raises `ollama._types.ResponseError`, not `MilvusException`, so the watcher still crashes on the exact repro from the issue.

Broaden the catch to `Exception` and log with `logger.exception` (full traceback retained) so a single bad file can never take down the watcher. This restores the pre-0.3.0 behavior that #352 describes.

Closes #352

## Test plan

- [x] `uv run python -m pytest` passes
- [x] Confirmed the comment block explains why we intentionally use a broad catch here (daemon loop)
- [ ] Manual smoke test: point watch at a file that causes the embedder to raise a non-Milvus error, confirm the watcher logs the error and keeps running