### PR TITLE
docs: improve comparison navigation

### DIFF
--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -2,6 +2,11 @@
 
 memsearch is both a CLI engine and a set of native plugins for four coding CLIs, so we compare it against projects along that whole spectrum, plus Claude Code's built-in memory as a baseline: [Claude Code native memory](https://docs.claude.com/en/docs/claude-code/memory), [claude-mem](https://github.com/thedotmack/claude-mem), [qmd](https://github.com/tobi/qmd), [MemPalace](https://github.com/milla-jovovich/mempalace), [mem0](https://github.com/mem0ai/mem0), [Letta / MemGPT](https://github.com/letta-ai/letta).
 
+Need a different level of detail?
+- Use [Getting Started](../getting-started.md) if you want a working local setup first
+- Use [Design Philosophy](../design-philosophy.md) if you want the principles behind the project
+- Use [Architecture](../architecture.md) if you want the implementation/data-flow view
+
 > Verified against each project's README / official docs. The space moves fast — [open an issue](https://github.com/zilliztech/memsearch/issues) if anything looks stale.
 
 ## At a glance


### PR DESCRIPTION
## Summary
- add a small routing block near the top of `docs/home/comparison.md`
- point readers to Getting Started, Design Philosophy, and Architecture depending on what they need next
- make the comparison page less of a dead end for readers who land there first

## Problem
Issue #91 is partly about page-to-page flow. The comparison page helps users evaluate memsearch against alternatives, but it does not currently route them toward setup docs, philosophy docs, or implementation docs when they want to go deeper.

## Changes
- add a `Need a different level of detail?` handoff block near the top of `docs/home/comparison.md`
- link to:
  - `getting-started.md`
  - `design-philosophy.md`
  - `architecture.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
