### PR TITLE
docs: add homepage developer architecture link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 Build custom agent integrations with the memsearch CLI or Python API.
 
+Want the implementation model first? See [Architecture](architecture.md).
+
 ### Python API
 
 ```python


### PR DESCRIPTION
## Summary
- add a direct Architecture link to the homepage developer section
- help implementation-focused builders jump from the landing page into the architecture docs before diving into API/CLI details

## Problem
Issue #91 is partly about discoverability. The homepage developer section already points readers toward API/CLI entry points, but it does not give implementation-focused builders an immediate path to the architecture page.

## Changes
- add a short cross-link under `## For Agent Developers` in `docs/index.md`
- point readers to `architecture.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
