### PR TITLE
docs: improve architecture navigation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,11 @@
 
 This page explains the technical architecture and key implementation decisions behind memsearch. For design principles, competitor comparison, and the "why" behind these decisions, see [Design Philosophy](design-philosophy.md).
 
+Need a different level of detail?
+- Use [Getting Started](getting-started.md) if you want a working local setup first
+- Use [CLI Reference](cli.md) if you want command-level usage
+- Use [Python API](python-api.md) if you are integrating memsearch into your own code
+
 ---
 
 ## Cross-Platform Memory Sharing


### PR DESCRIPTION
## Summary
- add a small routing block near the top of `docs/architecture.md`
- point readers to Getting Started, CLI Reference, and Python API depending on what they need next
- make the architecture page less of a dead end for users who land there first

## Problem
Issue #91 is partly about page-to-page flow. The architecture page is useful, but it assumes the reader already knows whether they need setup docs, CLI docs, or API docs next.

## Changes
- add a `Need a different level of detail?` handoff block near the top of `docs/architecture.md`
- link to:
  - `getting-started.md`
  - `cli.md`
  - `python-api.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
