### PR TITLE
docs: add homepage help links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@
 
 > Install the plugin, get persistent memory. No commands to learn, no manual saving -- your agent remembers what you worked on across sessions, automatically.
 
+[:octicons-arrow-right-24: Getting Started](getting-started.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: FAQ](faq.md){ .md-button }
+[:octicons-arrow-right-24: Troubleshooting](troubleshooting.md){ .md-button }
+
 ---
 
 ## For Agent Users
@@ -114,6 +118,8 @@ pip install "memsearch[onnx]"
 ```
 
 [:octicons-arrow-right-24: Getting Started](getting-started.md){ .md-button }
+[:octicons-arrow-right-24: FAQ](faq.md){ .md-button }
+[:octicons-arrow-right-24: Troubleshooting](troubleshooting.md){ .md-button }
 
 ---
 


### PR DESCRIPTION
## Summary
- add top-level homepage buttons for Getting Started, FAQ, and Troubleshooting
- add the same help links in the developer install section on the homepage
- make new support/discovery pages reachable directly from the landing page

## Problem
Issue #91 is not just about creating more docs pages — users also need obvious entry points to them. Even after adding FAQ and Troubleshooting, the homepage still pushed readers mostly toward platform docs and deeper references.

## Changes
- add homepage buttons for:
  - Getting Started
  - FAQ
  - Troubleshooting
- add the same links near the CLI/Python install area for developer-oriented readers

Fixes #91

## Validation
- manual content check for the new homepage buttons/links
- `git diff --check`
