### PR TITLE
docs: add homepage user comparison link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+Still comparing options? See [Comparison with Alternatives](home/comparison.md).
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.


### PR DESCRIPTION
## Summary
- add a direct Comparison link to the homepage user section
- help undecided users jump from the landing page into the alternatives evaluation page before choosing a platform

## Problem
Issue #91 is partly about discoverability. The homepage user section already routes readers toward platform selection, but it does not give undecided users an immediate path to the alternatives comparison page.

## Changes
- add a short cross-link under `## For Agent Users` in `docs/index.md`
- point readers to `home/comparison.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
