### PR TITLE
docs: add FAQ page

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,76 @@
+# FAQ
+
+## Does memsearch work on Windows?
+
+Yes, but **Milvus Lite** (the default local `.db` backend) does not provide Windows binaries.
+
+If you are on Windows, use one of these options instead:
+
+- **Milvus Server** via Docker
+- **Zilliz Cloud**
+- **WSL2** if you specifically want the Milvus Lite local-file workflow
+
+See [Getting Started — Milvus Backends](getting-started.md#milvus-backends) for the backend comparison and recommended setup.
+
+## How do I wipe and rebuild the index?
+
+Use `memsearch reset --yes` to drop the current collection, then run `memsearch index` again.
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+This deletes the indexed chunks in Milvus, but it does **not** delete your source markdown files.
+
+For command details, see the [CLI reference](cli.md#memsearch-reset).
+
+## How do I see what is indexed?
+
+Start with index stats:
+
+```bash
+memsearch stats
+```
+
+That shows the total indexed chunk count for the active collection.
+
+To inspect actual indexed content, run a representative search, then progressively expand results:
+
+```bash
+memsearch search "redis ttl"
+memsearch expand <chunk_id>
+```
+
+See the [CLI reference](cli.md#memsearch-stats) for `stats`, and the `search` / `expand` sections for content inspection workflows.
+
+## Why is search returning irrelevant results?
+
+Common causes:
+
+- the current embedding provider does not match the kind of content you indexed
+- the index is stale and needs re-indexing
+- your query is too short or too vague
+- you switched providers/models and are still searching an old index
+
+Practical things to try:
+
+1. Re-index your memory files: `memsearch index . --force`
+2. Make the query more specific
+3. Check which embedding provider you configured
+4. If you recently changed providers, consider resetting and rebuilding the index
+
+See [Configuration](home/configuration.md) for embedding provider options.
+
+## What does "dimension mismatch" mean, and how do I fix it?
+
+A dimension mismatch means your existing Milvus collection was created with one embedding dimension, but your current embedding provider/model is producing vectors with a different dimension.
+
+The usual fix is to reset the collection and re-index from source markdown files:
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+Because markdown is the source of truth, rebuilding the vector index is safe as long as your original memory files are still present.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - Comparison with Alternatives: home/comparison.md
     - Embedding Model Evaluation: home/embedding-evaluation.md
     - Quickstart: getting-started.md
+    - FAQ: faq.md
   - Claude Code Plugin:
     - Overview: platforms/claude-code/index.md
     - Installation: platforms/claude-code/installation.md


### PR DESCRIPTION
## Summary
- add a new top-level `docs/faq.md` page
- cover common support questions around Windows, resetting/rebuilding, stats, irrelevant search results, and dimension mismatch
- add the FAQ page to the docs navigation

## Problem
Issue #91 calls out that common user questions are scattered across the docs and that the FAQ coverage is too thin. Right now there is no dedicated top-level FAQ page in the docs nav for frequently repeated operational questions.

## Changes
- add `docs/faq.md`
- answer five common questions:
  - Windows support
  - wipe and rebuild the index
  - how to see what is indexed
  - why search results can be irrelevant
  - what dimension mismatch means and how to fix it
- wire the page into `mkdocs.yml`

Fixes #91

## Validation
- Python assertion check for the FAQ headings and nav entry
- `git diff --check`
