### PR TITLE
docs: add provider faq handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,8 @@ graph LR
 | Ollama | `memsearch[ollama]` | `nomic-embed-text` |
 | Local | `memsearch[local]` | `all-MiniLM-L6-v2` |
 
+Have provider questions? See [FAQ](faq.md).
+
 ---
 
 ## Milvus Backend


### PR DESCRIPTION
## Summary
- add a direct FAQ handoff after the homepage embedding provider summary
- help readers move from the provider/model overview into common provider and compatibility questions

## Problem
Issue #91 is partly about discoverability. The homepage shows the available embedding providers and default model, but it does not give readers an immediate path to common questions about provider choices and compatibility.

## Changes
- add a short handoff line after the `Embedding Providers` section in `docs/index.md`
- point readers to `faq.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
