### PR TITLE
docs: add getting-started links to entry pages

### DIFF
--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -2,6 +2,8 @@
 
 Build memory into your own agents using the memsearch CLI and Python API.
 
+> **Prefer a broader walkthrough first?** Read [Getting Started](../getting-started.md) for the indexing/search flow, or see the [Platform Comparison](../platforms/index.md) to understand how the plugins layer on top.
+
 ## Install
 
 ```bash

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -2,6 +2,8 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
 
+> **New to memsearch?** Start with [Getting Started](../getting-started.md) for the core concepts, or compare platforms in the [Platform Comparison](../platforms/index.md).
+
 ## Choose Your Platform
 
 | Platform | Install | Maturity |


### PR DESCRIPTION
## Summary
- add quick getting-started/platform-comparison callouts to the user and developer landing pages
- make the docs entry pages easier to navigate for readers who land there first

## Testing
- uv sync --group docs
- uv run mkdocs build
