### PR TITLE
docs: add homepage configuration link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,6 +183,8 @@ graph LR
 | **Milvus Server** | `http://localhost:19530` | Multi-agent, team environments |
 | **Zilliz Cloud** | `https://in03-xxx.zillizcloud.com` | Production, fully managed -- [free tier](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) |
 
+Want to change the default embedding provider or Milvus backend? See [Configuration](home/configuration.md).
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add a direct Configuration link to the homepage provider/backend summary area
- help readers move from default install choices into provider/backend customization docs

## Problem
Issue #91 is partly about discoverability. The homepage explains the default embedding providers and Milvus backend modes, but it does not currently point readers to the page where those defaults are actually configured.

## Changes
- add a short handoff line after the Milvus backend summary in `docs/index.md`
- point readers to `home/configuration.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
