### PR TITLE
docs: add embedding evaluation handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to see how the default embedding choice was evaluated? See [Embedding Model Evaluation](home/embedding-evaluation.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Embedding Model Evaluation handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into the rationale behind the default embedding choice

## Problem
Issue #91 is partly about discoverability. The homepage explains the search/indexing model, but it does not give readers an immediate next step into the page that explains how the default embedding model was evaluated.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `home/embedding-evaluation.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
