### PR TITLE
docs: add cli handoff from architecture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to operate directly from the terminal after understanding the model? See [CLI reference](cli.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct CLI reference handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into command-level usage

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works, but it does not give CLI-oriented readers an immediate next step into the command reference after they understand the model.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `cli.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
