### PR TITLE
docs: link for-developers to comparison

### DIFF
--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -2,6 +2,8 @@
 
 Build memory into your own agents using the memsearch CLI and Python API.
 
+If you're still evaluating options, start with [Comparison with Alternatives](comparison.md) before committing to an integration path.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- add a direct link from `docs/home/for-developers.md` to the alternatives comparison page
- help undecided developers evaluate memsearch before committing to an integration path

## Problem
Issue #91 is partly about discoverability. The `For Agent Developers` page currently assumes the reader is ready to install or integrate, but some readers first want a product-level comparison with alternatives.

## Changes
- add a short cross-link near the top of `docs/home/for-developers.md`
- point readers to `comparison.md` before the install section

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
