### PR TITLE
docs: improve design philosophy navigation

### DIFF
--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -2,6 +2,11 @@
 
 This page explains the core principles behind memsearch and how they differentiate it from other agent memory solutions.
 
+Need a different level of detail?
+- Use [Getting Started](getting-started.md) if you want a working local setup first
+- Use [Architecture](architecture.md) if you want the implementation/data-flow view
+- Use [CLI Reference](cli.md) if you want command-level usage
+
 ---
 
 ## Markdown is the Source of Truth


### PR DESCRIPTION
## Summary
- add a small routing block near the top of `docs/design-philosophy.md`
- point readers to Getting Started, Architecture, and CLI Reference depending on what they need next
- make the philosophy page less of a dead end for users who land there first

## Problem
Issue #91 is partly about page-to-page flow. The design philosophy page explains the "why", but it does not currently help readers jump to setup docs, implementation docs, or command docs when they need a different level of detail.

## Changes
- add a `Need a different level of detail?` handoff block near the top of `docs/design-philosophy.md`
- link to:
  - `getting-started.md`
  - `architecture.md`
  - `cli.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
