### PR TITLE
docs: add FAQ, troubleshooting, zero-config quickstart, OpenCode Windows notes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,76 @@
+# FAQ
+
+## Does memsearch work on Windows?
+
+Yes, but **Milvus Lite** (the default local `.db` backend) does not provide Windows binaries.
+
+If you are on Windows, use one of these options instead:
+
+- **Milvus Server** via Docker
+- **Zilliz Cloud**
+- **WSL2** if you specifically want the Milvus Lite local-file workflow
+
+See [Getting Started — Milvus Backends](getting-started.md#milvus-backends) for the backend comparison and recommended setup.
+
+## How do I wipe and rebuild the index?
+
+Use `memsearch reset --yes` to drop the current collection, then run `memsearch index` again.
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+This deletes the indexed chunks in Milvus, but it does **not** delete your source markdown files.
+
+For command details, see the [CLI reference](cli.md#memsearch-reset).
+
+## How do I see what is indexed?
+
+Start with index stats:
+
+```bash
+memsearch stats
+```
+
+That shows the total indexed chunk count for the active collection.
+
+To inspect actual indexed content, run a representative search, then progressively expand results:
+
+```bash
+memsearch search "redis ttl"
+memsearch expand <chunk_id>
+```
+
+See the [CLI reference](cli.md#memsearch-stats) for `stats`, and the `search` / `expand` sections for content inspection workflows.
+
+## Why is search returning irrelevant results?
+
+Common causes:
+
+- the current embedding provider does not match the kind of content you indexed
+- the index is stale and needs re-indexing
+- your query is too short or too vague
+- you switched providers/models and are still searching an old index
+
+Practical things to try:
+
+1. Re-index your memory files: `memsearch index . --force`
+2. Make the query more specific
+3. Check which embedding provider you configured
+4. If you recently changed providers, consider resetting and rebuilding the index
+
+See [Configuration](home/configuration.md) for embedding provider options.
+
+## What does "dimension mismatch" mean, and how do I fix it?
+
+A dimension mismatch means your existing Milvus collection was created with one embedding dimension, but your current embedding provider/model is producing vectors with a different dimension.
+
+The usual fix is to reset the collection and re-index from source markdown files:
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+Because markdown is the source of truth, rebuilding the vector index is safe as long as your original memory files are still present.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,38 @@ $ pip install "memsearch[anthropic]"   # Anthropic (for compact/summarization LL
 $ pip install "memsearch[all]"         # Everything above
 ```
 
+## Zero-config quick start (no API key)
+
+If you want the fastest path to a working local setup, use local embeddings plus the default **Milvus Lite** backend. This runs entirely on your machine and does not require an API key.
+
+```bash
+$ mkdir -p quickstart-notes
+$ printf '# Notes\n\n- Redis TTL is 15 minutes\n- Staging URL is https://staging.example.com\n' > quickstart-notes/MEMORY.md
+$ pip install "memsearch[local]"
+```
+
+```python
+import asyncio
+from memsearch import MemSearch
+
+async def main():
+    mem = MemSearch(
+        paths=["./quickstart-notes"],
+        embedding_provider="local",
+    )
+    await mem.index()
+
+    results = await mem.search("what is the Redis TTL?", top_k=3)
+    for r in results:
+        print(r["content"])
+
+    mem.close()
+
+asyncio.run(main())
+```
+
+Use this path when you want to evaluate memsearch quickly before wiring in OpenAI, Ollama, or a remote Milvus deployment.
+
 ---
 
 ## How It All Fits Together
@@ -637,9 +669,15 @@ mem = MemSearch(paths=["./docs/shared-knowledge", "./.memsearch/memory"])
 
 ## What's Next
 
+Now that you have a working setup, pick the next page based on what you're trying to do:
+
+- **[FAQ](faq.md)** -- common questions about Windows, reset/rebuild flows, and dimension mismatch
+- **[Troubleshooting](troubleshooting.md)** -- operational recovery steps when search, indexing, or embeddings behave unexpectedly
+- **[CLI Reference](cli.md)** -- complete reference for all `memsearch` commands, flags, and options
+- **[Python API](python-api.md)** -- build custom agent integrations
+- **[Integrations](integrations.md)** -- plug memsearch into LangChain, LangGraph, LlamaIndex, and CrewAI
 - **[Architecture](architecture.md)** -- deep dive into the chunking pipeline, dedup strategy, and data flow diagrams
 - **[Design Philosophy](design-philosophy.md)** -- why markdown, why Milvus, comparison with competitors
-- **[CLI Reference](cli.md)** -- complete reference for all `memsearch` commands, flags, and options
 - **[Claude Code Plugin](platforms/claude-code/index.md)** -- install memsearch for Claude Code
-- **[Platform Comparison](platforms/index.md)** -- compare all 4 supported platforms
+- **[Platform Comparison](platforms/index.md)** -- compare all supported platforms
 - **[Python API](python-api.md)** -- build custom agent integrations

--- a/docs/platforms/opencode/index.md
+++ b/docs/platforms/opencode/index.md
@@ -44,8 +44,13 @@ If you use multiple AI coding agents (e.g., OpenCode for some projects, Claude C
 
 ---
 
+## Platform Notes
+
+!!! warning "Native Windows is not supported yet"
+    The current OpenCode plugin depends on external `bash` and `python3` helper scripts. For Windows, run it inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) or another POSIX-compatible shell environment. See [issue #387](https://github.com/zilliztech/memsearch/issues/387).
+
 ## Pages
 
-- [Installation](installation.md) -- prerequisites, automated and manual install
+- [Installation](installation.md) -- prerequisites, automated and manual install, verification steps, Windows notes
 - [How It Works](how-it-works.md) -- capture daemon, cold-start, memory files, architecture
 - [Memory Tools](memory-tools.md) -- three registered tools, progressive recall, comparisons

--- a/docs/platforms/opencode/installation.md
+++ b/docs/platforms/opencode/installation.md
@@ -5,6 +5,42 @@
 - OpenCode with plugin support
 - Python 3.10+
 - memsearch installed: `uv tool install "memsearch[onnx]"`
+- POSIX shell environment for the plugin helper scripts (`bash` + `python3`)
+
+!!! warning "Native Windows is not supported yet"
+    The OpenCode plugin currently shells out to `bash` and `python3` helper scripts for collection derivation, transcript parsing, and the background capture daemon. On a plain Windows install without a POSIX shell, the plugin may fail with errors like `derive-collection.sh: No such file or directory`.
+
+    Recommended options:
+
+    - Run OpenCode + memsearch inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)
+    - Or use Git Bash / another POSIX-compatible shell and expect some path-handling rough edges
+
+    If you need native Windows support, track [issue #387](https://github.com/zilliztech/memsearch/issues/387).
+
+## Verify the plugin is working
+
+After restarting OpenCode, use this quick checklist:
+
+1. Open a project and chat for a few turns.
+2. Confirm memory files appear:
+
+```bash
+ls .memsearch/memory/
+```
+
+3. Inspect today's memory file:
+
+```bash
+cat .memsearch/memory/$(date +%Y-%m-%d).md
+```
+
+4. Ask a recall question in OpenCode, for example:
+
+```text
+We discussed the authentication flow before, what was the approach?
+```
+
+If capture is working, you should see daily markdown files appear and the agent should be able to use `memory_search` / `memory_get` / `memory_transcript` when history is relevant.
 
 ## Install from npm (recommended)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,108 @@
+# Troubleshooting
+
+This page covers common **memsearch core** issues that affect the Python library, CLI, and platform plugins alike. For plugin-specific hook/runtime issues, see the individual platform troubleshooting pages.
+
+## Search returns no results
+
+Start with basic index health checks:
+
+```bash
+memsearch stats
+memsearch search "your query here" --top-k 5
+```
+
+If `stats` shows 0 or the count is unexpectedly low, rebuild the index:
+
+```bash
+memsearch index . --force
+```
+
+Common causes:
+
+- the relevant markdown files were never indexed
+- the index is stale and needs re-indexing
+- the query is too short or vague
+- the embedding provider/model changed after the collection was created
+
+## Dimension mismatch
+
+A dimension mismatch means the existing Milvus collection was created with one embedding dimension, but your current embedding provider/model is producing a different vector size.
+
+Typical fix:
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+This is safe because your markdown files are the source of truth; resetting only drops the vector index.
+
+## API key missing
+
+If you use a hosted embedding provider, make sure the expected API key is present.
+
+Common environment variables:
+
+- `OPENAI_API_KEY`
+- `GOOGLE_API_KEY`
+- `VOYAGE_API_KEY`
+
+If you do not want to manage API keys, switch to a local provider such as ONNX, Ollama, or `local` sentence-transformers.
+
+## Windows + Milvus Lite
+
+Milvus Lite (the default local `.db` backend) does not provide Windows binaries.
+
+On Windows, use one of these options instead:
+
+- Milvus Server via Docker
+- Zilliz Cloud
+- WSL2 if you specifically want the local Milvus Lite workflow
+
+See [Getting Started — Milvus Backends](getting-started.md#milvus-backends).
+
+## Rebuild from source markdown
+
+To wipe the current collection and rebuild from markdown files:
+
+```bash
+memsearch reset --yes
+memsearch index .
+```
+
+Useful when:
+
+- you switched embedding providers/models
+- search quality looks wrong after a configuration change
+- you want to confirm the stored vectors match the current source markdown
+
+## Inspect what is indexed
+
+Use `stats` for a quick count:
+
+```bash
+memsearch stats
+```
+
+Then inspect actual content with progressive disclosure:
+
+```bash
+memsearch search "redis ttl"
+memsearch expand <chunk_id>
+```
+
+## Remote Milvus stats look stale
+
+On remote Milvus Server / Zilliz Cloud, `stats` may lag immediately after upserts because collection stats update after flush/compaction.
+
+Search results are still the better source of truth for "is my content searchable right now?"
+
+## First local model download is slow
+
+Local embedding setups such as ONNX may need to download model artifacts on first use. That initial run can feel slow compared with later runs.
+
+If you want to warm the cache ahead of time, run a dummy command once:
+
+```bash
+memsearch search "warmup"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ nav:
     - Comparison with Alternatives: home/comparison.md
     - Embedding Model Evaluation: home/embedding-evaluation.md
     - Quickstart: getting-started.md
+    - FAQ: faq.md
+    - Troubleshooting: troubleshooting.md
   - Claude Code Plugin:
     - Overview: platforms/claude-code/index.md
     - Installation: platforms/claude-code/installation.md

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -30,6 +30,8 @@ uv tool install 'memsearch[onnx]'
 }
 ```
 
+> Windows note: the current plugin shells out to `bash` and `python3` helper scripts. Plain Windows installs are not supported yet; use WSL2 (recommended) or a POSIX-compatible shell such as Git Bash. See issue #387.
+
 ### Install from Source (development)
 
 ```bash
@@ -72,6 +74,17 @@ OpenCode Session
         ├── memory_get    ──→ memsearch expand (full context)
         └── memory_transcript ──→ parse-transcript.py (SQLite reader)
 ```
+
+## Verify It Works
+
+After restarting OpenCode, chat for a few turns in a project and confirm memory capture is happening:
+
+```bash
+ls .memsearch/memory/
+cat .memsearch/memory/$(date +%Y-%m-%d).md
+```
+
+If the plugin is active, daily markdown files should appear and grow as conversations finish.
 
 ## Recall Memories
 


### PR DESCRIPTION
## Summary

Consolidates the most valuable documentation improvements from community contributions by @haosenwang1018 (#415, #416, #417, #419, #421) into a single PR.

### New pages
- **`docs/faq.md`** — 5 common questions: Windows support, wipe/rebuild, inspect indexed content, search quality, dimension mismatch
- **`docs/troubleshooting.md`** — 8 concrete recovery scenarios: no results, dimension mismatch, API key missing, Windows + Milvus Lite, rebuild from markdown, inspect what's indexed, stale remote stats, slow first model download

### Getting Started improvements
- **Zero-config quickstart** section — complete local-only example using `local` embeddings + Milvus Lite, no API key needed
- **Expanded "What's Next"** — added FAQ, Troubleshooting, Python API, Integrations links alongside existing entries

### OpenCode Windows documentation
- Windows/WSL2 warning admonitions in docs overview, installation page, and plugin README
- Installation verification checklist (references #387)

### Navigation
- mkdocs.yml nav entries for FAQ and Troubleshooting under the main section

Based on work from @haosenwang1018 in PRs #415, #416, #417, #419, #421.

## Test plan

- [x] `bash -n` on all shell examples
- [x] All internal doc links point to existing pages
- [x] mkdocs nav entries match actual file paths