### PR TITLE
docs: add python api handoff from architecture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to integrate this flow programmatically after understanding the model? See [Python API reference](python-api.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Python API reference handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into programmatic integration details

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works, but it does not give API-oriented readers an immediate next step into the Python API reference after they understand the model.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `python-api.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
