### PR TITLE
docs: improve for-developers navigation

### DIFF
--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -2,6 +2,12 @@
 
 Build memory into your own agents using the memsearch CLI and Python API.
 
+New here?
+- Start with [Getting Started](../getting-started.md) if you want the fastest working local setup
+- Jump to [CLI Reference](../cli.md) if you prefer shell workflows
+- Jump to [Python API](../python-api.md) if you are embedding memsearch into your own code
+- Read [Architecture](../architecture.md) if you want the underlying indexing and recall model first
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- add a clearer "new here?" handoff block to `docs/home/for-developers.md`
- point developers to Getting Started, CLI, Python API, and Architecture
- make the developer entry page a better routing page instead of only an install/example page

## Problem
Issue #91 is partly about navigation and page-to-page flow. The `For Agent Developers` page currently starts with install instructions, but it does not help new readers decide whether they should go deeper into CLI docs, Python API docs, or architecture docs next.

## Changes
- add a short "New here?" block near the top of `docs/home/for-developers.md`
- link to:
  - `getting-started.md`
  - `cli.md`
  - `python-api.md`
  - `architecture.md`

Fixes #91

## Validation
- Python assertion check for the new links
- `git diff --check`
