### PR TITLE
docs: add user platform comparison handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+Not sure which platform fits best? See [Platform comparison](platforms/index.md).
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.


### PR DESCRIPTION
## Summary
- add a direct Platform comparison handoff to the homepage user section
- help readers compare integrations before diving into a platform-specific install flow

## Problem
Issue #91 is partly about discoverability. The homepage user section starts platform-specific guidance immediately, but it does not give undecided users an immediate path to the cross-platform comparison page.

## Changes
- add a short cross-link under `## For Agent Users` in `docs/index.md`
- point readers to `platforms/index.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
