### PR TITLE
docs(readme): clarify CLI-tool vs project-dependency install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,19 +319,30 @@ User: "What did we discuss about batch size?"
 ### 📦 Installation
 
 ```bash
-# pip
-pip install memsearch
+# Install as a global CLI tool — recommended when you mainly use the
+# `memsearch` command or any of the agent plugins (Claude Code, Codex,
+# OpenClaw, OpenCode), which all shell out to the CLI.
+uv tool install memsearch       # via uv
+pipx install memsearch          # via pipx
+pip install memsearch           # plain pip
 
-# or uv (recommended)
-uv add memsearch
+# Install as a project dependency — use this if you want to import
+# `memsearch` from your own Python code (e.g. via the MemSearch class).
+uv add memsearch                # via uv, adds to pyproject.toml
+pip install memsearch           # into an activated venv
 ```
 
 <details>
 <summary><b>Optional embedding providers</b></summary>
 
 ```bash
-pip install "memsearch[onnx]"    # Local ONNX (recommended, no API key)
-# or: uv add "memsearch[onnx]"
+# As a CLI tool (recommended — local ONNX, no API key)
+uv tool install "memsearch[onnx]"
+pipx install "memsearch[onnx]"
+pip install "memsearch[onnx]"
+
+# As a project dependency
+uv add "memsearch[onnx]"
 
 # Other options: [openai], [google], [voyage], [jina], [mistral], [ollama], [local], [all]
 ```


### PR DESCRIPTION
## Summary

The README previously recommended `uv add memsearch` as the primary uv install, but that's the wrong command for the dominant use case: memsearch is mainly a CLI, and every platform plugin (Claude Code, Codex, OpenClaw, OpenCode) shells out to the `memsearch` command.

`uv add` only installs the package into the current project's venv, so a user who ran it and then typed `memsearch --help` in any other directory would hit "command not found" — a real onboarding trap. We've also seen PR #301 try to patch this from the community side, which is how it surfaced.

This PR splits the install block into two explicit groups:

1. **Global CLI tool** (`uv tool install` / `pipx install` / `pip install`) — for users who want `memsearch` available everywhere. This is the plugin path and the most common case.
2. **Project dependency** (`uv add` / `pip install` into a venv) — for users who want to `from memsearch import MemSearch` in their own Python code.

Same split applied to the optional-extras section.

## Test plan

- [x] Rendered preview locally — the new CLI/library distinction reads cleanly
- [x] No code changes, pure docs

Supersedes #301.