### PR TITLE
docs: add homepage user getting started link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+Need the full quickstart first? See [Getting Started](getting-started.md).
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.


### PR DESCRIPTION
## Summary
- add a direct Getting Started link to the homepage user section
- help readers jump from the landing page into the full quickstart before picking a specific platform

## Problem
Issue #91 is partly about discoverability. The homepage user section routes readers toward platform-specific docs, but it does not give readers an immediate path to the general getting-started flow.

## Changes
- add a short cross-link under `## For Agent Users` in `docs/index.md`
- point readers to `getting-started.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
