### PR TITLE
docs: add homepage user troubleshooting link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+Hit a common setup problem? See [Troubleshooting](troubleshooting.md).
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.


### PR DESCRIPTION
## Summary
- add a direct Troubleshooting link to the homepage user section
- help readers jump from the landing page into common setup issues before choosing a specific platform

## Problem
Issue #91 is partly about discoverability. The homepage user section routes readers toward platform-specific docs, but it does not give readers an immediate path to the troubleshooting page.

## Changes
- add a short cross-link under `## For Agent Users` in `docs/index.md`
- point readers to `troubleshooting.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
