### PR TITLE
docs: add homepage faq handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Have questions after reading how it works? See [FAQ](faq.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct FAQ handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into common product and compatibility questions

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works and links to Architecture and Design Philosophy, but it does not give readers an immediate next step into the FAQ page.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `faq.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
