### PR TITLE
docs: add homepage getting started handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Ready to try it after reading the architecture? See [Getting Started](getting-started.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Getting Started handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into actually trying it

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works and links to Architecture and Design Philosophy, but it does not give readers an immediate next step into the practical getting-started flow.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `getting-started.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
