### PR TITLE
docs: clarify opencode windows requirements

### DIFF
--- a/docs/platforms/opencode/index.md
+++ b/docs/platforms/opencode/index.md
@@ -44,8 +44,13 @@ If you use multiple AI coding agents (e.g., OpenCode for some projects, Claude C
 
 ---
 
+## Platform Notes
+
+!!! warning "Native Windows is not supported yet"
+    The current OpenCode plugin depends on external `bash` and `python3` helper scripts. For Windows, run it inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) or another POSIX-compatible shell environment. See [issue #387](https://github.com/zilliztech/memsearch/issues/387).
+
 ## Pages
 
-- [Installation](installation.md) -- prerequisites, automated and manual install
+- [Installation](installation.md) -- prerequisites, automated and manual install, verification steps, Windows notes
 - [How It Works](how-it-works.md) -- capture daemon, cold-start, memory files, architecture
 - [Memory Tools](memory-tools.md) -- three registered tools, progressive recall, comparisons

--- a/docs/platforms/opencode/installation.md
+++ b/docs/platforms/opencode/installation.md
@@ -5,6 +5,42 @@
 - OpenCode with plugin support
 - Python 3.10+
 - memsearch installed: `uv tool install "memsearch[onnx]"`
+- POSIX shell environment for the plugin helper scripts (`bash` + `python3`)
+
+!!! warning "Native Windows is not supported yet"
+    The OpenCode plugin currently shells out to `bash` and `python3` helper scripts for collection derivation, transcript parsing, and the background capture daemon. On a plain Windows install without a POSIX shell, the plugin may fail with errors like `derive-collection.sh: No such file or directory`.
+
+    Recommended options:
+
+    - Run OpenCode + memsearch inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)
+    - Or use Git Bash / another POSIX-compatible shell and expect some path-handling rough edges
+
+    If you need native Windows support, track [issue #387](https://github.com/zilliztech/memsearch/issues/387).
+
+## Verify the plugin is working
+
+After restarting OpenCode, use this quick checklist:
+
+1. Open a project and chat for a few turns.
+2. Confirm memory files appear:
+
+```bash
+ls .memsearch/memory/
+```
+
+3. Inspect today's memory file:
+
+```bash
+cat .memsearch/memory/$(date +%Y-%m-%d).md
+```
+
+4. Ask a recall question in OpenCode, for example:
+
+```text
+We discussed the authentication flow before, what was the approach?
+```
+
+If capture is working, you should see daily markdown files appear and the agent should be able to use `memory_search` / `memory_get` / `memory_transcript` when history is relevant.
 
 ## Install from npm (recommended)
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -30,6 +30,8 @@ uv tool install 'memsearch[onnx]'
 }
 ```
 
+> Windows note: the current plugin shells out to `bash` and `python3` helper scripts. Plain Windows installs are not supported yet; use WSL2 (recommended) or a POSIX-compatible shell such as Git Bash. See issue #387.
+
 ### Install from Source (development)
 
 ```bash
@@ -72,6 +74,17 @@ OpenCode Session
         ├── memory_get    ──→ memsearch expand (full context)
         └── memory_transcript ──→ parse-transcript.py (SQLite reader)
 ```
+
+## Verify It Works
+
+After restarting OpenCode, chat for a few turns in a project and confirm memory capture is happening:
+
+```bash
+ls .memsearch/memory/
+cat .memsearch/memory/$(date +%Y-%m-%d).md
+```
+
+If the plugin is active, daily markdown files should appear and grow as conversations finish.
 
 ## Recall Memories
 


### PR DESCRIPTION
## Summary
- document that the OpenCode plugin currently requires `bash` and `python3`
- add a Windows note pointing users to WSL2 / POSIX shell environments
- add explicit "verify it works" steps so users know how to confirm capture and recall are active

## Problem
Issue #387 shows that users can follow the current OpenCode installation docs on plain Windows, add the plugin to `opencode.json`, and then hit script-path errors without any clear guidance on root cause or how to validate the install.

## Changes
- add a prerequisite / warning block in the OpenCode installation docs
- add a Windows support note to the OpenCode platform landing page
- update the plugin README with the same Windows caveat and post-install verification steps

Fixes #387
