### PR TITLE
docs: add configuration handoff from architecture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to tune the pieces behind this flow? See [Configuration](home/configuration.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Configuration handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into the configuration details behind that flow

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works, but it does not give configuration-oriented readers an immediate next step into the configuration page after they understand the model.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `home/configuration.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
