### PR TITLE
docs: add homepage developer comparison link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 Build custom agent integrations with the memsearch CLI or Python API.
 
+Still evaluating memory solutions? See [Comparison with Alternatives](home/comparison.md).
+
 ### Python API
 
 ```python


### PR DESCRIPTION
## Summary
- add a direct Comparison link to the homepage developer section
- help undecided builders jump from the landing page into the alternatives evaluation page before diving into API/CLI details

## Problem
Issue #91 is partly about discoverability. The homepage developer section already routes readers to the Python API and CLI reference, but it does not give undecided developers an immediate path to the alternatives comparison page.

## Changes
- add a short cross-link under `## For Agent Developers` in `docs/index.md`
- point readers to `home/comparison.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
