### PR TITLE
docs: improve for-users navigation

### DIFF
--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -2,6 +2,10 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
 
+New here?
+- Start with [Getting Started](../getting-started.md) for the fastest end-to-end setup
+- Use [Platform Comparison](../platforms/index.md) if you're deciding between Claude Code, OpenClaw, OpenCode, and Codex
+
 ## Choose Your Platform
 
 | Platform | Install | Maturity |
@@ -40,4 +44,4 @@ Each platform adapts the same architecture to its own plugin system:
 - **OpenCode**: [Full guide →](../platforms/opencode/index.md)
 - **Codex CLI**: [Full guide →](../platforms/codex/index.md)
 
-See the [Platform Comparison](../platforms/index.md) for a detailed feature matrix.
+See the [Platform Comparison](../platforms/index.md) for a detailed feature matrix. Once you've picked a platform, continue with [Getting Started](../getting-started.md) for backend and installation setup.


### PR DESCRIPTION
## Summary
- add a clearer "new here?" handoff in `docs/home/for-users.md`
- point readers directly to Getting Started and Platform Comparison
- make the platform-choice page flow better into installation/setup docs

## Problem
Issue #91 is partly about docs discoverability. The `For Agent Users` page explains the supported platforms, but it does not currently guide new readers toward the best next page depending on whether they want a fast setup or a platform decision.

## Changes
- add a short "New here?" block near the top of `docs/home/for-users.md`
- link to:
  - `getting-started.md`
  - `platforms/index.md`
- add a stronger end-of-page handoff from platform comparison back to setup

Fixes #91

## Validation
- Python assertion check for the new links
- `git diff --check`
