### PR TITLE
docs: add homepage bottom overview links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -185,6 +185,10 @@ graph LR
 
 ---
 
+Not sure where to go next?
+- **Using memsearch in an agent?** → [For Agent Users](home/for-users.md)
+- **Building on top of memsearch?** → [For Agent Developers](home/for-developers.md)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- add a small bottom-of-page handoff on the homepage
- route readers from the end of `docs/index.md` back to the user and developer overview pages
- make the homepage useful both at the top and at the bottom

## Problem
Issue #91 is partly about discoverability. The homepage now has many entry points near the top, but readers who scroll through the full page still hit the license section without an obvious final routing choice.

## Changes
- add a short `Not sure where to go next?` block near the end of `docs/index.md`
- link to:
  - `home/for-users.md`
  - `home/for-developers.md`

Fixes #91

## Validation
- Python assertion check for the new links
- `git diff --check`
