### PR TITLE
fix(chunker): don't split engineering text on ASCII punctuation

### DIFF
--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -235,7 +235,13 @@ def _split_large_section(
 
 
 # Sentence-ending punctuation for splitting long text without line breaks.
-_SENTENCE_END_RE = re.compile(r"[。\uFF01\uFF1F.!?]\s*")
+# CJK punctuation (。！？；ellipsis) always acts as a boundary.
+# ASCII punctuation (.!?;) only counts when followed by whitespace, end-of-
+# string, or a CJK character — so `user@example.com`, `path/to/file.py`,
+# `http://foo.bar`, and `v1.2.3` are not split mid-token.
+_SENTENCE_END_RE = re.compile(
+    r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)"
+)
 
 
 def _split_long_text(text: str, max_size: int) -> list[str]:

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -235,10 +235,11 @@ def _split_large_section(
 
 
 # Sentence-ending punctuation for splitting long text without line breaks.
-# CJK punctuation (。！？；ellipsis) always acts as a boundary.
-# ASCII punctuation (.!?;) only counts when followed by whitespace, end-of-
-# string, or a CJK character — so `user@example.com`, `path/to/file.py`,
-# `http://foo.bar`, and `v1.2.3` are not split mid-token.
+# CJK punctuation (fullwidth stop/exclaim/question/semicolon + ellipsis)
+# always acts as a boundary. ASCII punctuation (.!?;) only counts when
+# followed by whitespace, end-of-string, or a CJK character -- so
+# `user@example.com`, `path/to/file.py`, `http://foo.bar`, and `v1.2.3`
+# are not split mid-token.
 _SENTENCE_END_RE = re.compile(
     r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)"
 )

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -141,3 +141,100 @@ def test_clean_content_handles_adjacent_html_comments() -> None:
     assert "first comment" not in cleaned
     assert "second comment" not in cleaned
     assert cleaned == "Header\n\nBody text"
+
+
+# --- Sentence-boundary splitting for long text without line breaks ---
+#
+# The chunker falls back to sentence-level splitting when a paragraph is
+# longer than `max_chunk_size`. The tests below pin down the expected
+# behavior of `_SENTENCE_END_RE`:
+#   - CJK punctuation (。！？；……) always counts as a boundary
+#   - ASCII punctuation (.!?;) only counts when followed by whitespace,
+#     end-of-string, or a CJK character — so engineering text like emails,
+#     URLs, file extensions, and version numbers is not split mid-token.
+
+
+def test_long_cjk_text_splits_on_cjk_sentence_boundaries() -> None:
+    """Long Chinese text should split at CJK full-stop."""
+    sentence = "这是一个用于测试中文分句行为的长句子。"
+    text = sentence * 8
+
+    chunks = chunk_markdown(text, source="zh.md", max_chunk_size=40)
+
+    assert len(chunks) > 1
+    assert all(chunk.content.endswith("。") for chunk in chunks[:-1])
+    assert all(len(chunk.content) <= 40 for chunk in chunks)
+
+
+def test_long_mixed_text_prefers_sentence_boundaries() -> None:
+    """Mixed Chinese/English text still splits on sentence punctuation."""
+    sentence = "请检查 Redis cache 是否命中。Then verify the fallback path works!"
+    text = sentence * 5
+
+    chunks = chunk_markdown(text, source="mixed.md", max_chunk_size=45)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 45 for chunk in chunks)
+    # Each non-final chunk should end at a real sentence boundary.
+    assert all(chunk.content.endswith(("。", "!")) for chunk in chunks[:-1])
+
+
+def test_ascii_dot_in_engineering_text_is_not_a_boundary() -> None:
+    """Dots inside emails, URLs, file paths, and version numbers should not split."""
+    # Each token has ASCII dots immediately followed by non-whitespace, so the
+    # lookahead in _SENTENCE_END_RE should reject them as boundaries. The
+    # chunker is then forced to hard-split at max_chunk_size.
+    tokens = [
+        "user@example.com",
+        "https://foo.bar/baz",
+        "path/to/file.py",
+        "memsearch.config.toml",
+        "v1.2.3",
+    ]
+    text = " ".join(tokens * 8)
+
+    chunks = chunk_markdown(text, source="engineering.md", max_chunk_size=60)
+
+    assert len(chunks) > 1
+    # No chunk boundary should split any of these tokens in half.
+    joined = " || ".join(chunk.content for chunk in chunks)
+    for token in tokens:
+        assert token in joined, f"token {token!r} was broken across chunks"
+
+
+def test_ascii_dot_followed_by_space_is_a_boundary() -> None:
+    """Regular English sentences still split normally on `. ` / `! ` / `? `."""
+    sentence = "This is a complete sentence. And here is another one! Is this a question? "
+    text = sentence * 5
+
+    chunks = chunk_markdown(text, source="en.md", max_chunk_size=60)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 60 for chunk in chunks)
+    # Every non-final chunk should end at a sentence-ending punctuation.
+    assert all(chunk.content.rstrip().endswith((".", "!", "?")) for chunk in chunks[:-1])
+
+
+def test_long_cjk_text_splits_on_ellipsis() -> None:
+    """Chinese ellipsis (……) acts as a sentence boundary when splitting."""
+    sentence = "这个排查过程还没结束……但是系统已经记录了关键上下文……"
+    text = sentence * 4
+
+    chunks = chunk_markdown(text, source="ellipsis.md", max_chunk_size=35)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 35 for chunk in chunks)
+    assert all(chunk.content.endswith("……") for chunk in chunks[:-1])
+
+
+def test_long_cjk_text_splits_on_fullwidth_semicolon() -> None:
+    """Chinese fullwidth semicolon (；) acts as a sentence boundary."""
+    semicolon = "\uff1b"
+    sentence = f"先检查缓存命中率{semicolon}再确认索引是否完成{semicolon}"
+    text = sentence * 5
+
+    chunks = chunk_markdown(text, source="semicolon.md", max_chunk_size=24)
+
+    assert len(chunks) > 1
+    assert all(len(chunk.content) <= 24 for chunk in chunks)
+    assert all(chunk.content.endswith(semicolon) for chunk in chunks[:-1])

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -148,9 +148,10 @@ def test_clean_content_handles_adjacent_html_comments() -> None:
 # The chunker falls back to sentence-level splitting when a paragraph is
 # longer than `max_chunk_size`. The tests below pin down the expected
 # behavior of `_SENTENCE_END_RE`:
