### PR TITLE
docs: add for-developers next steps

### DIFF
--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -61,3 +61,10 @@ Plugin Recall:   memsearch search → memsearch expand → parse-transcript
 ```
 
 If you're building a plugin for a new platform, see the [Architecture](../architecture.md) and existing plugin source code in `plugins/`.
+
+## Next Steps
+
+- **Want command-level usage?** → [CLI Reference](../cli.md)
+- **Want the full library surface?** → [Python API](../python-api.md)
+- **Want the indexing / recall model?** → [Architecture](../architecture.md)
+- **Still need the fastest first setup?** → [Getting Started](../getting-started.md)


### PR DESCRIPTION
## Summary
- add a small `Next Steps` block to `docs/home/for-developers.md`
- route developers from the overview page directly to CLI, Python API, Architecture, or Getting Started
- make the developer entry page a better handoff surface after the intro example

## Problem
Issue #91 is partly about page-to-page flow. The `For Agent Developers` page introduces the project well, but it does not currently give readers an explicit next step after the install/example overview.

## Changes
- add a `Next Steps` section near the end of `docs/home/for-developers.md`
- link to:
  - `../cli.md`
  - `../python-api.md`
  - `../architecture.md`
  - `../getting-started.md`

Fixes #91

## Validation
- Python assertion check for the new section and links
- `git diff --check`
