### PR TITLE
docs: add homepage overview links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+[:octicons-arrow-right-24: User overview](home/for-users.md){ .md-button }
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.
@@ -77,6 +79,8 @@ All platforms share the same markdown memory format and derive collection names 
 ## For Agent Developers
 
 Build custom agent integrations with the memsearch CLI or Python API.
+
+[:octicons-arrow-right-24: Developer overview](home/for-developers.md){ .md-button }
 
 ### Python API
 


### PR DESCRIPTION
## Summary
- add direct homepage entry buttons for the user and developer overview pages
- make the landing page route readers into the curated overview flows instead of only lower-level docs

## Problem
Issue #91 is partly about discoverability. The homepage already links to platform docs, Getting Started, CLI, and Python API, but it did not directly expose the higher-level overview pages for agent users and agent developers.

## Changes
- add a `User overview` button under the `For Agent Users` section
- add a `Developer overview` button under the `For Agent Developers` section

Fixes #91

## Validation
- manual content check for the two new homepage buttons
- `git diff --check`
