### PR TITLE
docs: add platform comparison handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to compare how the integrations differ across platforms? See [Platform comparison](platforms/index.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Platform comparison handoff after the homepage architecture overview
- help readers move from understanding cross-platform memory sharing into the platform comparison page

## Problem
Issue #91 is partly about discoverability. The homepage explains that memories can be shared across platforms, but it does not give readers an immediate next step into the page that compares the integrations directly.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `platforms/index.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
