### PR TITLE
docs: add platform comparison end handoff

### DIFF
--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -101,3 +101,11 @@ All plugins write standard markdown and derive collection names from the project
 - **Python 3.10+**
 - **memsearch** installed: `uv tool install "memsearch[onnx]"` (or `pip install "memsearch[onnx]"`)
 - First-time ONNX model download: ~558 MB from HuggingFace Hub (cached after first run)
+
+## Next Steps
+
+- **Need shared backend/setup basics first?** → [Getting Started](../getting-started.md)
+- **Installing for Claude Code?** → [Claude Code Plugin](claude-code/index.md)
+- **Installing for OpenClaw?** → [OpenClaw Plugin](openclaw/index.md)
+- **Installing for OpenCode?** → [OpenCode Plugin](opencode/index.md)
+- **Installing for Codex CLI?** → [Codex CLI Plugin](codex/index.md)


### PR DESCRIPTION
## Summary
- add a small `Next Steps` block near the end of `docs/platforms/index.md`
- route readers from the comparison page directly to the correct platform install guide or back to Getting Started
- make the comparison page useful both before and after the feature matrix

## Problem
Issue #91 is partly about page-to-page flow. The platform comparison page now has an early help block, but it still ends abruptly after prerequisites without an explicit final handoff into setup/install docs.

## Changes
- add a `Next Steps` section after the shared prerequisites
- link to:
  - `../getting-started.md`
  - `claude-code/index.md`
  - `openclaw/index.md`
  - `opencode/index.md`
  - `codex/index.md`

Fixes #91

## Validation
- Python assertion check for the new section and links
- `git diff --check`
