### PR TITLE
docs: add help links to platform comparison

### DIFF
--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -2,6 +2,11 @@
 
 memsearch provides plugins for 4 AI coding agent platforms. All plugins share the same core architecture: capture conversations to markdown, index with Milvus, recall via semantic search.
 
+Need help beyond the feature matrix?
+- Start with [Getting Started](../getting-started.md) for the fastest working setup
+- Check the [FAQ](../faq.md) for common operational questions
+- Use [Troubleshooting](../troubleshooting.md) when indexing/search behavior looks wrong
+
 ---
 
 ## Comparison Table


### PR DESCRIPTION
## Summary
- add links from the platform comparison page to Getting Started, FAQ, and Troubleshooting
- make the comparison page a better jumping-off point for setup and debugging

## Problem
Issue #91 is partly about discoverability. The platform comparison page helps users choose a platform, but it does not currently route them toward the most useful follow-up pages when they need setup guidance or operational help.

## Changes
- add a short help block near the top of `docs/platforms/index.md`
- link to:
  - Getting Started
  - FAQ
  - Troubleshooting

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
