### PR TITLE
docs: add comparison handoff from architecture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ graph LR
 
 [:octicons-arrow-right-24: Architecture](architecture.md){ .md-button } [:octicons-arrow-right-24: Design Philosophy](design-philosophy.md){ .md-button }
 
+Want to compare this architecture with other approaches? See [Comparison with Alternatives](home/comparison.md).
+
 ---
 
 ## Embedding Providers


### PR DESCRIPTION
## Summary
- add a direct Comparison with Alternatives handoff after the homepage architecture overview
- help readers move from understanding how memsearch works into comparing that design with other approaches

## Problem
Issue #91 is partly about discoverability. The homepage explains how memsearch works, but it does not give comparison-oriented readers an immediate next step into the alternatives page after they understand the model.

## Changes
- add a short handoff line after the `How It Works` section in `docs/index.md`
- point readers to `home/comparison.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
