### PR TITLE
docs: add embedding evaluation handoff after platform comparison

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,8 @@ All platforms share the same markdown memory format and derive collection names 
 
 [:octicons-arrow-right-24: Platform comparison](platforms/index.md){ .md-button }
 
+Want the benchmark context behind the default model choices? See [Embedding Model Evaluation](home/embedding-evaluation.md).
+
 ---
 
 ## For Agent Developers


### PR DESCRIPTION
## Summary
- add a direct Embedding Model Evaluation handoff after the homepage platform comparison table
- help readers move from comparing integrations into the benchmark context behind default model choices

## Problem
Issue #91 is partly about discoverability. The homepage includes a platform comparison table, but after readers compare platforms there is no immediate next step into the embedding evaluation path.

## Changes
- add a short handoff line after the `Platform comparison` button in `docs/index.md`
- point readers to `home/embedding-evaluation.md`

Fixes #91

## Validation
- Python assertion check for the new link
- `git diff --check`
