### PR TITLE
docs: improve configuration navigation

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -2,6 +2,11 @@
 
 memsearch uses a layered TOML config system. Most users don't need to configure anything — the defaults work out of the box.
 
+Before changing providers or backends:
+- Use [Getting Started](../getting-started.md) if you still need a first working setup
+- Check the [FAQ](../faq.md) for common configuration pitfalls
+- Use [Troubleshooting](../troubleshooting.md) if search or indexing broke after a config change
+
 ## Config Locations (priority low → high)
 
 1. `~/.memsearch/config.toml` — global defaults


### PR DESCRIPTION
## Summary
- add a small handoff block near the top of `docs/home/configuration.md`
- point readers to Getting Started, FAQ, and Troubleshooting before they change providers/backends
- make the configuration page a safer entry point for users who are about to tweak settings

## Problem
Issue #91 is partly about page-to-page flow. The configuration page is where users often start changing embedding providers or Milvus backends, but it does not currently route them toward setup docs or recovery/help pages before or after those changes.

## Changes
- add a short pre-change handoff block near the top of `docs/home/configuration.md`
- link to:
  - `getting-started.md`
  - `faq.md`
  - `troubleshooting.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
