### PR TITLE
docs: add developer handoff after platform comparison

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 [:octicons-arrow-right-24: Platform comparison](platforms/index.md){ .md-button }
 
+Want the implementation-oriented path after comparing platforms? See [For Agent Developers](home/for-developers.md).
+
 ---
 
 ## For Agent Developers


### PR DESCRIPTION
## Summary
- add a direct developer-oriented handoff after the homepage platform comparison table
- help readers move from comparing integrations into the implementation-oriented developer overview flow

## Problem
Issue #91 is partly about discoverability. The homepage includes a platform comparison table, but after readers compare platforms there is no immediate next step back into the developer path.

## Changes
- add a short handoff line after the `Platform comparison` button in `docs/index.md`
- point readers to `home/for-developers.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
