### PR TITLE
docs: add for-users next steps

### DIFF
--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -41,3 +41,11 @@ Each platform adapts the same architecture to its own plugin system:
 - **Codex CLI**: [Full guide →](../platforms/codex/index.md)
 
 See the [Platform Comparison](../platforms/index.md) for a detailed feature matrix.
+
+## Next Steps
+
+- **Want the fastest shared setup path?** → [Getting Started](../getting-started.md)
+- **Already picked Claude Code?** → [Claude Code Plugin](../platforms/claude-code/index.md)
+- **Already picked OpenClaw?** → [OpenClaw Plugin](../platforms/openclaw/index.md)
+- **Already picked OpenCode?** → [OpenCode Plugin](../platforms/opencode/index.md)
+- **Already picked Codex CLI?** → [Codex CLI Plugin](../platforms/codex/index.md)


### PR DESCRIPTION
## Summary
- add a small `Next Steps` block to `docs/home/for-users.md`
- route users from the high-level overview directly to Getting Started or the exact platform guide they chose
- make the user entry page a better handoff surface after platform selection

## Problem
Issue #91 is partly about page-to-page flow. The `For Agent Users` page helps readers understand the plugin model and choose a platform, but it does not currently give them an explicit next step after that decision.

## Changes
- add a `Next Steps` section near the end of `docs/home/for-users.md`
- link to:
  - `getting-started.md`
  - Claude Code plugin docs
  - OpenClaw plugin docs
  - OpenCode plugin docs
  - Codex CLI plugin docs

Fixes #91

## Validation
- Python assertion check for the new section and links
- `git diff --check`
