### PR TITLE
docs: add developer handoff from architecture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to build this flow into your own tooling? See [For Agent Developers](home/for-developers.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct developer-oriented handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into the developer overview flow

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works, but it does not give developers an immediate next step back into the implementation-oriented path after they understand the model.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `home/for-developers.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
