### PR TITLE
docs: improve CLI reference navigation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,10 @@
 
 memsearch provides a command-line interface for indexing, searching, and managing semantic memory over markdown knowledge bases.
 
+New here?
+- Use [Getting Started](getting-started.md) if you want the fastest working setup before reading every command
+- Use [Configuration](home/configuration.md) if you need to switch embedding providers or Milvus backends
+
 ```bash
 $ memsearch --version
 memsearch, version 0.1.3


### PR DESCRIPTION
## Summary
- add a small "new here?" handoff block near the top of `docs/cli.md`
- point readers to Getting Started and Configuration before they dive into the full command reference
- make the CLI reference less of a dead-end page for first-time users

## Problem
Issue #91 is partly about docs flow and discoverability. The CLI reference is comprehensive, but it assumes the reader already has a working setup and understands where provider/backend configuration lives.

## Changes
- add a short handoff block near the top of `docs/cli.md`
- link to:
  - `getting-started.md`
  - `home/configuration.md`

Fixes #91

## Validation
- Python assertion check for the two new links
- `git diff --check`
