### PR TITLE
docs: link FAQ and troubleshooting

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,8 @@
 
 memsearch provides a command-line interface for indexing, searching, and managing semantic memory over markdown knowledge bases.
 
+If you run into operational issues while using these commands, see the top-level [Troubleshooting](troubleshooting.md) guide and [FAQ](faq.md).
+
 ```bash
 $ memsearch --version
 memsearch, version 0.1.3

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -2,6 +2,8 @@
 
 memsearch uses a layered TOML config system. Most users don't need to configure anything — the defaults work out of the box.
 
+If you are changing providers/backends and run into problems later, the top-level [Troubleshooting](../troubleshooting.md) guide and [FAQ](../faq.md) cover the most common recovery steps.
+
 ## Config Locations (priority low → high)
 
 1. `~/.memsearch/config.toml` — global defaults

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2,6 +2,8 @@
 
 memsearch provides a high-level Python API through the `MemSearch` class. Import it, point it at your markdown files, and you get semantic memory for your agent in a few lines of code.
 
+For common operational failures such as dimension mismatch, stale indexes, or Windows backend questions, see the top-level [Troubleshooting](troubleshooting.md) guide and [FAQ](faq.md).
+
 ```python
 from memsearch import MemSearch
 


### PR DESCRIPTION
## Summary
- link CLI docs to the top-level Troubleshooting guide and FAQ
- link Python API docs to the same operational help pages
- link Configuration docs to recovery/help pages for provider/backend changes

## Problem
Issue #91 is partly about structure and discoverability, not just missing pages. Even after adding FAQ and Troubleshooting pages, users still may not find them from the pages where operational problems first show up.

## Changes
- add troubleshooting/help links near the top of `docs/cli.md`
- add troubleshooting/help links near the top of `docs/python-api.md`
- add troubleshooting/help links near the top of `docs/home/configuration.md`

Fixes #91

## Validation
- Python assertion check for the new links
- `git diff --check`
