### PR TITLE
docs: add homepage embedding evaluation link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,8 @@ graph LR
 | Ollama | `memsearch[ollama]` | `nomic-embed-text` |
 | Local | `memsearch[local]` | `all-MiniLM-L6-v2` |
 
+Want to know why the default embedding model is `bge-m3-onnx-int8`? See [Embedding Model Evaluation](home/embedding-evaluation.md).
+
 ---
 
 ## Milvus Backend


### PR DESCRIPTION
## Summary
- add a direct link from the homepage embedding provider summary to the embedding evaluation page
- help readers move from the default model table to the benchmark/rationale behind that default

## Problem
Issue #91 is partly about discoverability. The homepage shows the default embedding provider/model, but it does not currently point readers to the page that explains why that model is the default.

## Changes
- add a short handoff line after the embedding provider summary in `docs/index.md`
- point readers to `home/embedding-evaluation.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
