### PR TITLE
docs: add user handoff after platform comparison

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 [:octicons-arrow-right-24: Platform comparison](platforms/index.md){ .md-button }
 
+Want the practical user path after comparing platforms? See [For Agent Users](home/for-users.md).
+
 ---
 
 ## For Agent Developers


### PR DESCRIPTION
## Summary
- add a direct user-oriented handoff after the homepage platform comparison table
- help readers move from comparing integrations into the practical user overview flow

## Problem
Issue #91 is partly about discoverability. The homepage includes a platform comparison table, but after readers compare platforms there is no immediate next step back into the practical user path.

## Changes
- add a short handoff line after the `Platform comparison` button in `docs/index.md`
- point readers to `home/for-users.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
