### PR TITLE
docs: add zero-config quickstart

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,38 @@ $ pip install "memsearch[anthropic]"   # Anthropic (for compact/summarization LL
 $ pip install "memsearch[all]"         # Everything above
 ```
 
+## Zero-config quick start (no API key)
+
+If you want the fastest path to a working local setup, use local embeddings plus the default **Milvus Lite** backend. This runs entirely on your machine and does not require an API key.
+
+```bash
+$ mkdir -p quickstart-notes
+$ printf '# Notes\n\n- Redis TTL is 15 minutes\n- Staging URL is https://staging.example.com\n' > quickstart-notes/MEMORY.md
+$ pip install "memsearch[local]"
+```
+
+```python
+import asyncio
+from memsearch import MemSearch
+
+async def main():
+    mem = MemSearch(
+        paths=["./quickstart-notes"],
+        embedding_provider="local",
+    )
+    await mem.index()
+
+    results = await mem.search("what is the Redis TTL?", top_k=3)
+    for r in results:
+        print(r["content"])
+
+    mem.close()
+
+asyncio.run(main())
+```
+
+Use this path when you want to evaluate memsearch quickly before wiring in OpenAI, Ollama, or a remote Milvus deployment.
+
 ---
 
 ## How It All Fits Together


### PR DESCRIPTION
## Summary
- add a self-contained zero-config quick start to `docs/getting-started.md`
- show a local, no-API-key setup using `memsearch[local]`
- include a minimal markdown file, indexing step, and search example in one place

## Problem
Issue #91 calls out that the easiest path to trying memsearch — local embeddings plus the default Milvus Lite backend — is currently spread across multiple sections. New users have to piece together installation, backend assumptions, and a first runnable example.

## Changes
- add a `Zero-config quick start (no API key)` section near the top of `getting-started.md`
- use `pip install "memsearch[local]"` and a tiny `MEMORY.md` example
- show the full flow in one snippet: create notes -> index -> search -> print results

Fixes #91

## Validation
- `python` assertion check for the new section and example content
- `git diff --check`
