### PR TITLE
docs: add developer platform comparison handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 Build custom agent integrations with the memsearch CLI or Python API.
 
+Not sure which integration path fits best? See [Platform comparison](platforms/index.md).
+
 ### Python API
 
 ```python


### PR DESCRIPTION
## Summary
- add a direct Platform comparison handoff to the homepage developer section
- help readers compare integration paths before diving into API and CLI references

## Problem
Issue #91 is partly about discoverability. The homepage developer section starts API/CLI-oriented guidance immediately, but it does not give undecided developers an immediate path to the cross-platform comparison page.

## Changes
- add a short cross-link under `## For Agent Developers` in `docs/index.md`
- point readers to `platforms/index.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
