### PR TITLE
docs: add backend faq handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,6 +183,8 @@ graph LR
 | **Milvus Server** | `http://localhost:19530` | Multi-agent, team environments |
 | **Zilliz Cloud** | `https://in03-xxx.zillizcloud.com` | Production, fully managed -- [free tier](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-docs) |
 
+Have backend questions? See [FAQ](faq.md).
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add a direct FAQ handoff after the homepage Milvus backend summary
- help readers move from backend mode selection into common backend and compatibility questions

## Problem
Issue #91 is partly about discoverability. The homepage shows the available Milvus backend modes, but it does not give readers an immediate path to common questions about backend choices, URI formats, and compatibility.

## Changes
- add a short handoff line after the `Milvus Backend` section in `docs/index.md`
- point readers to `faq.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
