### PR TITLE
docs: add comparison next steps

### DIFF
--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -62,6 +62,12 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 - **Cursor / ChatGPT / Gemini CLI users** → mem0, MemPalace, or claude-mem.
 - **Just need a local markdown search engine** → qmd.
 
+## Next Steps
+
+- **Ready to try memsearch quickly?** → [Getting Started](../getting-started.md)
+- **Evaluating as an end user?** → [For Agent Users](for-users.md)
+- **Evaluating as a builder/integrator?** → [For Agent Developers](for-developers.md)
+
 ## References
 
 - Claude Code native memory — [docs](https://docs.claude.com/en/docs/claude-code/memory)


### PR DESCRIPTION
## Summary
- add a small `Next Steps` block near the end of `docs/home/comparison.md`
- route readers from the alternatives comparison directly to Getting Started, For Agent Users, or For Agent Developers
- make the comparison page a better endpoint after product evaluation

## Problem
Issue #91 is partly about page-to-page flow. The comparison page helps readers decide whether memsearch fits, but it does not currently give them a clear next step after that evaluation.

## Changes
- add a `Next Steps` section near the end of `docs/home/comparison.md`
- link to:
  - `../getting-started.md`
  - `for-users.md`
  - `for-developers.md`

Fixes #91

## Validation
- Python assertion check for the new section and links
- `git diff --check`
