### PR TITLE
docs: add homepage developer faq link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 Build custom agent integrations with the memsearch CLI or Python API.
 
+Have setup or compatibility questions first? See [FAQ](faq.md).
+
 ### Python API
 
 ```python


### PR DESCRIPTION
## Summary
- add a direct FAQ link to the homepage developer section
- help readers jump from the landing page into common setup and compatibility questions before diving into API/CLI references

## Problem
Issue #91 is partly about discoverability. The homepage developer section routes readers toward API and CLI references, but it does not give readers an immediate path to the FAQ page.

## Changes
- add a short cross-link under `## For Agent Developers` in `docs/index.md`
- point readers to `faq.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
