### PR TITLE
feat(plugins): surface memory structure instead of raw tail

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -166,8 +166,11 @@ if [ -n "$recent_files" ]; then
   context="# Recent Memory\n\n"
   for f in $recent_files; do
     basename_f=$(basename "$f")
-    # Read last ~30 lines from each file
-    content=$(tail -30 "$f" 2>/dev/null || true)
+    # Extract headings (## Session, ### turn timestamps) and bullet content —
+    # higher signal density than a raw tail, so Claude can see the structure
+    # of past days (what sessions existed, what topics came up) rather than
+    # just the last 30 lines of whichever file happened to be newest.
+    content=$(grep -E '^(#{2,4} |- )' "$f" 2>/dev/null | head -40 || true)
     if [ -n "$content" ]; then
       context+="## $basename_f\n$content\n\n"
     fi

--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -31,6 +31,16 @@ Search for memories relevant to: $ARGUMENTS
 
 5. **Return results**: Output a curated summary of the most relevant memories. Be concise — only include information that is genuinely useful for the user's current question.
 
+## When unsure what to search
+
+If the user's question is vague or you can't form a concrete search query, explore the raw markdown first — it is the source of truth for memory:
+
+- `ls -t $(git rev-parse --show-toplevel)/.memsearch/memory/ | head -10` — recent daily logs
+- `grep -h "^## " $(git rev-parse --show-toplevel)/.memsearch/memory/*.md | sort -u | tail -40` — session headings across all days
+- `cat $(git rev-parse --show-toplevel)/.memsearch/memory/<YYYY-MM-DD>.md` — read a specific day
+
+Once a concrete topic jumps out, go back to `memsearch search` with a specific query.
+
 ## Output Format
 
 Organize by relevance. For each memory include:

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -30,6 +30,16 @@ bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$ro
 
 5. **Return results**: Output a curated summary of the most relevant memories. Be concise — only include information that is genuinely useful for the user's current question.
 
