### PR TITLE
docs: improve getting started intro routing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,12 @@
 # Getting Started
 
+If you're here to evaluate memsearch quickly, this page is the right place to start.
+
+If you already know you want to embed memsearch into your own agents or tooling:
+- Use [For Agent Developers](home/for-developers.md) for the developer-oriented overview
+- Jump to [Python API](python-api.md) for library integration
+- Jump to [CLI Reference](cli.md) for shell-based workflows
+
 ## Installation
 
 Install memsearch with pip (OpenAI embeddings are included by default):


### PR DESCRIPTION
## Summary
- add a small routing block near the top of `docs/getting-started.md`
- keep the page focused on quick evaluation, while pointing developers to the more appropriate API/CLI entry points
- improve page-to-page flow for readers who land in Getting Started but actually want integration docs

## Problem
Issue #91 is partly about navigation flow. `getting-started.md` is the right page for first evaluation, but some readers land there when they already know they want Python API or CLI integration details.

## Changes
- add a short intro-routing block near the top of `docs/getting-started.md`
- link to:
  - `home/for-developers.md`
  - `python-api.md`
  - `cli.md`

Fixes #91

## Validation
- Python assertion check for the three new links
- `git diff --check`
