### PR TITLE
fix(store): normalize RRF hybrid search scores to [0, 1] range

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -172,17 +172,22 @@ class MilvusStore:
             **req_kwargs,
         )
 
+        reqs = [dense_req, bm25_req]
+        rrf_k = 60
         results = self._client.hybrid_search(
             collection_name=self._collection,
-            reqs=[dense_req, bm25_req],
-            ranker=RRFRanker(k=60),
+            reqs=reqs,
+            ranker=RRFRanker(k=rrf_k),
             limit=top_k,
             output_fields=self._QUERY_FIELDS,
         )
 
         if not results or not results[0]:
             return []
-        return [{**hit["entity"], "score": hit["distance"]} for hit in results[0]]
+        # Normalize RRF scores to [0, 1].
+        # Theoretical max = num_retrievers / (k + 1), when a result ranks #1 in every retriever.
+        max_rrf = len(reqs) / (rrf_k + 1)
+        return [{**hit["entity"], "score": hit["distance"] / max_rrf} for hit in results[0]]
 
     _QUERY_FIELDS: ClassVar[list[str]] = [
         "content",


### PR DESCRIPTION
## Summary

RRF (Reciprocal Rank Fusion) hybrid search scores were returned as raw values in the ~0.01–0.03 range, which is unintuitive for both users and LLM agents trying to judge result relevance.

This PR normalizes scores by dividing by the theoretical maximum `num_retrievers / (k + 1)`, mapping them to a [0, 1] range where:
- **1.0** = ranked #1 in all retrievers (dense + BM25)
- **0.5** = ranked #1 in one retriever only
- Values between reflect relative ranking quality

### Before / After

| Result | Before | After |
|--------|--------|-------|
| Top hit (both retrievers) | 0.0325 | 0.99 |
| Single-retriever hit | 0.0164 | 0.50 |

No behavioral change to ranking order — only the score representation is affected.

## Test plan

- [x] `pytest tests/test_store.py` — all 8 tests pass
- [x] Manual `memsearch search` confirms normalized scores