### PR TITLE
docs: add missing cross-links

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-memsearch provides a command-line interface for indexing, searching, and managing semantic memory over markdown knowledge bases.
+memsearch provides a command-line interface for indexing, searching, and managing semantic memory over markdown knowledge bases. If you're brand new to the project, start with [Getting Started](getting-started.md) for the first end-to-end setup before diving into command details.
 
 ```bash
 $ memsearch --version

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -464,6 +464,8 @@ memsearch uses a layered configuration system. Settings are resolved in priority
 
 Higher-priority sources override lower ones. This means you can set defaults globally, customize per project, and override on the fly with CLI flags.
 
+Common operational questions? See the [FAQ](faq.md).
+
 > **Note:** API keys can be configured via environment variables (e.g. `OPENAI_API_KEY`) or in config files using the `env:` reference syntax (e.g. `api_key = "env:MY_API_KEY"`). See [API Keys](#api-keys) and [Environment Variable References](#environment-variable-references) below.
 
 ### Interactive config wizard

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -16,7 +16,7 @@ print(results[0]["content"], results[0]["score"])       # content + similarity
 
 ## `MemSearch`
 
-The main entry point. Handles indexing, search, compaction, and file watching.
+The main entry point. Handles indexing, search, compaction, and file watching. For the underlying chunk model, dedup strategy, and collection layout, see [Architecture](architecture.md).
 
 ### Constructor
 


### PR DESCRIPTION
## Summary
- add a link from Python API docs to Architecture
- add a link from CLI docs to Getting Started
- add a link from Getting Started to the new FAQ page

## Problem
Issue #91 calls out a handful of obvious missing cross-links between major docs pages. Right now, new users and developers have to manually hop around the nav to connect setup guidance, architecture details, and common operational questions.

## Changes
- `docs/python-api.md` now links to `architecture.md` when introducing the main API surface
- `docs/cli.md` now points first-time users to `getting-started.md`
- `docs/getting-started.md` now points readers to `faq.md` for common operational questions

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
