### PR TITLE
docs: link for-users to platform comparison

### DIFF
--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -2,6 +2,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
 
+If you want a feature-by-feature matrix before choosing, see the full [Platform Comparison](../platforms/index.md).
+
 ## Choose Your Platform
 
 | Platform | Install | Maturity |


### PR DESCRIPTION
## Summary
- add a direct link from `docs/home/for-users.md` to the full platform comparison page
- help undecided users jump to the feature matrix before choosing an install path

## Problem
Issue #91 is partly about discoverability. The `For Agent Users` page already lists supported platforms, but readers who want a deeper feature-by-feature comparison do not get a direct pointer to `docs/platforms/index.md` until later.

## Changes
- add a short cross-link near the top of `docs/home/for-users.md`
- point readers to `../platforms/index.md` before the install table

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
