### PR TITLE
chore: bump memsearch 0.3.1, claude-code plugin 0.3.6, openclaw 0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "openclaw": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.3.0"
+version = "0.3.1"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump for the current release cycle.

| Component | Old | New | Highlights |
|-----------|-----|-----|------------|
| **memsearch** (PyPI) | 0.3.0 | **0.3.1** | chunker engineering-text fix (#412), watch daemon broad catch (#409), user-friendly CLI errors (#336), `--max-chunk-size` flag (#335) |
| **Claude Code plugin** | 0.3.5 | **0.3.6** | heading+bullet memory summary (#410), skill description expansion (#353), `MEMSEARCH_DIR` env override (#408) |
| **OpenClaw plugin** | 0.2.0 | **0.2.1** | heading+bullet summary (#410), skill description expansion (#353) |

**Not bumped in this PR:**
- **OpenCode plugin** will be bumped 0.1.1 → 0.1.2 and published to npm separately (2FA OTP required at `npm publish` time)
- **Codex CLI plugin** has no version number; users pull latest from main via `install.sh`

## Release plan after merge

1. Tag `v0.3.1` on `official/main` → GitHub Actions publishes to PyPI
2. Marketplace picks up claude-code 0.3.6 automatically (users `/plugin marketplace update`)
3. `clawhub package publish plugins/openclaw/` for OpenClaw 0.2.1
4. OpenCode 0.1.2 npm publish (follow-up, needs OTP)