### PR TITLE
docs: add platform comparison next steps

### DIFF
--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -94,6 +94,14 @@ All plugins write standard markdown and derive collection names from the project
 | Codex CLI user | [Codex plugin](codex/index.md) -- shell hooks, similar to Claude Code |
 | Using multiple platforms | Install plugins on each -- they share the same memory backend |
 
+### Next steps after choosing a platform
+
+- **Claude Code** → [Claude Code Plugin](claude-code/index.md)
+- **OpenClaw** → [OpenClaw Plugin](openclaw/index.md)
+- **OpenCode** → [OpenCode Plugin](opencode/index.md)
+- **Codex CLI** → [Codex CLI Plugin](codex/index.md)
+- **Still need backend/setup basics?** → [Getting Started](../getting-started.md)
+
 ---
 
 ## Prerequisites (all platforms)


### PR DESCRIPTION
## Summary
- add a small "next steps after choosing a platform" block to `docs/platforms/index.md`
- route readers from the comparison matrix directly to the correct platform install guide
- add a fallback link to Getting Started for shared backend/setup basics

## Problem
Issue #91 is partly about page-to-page flow. The platform comparison page helps readers decide which plugin they want, but it does not currently give them an explicit next step after that decision.

## Changes
- add a `Next steps after choosing a platform` block after the recommendation table
- link to:
  - Claude Code plugin docs
  - OpenClaw plugin docs
  - OpenCode plugin docs
  - Codex CLI plugin docs
  - Getting Started

Fixes #91

## Validation
- Python assertion check for the new links
- `git diff --check`
