### PR TITLE
docs: add homepage backend setup link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,6 +183,8 @@ graph LR
 | **Milvus Server** | `http://localhost:19530` | Multi-agent, team environments |
 | **Zilliz Cloud** | `https://in03-xxx.zillizcloud.com` | Production, fully managed -- [free tier](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) |
 
+Need help choosing the right backend and URI format? See [Getting Started](getting-started.md#milvus-backends).
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add a direct link from the homepage Milvus backend summary to the backend setup section in Getting Started
- help readers move from backend mode selection into the concrete setup guidance

## Problem
Issue #91 is partly about discoverability. The homepage explains the available Milvus backend modes, but it does not currently point readers to the section that explains how to choose and configure those backends.

## Changes
- add a short handoff line after the Milvus backend summary in `docs/index.md`
- point readers to `getting-started.md#milvus-backends`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
