### PR TITLE
docs: add provider getting started handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,8 @@ graph LR
 | Ollama | `memsearch[ollama]` | `nomic-embed-text` |
 | Local | `memsearch[local]` | `all-MiniLM-L6-v2` |
 
+Ready to try a provider choice? See [Getting Started](getting-started.md).
+
 ---
 
 ## Milvus Backend


### PR DESCRIPTION
## Summary
- add a direct Getting Started handoff after the homepage embedding provider summary
- help readers move from the provider/model overview into the practical setup flow

## Problem
Issue #91 is partly about discoverability. The homepage shows the available embedding providers and default model, but it does not give readers an immediate path from provider choice into the getting-started flow.

## Changes
- add a short handoff line after the `Embedding Providers` section in `docs/index.md`
- point readers to `getting-started.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
