### PR TITLE
docs: improve Python API navigation

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2,6 +2,11 @@
 
 memsearch provides a high-level Python API through the `MemSearch` class. Import it, point it at your markdown files, and you get semantic memory for your agent in a few lines of code.
 
+New here?
+- Use [Getting Started](getting-started.md) if you still need the fastest working setup
+- Use [Configuration](home/configuration.md) if you need to switch embedding providers or Milvus backends
+- Use [Architecture](architecture.md) if you want the underlying indexing and recall model first
+
 ```python
 from memsearch import MemSearch
 


### PR DESCRIPTION
## Summary
- add a small "new here?" handoff block near the top of `docs/python-api.md`
- point readers to Getting Started, Configuration, and Architecture before they dive into the full API reference
- make the Python API page less of a dead-end page for first-time users

## Problem
Issue #91 is partly about docs flow and discoverability. The Python API page is useful, but it assumes the reader already has a working setup and understands where provider/backend configuration and implementation details live.

## Changes
- add a short handoff block near the top of `docs/python-api.md`
- link to:
  - `getting-started.md`
  - `home/configuration.md`
  - `architecture.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
