### PR TITLE
docs: add homepage comparison link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -156,7 +156,7 @@ graph LR
 - **Three-layer progressive disclosure** -- search summaries, expand to full sections, drill into original transcripts
 - **Cross-platform memory sharing** -- shared Milvus backend lets agents on different platforms access the same memories
 
-[:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
+[:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button } [:octicons-arrow-right-24: Comparison](home/comparison.md){ .md-button }
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Comparison button to the homepage "How It Works" section
- let readers jump from implementation overview directly to the alternatives comparison page
- connect the homepage's architecture/philosophy area to the product-evaluation docs

## Problem
Issue #91 is partly about discoverability. The homepage already routes readers to Architecture and Design Philosophy, but it does not expose the alternatives comparison page from the same high-level conceptual area.

## Changes
- add a `Comparison` button next to the existing `Architecture` and `Design Philosophy` buttons in `docs/index.md`

Fixes #91

## Validation
- manual content check for the new homepage button
- `git diff --check`
