### PR TITLE
chore: bump opencode plugin 0.1.1 -> 0.1.2

### DIFF
--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

Bump `@zilliz/memsearch-opencode` from 0.1.1 to 0.1.2 to include the recent improvements:

- feat: heading+bullet summary in `getRecentMemories` (#410)
- Expand memory-recall skill description (#353)

Published to npm as a follow-up (2FA OTP required at `npm publish` time, so doing this bump on its own instead of bundling with #413).