-#   - CJK punctuation (。！？；……) always counts as a boundary
+#   - CJK punctuation (fullwidth stop/exclaim/question/semicolon + ellipsis)
+#     always counts as a boundary.
 #   - ASCII punctuation (.!?;) only counts when followed by whitespace,
-#     end-of-string, or a CJK character — so engineering text like emails,
+#     end-of-string, or a CJK character -- so engineering text like emails,
 #     URLs, file extensions, and version numbers is not split mid-token.
 
 
@@ -228,7 +229,7 @@ def test_long_cjk_text_splits_on_ellipsis() -> None:
 
 
 def test_long_cjk_text_splits_on_fullwidth_semicolon() -> None:
-    """Chinese fullwidth semicolon (；) acts as a sentence boundary."""
+    """Chinese fullwidth semicolon (U+FF1B) acts as a sentence boundary."""
     semicolon = "\uff1b"
     sentence = f"先检查缓存命中率{semicolon}再确认索引是否完成{semicolon}"
     text = sentence * 5


### PR DESCRIPTION
## Summary

`_SENTENCE_END_RE` in `chunker.py` treated every ASCII `.` `!` `?` as a sentence boundary when falling back to splitting long line-break-free text. That broke typical engineering content: emails, URLs, file paths, version numbers, and dotted identifiers all got split mid-token.

Examples that used to split in the middle:

```
user@example.com
https://foo.bar/baz
path/to/file.py
memsearch.config.toml
v1.2.3
```

Fix: add a lookahead so ASCII punctuation (`. ! ? ;`) only counts as a sentence boundary when **followed by whitespace, end-of-string, or a CJK character**. CJK punctuation (`。！？；`) keeps splitting unconditionally as before, and `……` / `…` / fullwidth `；` are added to match real Chinese writing.

```python
# Before:
_SENTENCE_END_RE = re.compile(r"[。\uFF01\uFF1F.!?]\s*")

# After:
_SENTENCE_END_RE = re.compile(
    r"(?:……|…|[。\uFF01\uFF1F\uFF1B]\s*|[.!?;](?=\s|$|[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF])\s*)"
)
```

Supersedes the chunker portion of #388. The rest of that bundled PR is already covered on main (`cli list` → we chose not to add one, see #277 / #410; `_on_change` try/except → #336 + #409; `store.query` missing-collection handling → already tolerated by existing callers).

## Test plan

- [x] `uv run python -m pytest tests/test_chunker.py` — 18 passed (6 new)
- New tests cover:
  - CJK full-stop boundaries
  - mixed CJK + English sentence splitting
  - English `. ` / `! ` / `? ` still split prose normally
  - emails / URLs / file paths / version numbers never split mid-token
  - `……` ellipsis and fullwidth `；` as boundaries