+## When unsure what to search
+
+If the user's question is vague or you can't form a concrete search query, explore the raw markdown first — it is the source of truth for memory:
+
+- `ls -t .memsearch/memory/ | head -10` — recent daily logs
+- `grep -h "^## " .memsearch/memory/*.md | sort -u | tail -40` — session headings across all days
+- `cat .memsearch/memory/<YYYY-MM-DD>.md` — read a specific day
+
+Once a concrete topic jumps out, go back to `memsearch search` with a specific query.
+
 ## Output Format
 
 Organize by relevance. For each memory include:

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -43,12 +43,15 @@ function ensureDir(dir: string): string {
 }
 
 /**
- * Read the tail of the N most recent daily .md files for cold-start context.
+ * Summarize the N most recent daily .md files for cold-start context.
+ * Extracts headings (## Session, ### turns) and bullet content so the
+ * agent sees the structure of past days rather than just the tail of
+ * whichever file happened to be newest.
  */
 function getRecentMemories(
   memDir: string,
   count = 2,
-  tailLines = 15
+  maxLinesPerFile = 30
 ): string {
   if (!existsSync(memDir)) return "";
 
@@ -59,27 +62,26 @@ function getRecentMemories(
 
   if (files.length === 0) return "";
 
-  // Extract only bullet-point lines (start with "- ") to keep context
-  // concise and avoid prependContext being echoed back as llm_output.
-  const bullets: string[] = [];
+  const summary: string[] = [];
   for (const file of files) {
     try {
       const content = readFileSync(join(memDir, file), "utf-8");
-      const lines = content.split("\n").slice(-tailLines);
-      const fileBullets = lines.filter((l) => l.startsWith("- "));
-      if (fileBullets.length > 0) {
-        bullets.push(`[${file}]`, ...fileBullets);
+      const lines = content.split("\n")
+        .filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- "))
+        .slice(0, maxLinesPerFile);
+      if (lines.length > 0) {
+        summary.push(`[${file}]`, ...lines);
       }
     } catch {
       /* skip unreadable files */
     }
   }
 
-  if (bullets.length === 0) {
+  if (summary.length === 0) {
     return `You have ${files.length} past memory file(s). Use the memory_search tool when the user's question could benefit from historical context.`;
   }
 
-  return `Recent memories (use memory_search for full search):\n${bullets.join("\n")}`;
+  return `Recent memories (use memory_search for full search):\n${summary.join("\n")}`;
 }
 
 /**

--- a/plugins/openclaw/skills/memory-recall/SKILL.md
+++ b/plugins/openclaw/skills/memory-recall/SKILL.md
@@ -41,3 +41,7 @@ Parses the original session transcript to retrieve the raw dialogue.
 - memory_get may reveal `<!-- session:UUID transcript:PATH -->` anchors — pass the path to memory_transcript
 - If memory_search returns no results, try rephrasing with different keywords
 - Results are sorted by relevance (hybrid BM25 + vector search)
+
+## When unsure what to search
+
+The SessionStart injection already shows you a heading-level preview of recent memory files — skim it first to spot concrete topics (dates, session numbers, task names). If that preview doesn't surface an obvious query, try broad keywords like `overview`, `recent work`, or a topic guess — hybrid BM25 + vector retrieval will surface chunks that share any of the terms, and you can iterate from there.

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -68,12 +68,15 @@ function deriveCollectionName(projectDir: string): string {
 }
 
 /**
- * Read the tail of the N most recent daily .md files for cold-start context.
+ * Summarize the N most recent daily .md files for cold-start context.
+ * Extracts headings (## Session, ### turns) and bullet content from each
+ * file so the agent sees the structure of past days (what sessions existed,
+ * what topics came up), not just the tail of whichever file is newest.
  */
 function getRecentMemories(
   memDir: string,
   count = 2,
-  tailLines = 15
+  maxLinesPerFile = 30
 ): string {
   if (!existsSync(memDir)) return "";
 
@@ -84,23 +87,24 @@ function getRecentMemories(
 
   if (files.length === 0) return "";
 
-  const bullets: string[] = [];
+  const summary: string[] = [];
   for (const file of files) {
     try {
       const content = readFileSync(join(memDir, file), "utf-8");
-      const lines = content.split("\n").slice(-tailLines);
-      const fileBullets = lines.filter((l) => l.startsWith("- ") || l.startsWith("[Human]") || l.startsWith("[Assistant]"));
-      if (fileBullets.length > 0) {
-        bullets.push(`[${file}]`, ...fileBullets);
+      const lines = content.split("\n")
+        .filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- ") || l.startsWith("[Human]") || l.startsWith("[Assistant]"))
+        .slice(0, maxLinesPerFile);
+      if (lines.length > 0) {
+        summary.push(`[${file}]`, ...lines);
       }
     } catch { /* skip */ }
   }
 
-  if (bullets.length === 0) {
+  if (summary.length === 0) {
     return `You have ${files.length} past memory file(s). Use the memory_search tool when the user's question could benefit from historical context.`;
   }
 
-  return `Recent memories (use memory_search for full search):\n${bullets.join("\n")}`;
+  return `Recent memories (use memory_search for full search):\n${summary.join("\n")}`;
 }
 
 /** Shell-escape a string for safe use inside single quotes. */

--- a/plugins/opencode/skills/memory-recall/SKILL.md
+++ b/plugins/opencode/skills/memory-recall/SKILL.md
@@ -30,6 +30,16 @@ Search for memories relevant to: $ARGUMENTS
 
 5. **Return results**: Output a curated summary of the most relevant memories. Be concise — only include information that is genuinely useful for the user's current question.
 
+## When unsure what to search
+
+If the user's question is vague or you can't form a concrete search query, explore the raw markdown first — it is the source of truth for memory:
+
+- `ls -t .memsearch/memory/ | head -10` — recent daily logs
+- `grep -h "^## " .memsearch/memory/*.md | sort -u | tail -40` — session headings across all days
+- `cat .memsearch/memory/<YYYY-MM-DD>.md` — read a specific day
+
+Once a concrete topic jumps out, go back to `memsearch search` with a specific query.
+
 ## Output Format
 
 Organize by relevance. For each memory include:


### PR DESCRIPTION
## Summary

Teach agents what's been memorized without needing a concrete search query (#277), by improving two things in parallel:

### 1. Cold-start context injection — switch from `tail -30` to heading+bullet summary

The SessionStart hook on each plugin previously injected `tail -30` of the two most recent daily .md files into the agent's initial context. That gave the tail of whichever file was newest but almost no sense of the overall structure (which sessions existed, what topics came up).

Switch to extracting headings (`## Session`, `### turn timestamps`) plus bullet content, capped at 30–40 lines per file. Same size budget, much higher signal density.

- `plugins/claude-code/hooks/session-start.sh`: shell `grep`
- `plugins/opencode/index.ts`: TS regex filter in `getRecentMemories`
- `plugins/openclaw/index.ts`: same

### 2. Add "When unsure what to search" guidance to `memory-recall` SKILL.md

All four platform skills now explicitly point agents at the raw markdown when they can't form a concrete query:

```bash
ls -t .memsearch/memory/ | head -10
grep -h "^## " .memsearch/memory/*.md | sort -u | tail -40
cat .memsearch/memory/<YYYY-MM-DD>.md
```

On openclaw (no shell access, only plugin-provided tools), the skill points at the SessionStart heading preview plus a broad-query strategy instead.

## Rationale

memsearch's design philosophy is "markdown is source of truth, Milvus is a derived index". When an agent wants to know "what's been memorized in summary" (exactly what #277 asks for), teaching it to use `ls`/`grep`/`cat` on the daily .md files is strictly better than adding a dedicated `memsearch list` CLI command:

- Unix tools compose (`grep -l Rust | xargs cat`) in ways a `list` command never will
- Avoids leaking the chunk abstraction (chunks are an internal representation of the markdown, not something users/agents should reason about)
- Stays consistent with the "markdown first" design principle
- Zero new CLI surface area

This supersedes PRs #305, #320, and #367 which all proposed adding a `memsearch list` command in various forms. Those can be closed after this lands.

## Test plan

- [x] `bash -n plugins/claude-code/hooks/session-start.sh`
- [x] `grep -E '^(#{2,4} |- )'` regex manually verified against a sample daily log
- [x] TS changes keep the same function signature, so callers (`experimental.chat.system.transform` hook) are unaffected
- [ ] Manual smoke test after merge: start a fresh claude-code session in a repo with existing `.memsearch/memory/*.md` and confirm the injected `# Recent Memory` block now shows session headings instead of a raw tail

Closes #277