### PR TITLE
docs: add architecture handoff after platform comparison

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 [:octicons-arrow-right-24: Platform comparison](platforms/index.md){ .md-button }
 
+Need the system model behind those integrations? See [Architecture](architecture.md).
+
 ---
 
 ## For Agent Developers


### PR DESCRIPTION
## Summary
- add a direct Architecture handoff after the homepage platform comparison table
- help readers move from comparing integrations back into the system model behind those paths

## Problem
Issue #91 is partly about discoverability. The homepage includes a platform comparison table, but after readers compare platforms there is no immediate next step into the architecture path.

## Changes
- add a short handoff line after the `Platform comparison` button in `docs/index.md`
- point readers to `architecture.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
