### PR TITLE
docs: add audience links to quickstart

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> **Choose your path:** setting up a plugin? Start with [For Agent Users](home/for-users.md). Building your own integration? Start with [For Agent Developers](home/for-developers.md). Comparing platforms first? See the [Platform Comparison](platforms/index.md).
+
 ## Installation
 
 Install memsearch with pip (OpenAI embeddings are included by default):


### PR DESCRIPTION
## Summary
- add a short audience-routing callout at the top of Getting Started
- link readers to the user guide, developer guide, and platform comparison before the install steps

## Testing
- uv sync --group docs
- uv run mkdocs build
