### PR TITLE
docs: add provider platform comparison handoff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,8 @@ graph LR
 | Ollama | `memsearch[ollama]` | `nomic-embed-text` |
 | Local | `memsearch[local]` | `all-MiniLM-L6-v2` |
 
+Want to compare which platforms use these defaults? See [Platform comparison](platforms/index.md).
+
 ---
 
 ## Milvus Backend


### PR DESCRIPTION
## Summary
- add a direct Platform comparison handoff after the homepage embedding provider summary
- help readers move from the provider/model overview into the cross-platform integration comparison page

## Problem
Issue #91 is partly about discoverability. The homepage shows the available embedding providers and default model, but it does not give readers an immediate path to the page that compares platform integrations.

## Changes
- add a short handoff line after the `Embedding Providers` section in `docs/index.md`
- point readers to `platforms/index.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
