### PR TITLE
feat: add [llm] + [prompts] config, unify plugin prompt templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ When modifying hooks/skills, keep in mind:
 - **Markdown is the source of truth.** Milvus is a derived index, rebuildable anytime from `.md` files.
 - **Composite chunk ID as PK.** `hash(source:startLine:endLine:contentHash:model)` — enables natural dedup without a separate cache.
 - **ONNX bge-m3 as plugin default.** The Claude Code plugin hooks default to `onnx` provider (bge-m3, CPU, no API key). The Python API still defaults to `openai`.
-- **Hybrid search by default.** Every collection has both dense vector and BM25 sparse fields. Search uses RRF to combine them.
+- **Hybrid search by default.** Every collection has both dense vector and BM25 sparse fields. Search uses RRF to combine them. RRF scores are normalized to `[0, 1]` (theoretical max = `num_retrievers / (k + 1)`).
+- **`[llm]` + `[prompts]` config.** New config sections for LLM provider selection and custom prompt templates. `[compact]` is deprecated but still works (fallback: `[llm]` > `[compact]` > defaults). Plugins read `prompts.summarize` for custom session summarization prompts. **Migration plan:** `[compact]` will be removed in the next major version (1.0). During the transition, `resolve_config()` emits a `DeprecationWarning` when user config files contain `[compact]`. The compact CLI command resolves LLM settings as `cfg.llm.* or cfg.compact.*`.
+- **Shared prompt template.** All four plugins share a single `summarize.txt` template (maintained in `plugins/_shared/prompts/`, synced via `scripts/sync-prompts.sh`). Template uses `{{AGENT_NAME}}` placeholder.
 - **Remote Milvus `query()` requires a filter.** Use `chunk_hash != ""` as a "match all" filter when no filter is provided (Milvus Lite doesn't enforce this, but Milvus Server does).
 
 ## Versioning & Release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,10 +282,18 @@ collection = "memsearch_chunks"
 provider = "openai"
 model = ""                           # empty = provider default
 
-[compact]
+[compact]                              # deprecated — use [llm] + [prompts]
 llm_provider = "openai"
-llm_model = ""                       # empty = provider default
-prompt_file = ""                     # custom prompt template path
+llm_model = ""
+prompt_file = ""
+
+[llm]                                  # LLM for compact & plugin summarization
+provider = ""                          # empty = plugin decides
+model = ""
+
+[prompts]
+compact = ""                           # custom compact prompt file
+summarize = ""                         # custom summarize prompt file
 
 [chunking]
 max_chunk_size = 1500

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,6 +173,14 @@ debounce_ms = 1500
 llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
+
+[llm]
+provider = ""
+model = ""
+
+[prompts]
+compact = ""
+summarize = ""
 ```
 
 ```bash
@@ -201,9 +209,15 @@ provider = "openai"
 | `chunking.max_chunk_size` | int | `1500` | Maximum chunk size in characters |
 | `chunking.overlap_lines` | int | `2` | Number of overlapping lines between adjacent chunks |
 | `watch.debounce_ms` | int | `1500` | File watcher debounce delay in milliseconds |
-| `compact.llm_provider` | string | `openai` | LLM provider for compact summarization |
-| `compact.llm_model` | string | `""` | Override LLM model (empty = provider default) |
-| `compact.prompt_file` | string | `""` | Path to a custom prompt template file |
+| `compact.llm_provider` | string | `openai` | *(deprecated)* LLM provider for compact — use `llm.provider` instead |
+| `compact.llm_model` | string | `""` | *(deprecated)* LLM model — use `llm.model` instead |
+| `compact.prompt_file` | string | `""` | *(deprecated)* Prompt file — use `prompts.compact` instead |
+| `llm.provider` | string | `""` | LLM provider (empty = plugin decides / compact defaults to openai) |
+| `llm.model` | string | `""` | LLM model override |
+| `llm.base_url` | string | `""` | OpenAI-compatible API base URL |
+| `llm.api_key` | string | `""` | API key (supports `env:VAR_NAME` syntax) |
+| `prompts.compact` | string | `""` | Custom prompt file for `memsearch compact` |
+| `prompts.summarize` | string | `""` | Custom prompt file for plugin session summarization |
 
 ---
 
@@ -297,13 +311,13 @@ Basic search:
 ```bash
 $ memsearch search "how to configure Redis caching"
 
---- Result 1 (score: 0.0328) ---
+--- Result 1 (score: 0.9919) ---
 Source: /home/user/docs/2026-01-15.md
 Heading: Redis Configuration
 Set REDIS_URL in .env to point to your Redis instance.
 Use `cache.set(key, value, ttl=300)` for 5-minute expiry...
 
---- Result 2 (score: 0.0326) ---
+--- Result 2 (score: 0.4919) ---
 Source: /home/user/docs/architecture.md
 Heading: Caching Layer
 We use Redis as the primary caching backend...
@@ -328,7 +342,7 @@ $ memsearch search "error handling" --json-output
     "heading_level": 2,
     "start_line": 45,
     "end_line": 62,
-    "score": 0.0330
+    "score": 0.9919
   }
 ]
 ```
@@ -342,7 +356,7 @@ $ memsearch search "database migrations" --provider google
 ### Notes
 
 - **Provider must match.** The search embedding provider and model must match whatever was used during indexing. Mixing providers will return poor results because the vector spaces are incompatible.
-- **Hybrid search.** Results are ranked using Reciprocal Rank Fusion (RRF) across both dense (cosine) and sparse (BM25) retrieval, giving you the best of semantic and keyword matching.
+- **Hybrid search.** Results are ranked using Reciprocal Rank Fusion (RRF) across both dense (cosine) and sparse (BM25) retrieval, giving you the best of semantic and keyword matching. Scores are normalized to `[0, 1]` where 1.0 means ranked #1 in all retrievers.
 - **Content is truncated.** In the default text output, each result's content is truncated to 500 characters. Use `--json-output` to get the full content.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,13 +149,13 @@ Indexed 8 chunks.
 
 ```bash
 $ memsearch search "what caching solution are we using?"
---- Result 1 (score: 0.0332) ---
+--- Result 1 (score: 0.9919) ---
 Source: MEMORY.md
 Heading: Architecture Decisions
 - ADR-003: Redis 7 for caching and sessions
 
 $ memsearch search "what did Bob work on recently?" --top-k 3
---- Result 1 (score: 0.0328) ---
+--- Result 1 (score: 0.9838) ---
 Source: memory/2026-02-10.md
 Heading: Standup Notes
 - Bob fixed the N+1 query in the order service — response time dropped from 800ms to 120ms
@@ -560,10 +560,18 @@ overlap_lines = 2
 [watch]
 debounce_ms = 1500
 
-[compact]
+[compact]                    # deprecated — use [llm] + [prompts] instead
 llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
+
+[llm]                        # LLM settings for compact & plugin summarization
+provider = ""                # empty = plugin decides; "openai"/"anthropic"/"gemini"
+model = ""
+
+[prompts]                    # custom prompt template files
+compact = ""                 # for memsearch compact
+summarize = ""               # for plugin session summarization
 ```
 
 ### Environment variable references

--- a/plugins/_shared/prompts/summarize.txt
+++ b/plugins/_shared/prompts/summarize.txt
@@ -1,0 +1,14 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
+
+Rules:
+- Write in third person: 'User asked...', '{{AGENT_NAME}} read file X', '{{AGENT_NAME}} ran command Y'
+- First bullet: what the user asked or wanted (one sentence)
+- Remaining bullets: what was done — tools called, files read/edited, commands run, key findings
+- Be specific: mention file names, function names, tool names, and concrete outcomes
+- Do NOT answer the human's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points
+- Write in the same language as the human's message in the transcript

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -82,38 +82,30 @@ with open(sys.argv[1]) as f:
 print(uuid)
 " "$TRANSCRIPT_PATH" 2>/dev/null || true)
 
-# Use claude -p to summarize the last turn into structured bullet points.
-# --model haiku: cheap and fast model for summarization
-# --no-session-persistence: don't save this throwaway session to disk
-# --no-chrome: skip browser integration
-# --system-prompt: separate role instructions from data (transcript via stdin)
+# Load summarization prompt: user custom (via config) > plugin built-in template
+AGENT_NAME="Claude Code"
+PROMPT_FILE=""
+if [ -n "$MEMSEARCH_CMD" ]; then
+  PROMPT_FILE=$($MEMSEARCH_CMD config get prompts.summarize 2>/dev/null || true)
+fi
+if [ -n "$PROMPT_FILE" ] && [ -f "$PROMPT_FILE" ]; then
+  SYSTEM_PROMPT=$(sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "$PROMPT_FILE")
+elif [ -f "${CLAUDE_PLUGIN_ROOT}/prompts/summarize.txt" ]; then
+  SYSTEM_PROMPT=$(sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "${CLAUDE_PLUGIN_ROOT}/prompts/summarize.txt")
+else
+  SYSTEM_PROMPT="You are a third-person note-taker. Summarize the transcript as 2-6 bullet points. Write in third person. Output ONLY bullet points."
+fi
+
+# Summarize the last turn into structured bullet points.
+# Default: use claude -p (plugin's own agent). If [llm] is configured, still
+# use claude -p since it's the most reliable path for Claude Code plugin.
 SUMMARY=""
 if command -v claude &>/dev/null; then
   SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
     --model haiku \
     --no-session-persistence \
     --no-chrome \
-    --system-prompt "You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human (labeled [Human]) and Claude Code (labeled [Claude Code]). Tool calls are labeled [Tool Call] and their results [Tool RESULT] or [Tool ERROR].
-
-Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT Claude Code, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
-
-Output 2-6 bullet points, each starting with '- '. NOTHING else.
-
-Rules:
-- Write in third person: 'User asked...', 'Claude read file X', 'Claude ran command Y'
-- First bullet: what the user asked or wanted (one sentence)
-- Remaining bullets: what Claude did — tools called, files read/edited, commands run, key findings
-- Be specific: mention file names, function names, tool names, and concrete outcomes
-- Do NOT answer the human's question yourself — just note what was discussed
-- Do NOT add any text before or after the bullet points
-- Write in the same language as the human's message (the [Human] line) in the transcript
-
-The transcript uses these labels:
-- [Human]: what the user said
-- [Claude Code]: what Claude Code said
-- [Claude Code calls tool]: a tool Claude Code invoked
-- [Tool output]: the result returned by a tool
-- [Tool error]: an error returned by a tool" \
+    --system-prompt "$SYSTEM_PROMPT" \
     2>/dev/null || true)
 fi
 

--- a/plugins/claude-code/prompts/summarize.txt
+++ b/plugins/claude-code/prompts/summarize.txt
@@ -1,0 +1,14 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
+
+Rules:
+- Write in third person: 'User asked...', '{{AGENT_NAME}} read file X', '{{AGENT_NAME}} ran command Y'
+- First bullet: what the user asked or wanted (one sentence)
+- Remaining bullets: what was done — tools called, files read/edited, commands run, key findings
+- Be specific: mention file names, function names, tool names, and concrete outcomes
+- Do NOT answer the human's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points
+- Write in the same language as the human's message in the transcript

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -79,23 +79,25 @@ run_worker() {
 
   ensure_memory_dir
 
+  # Load summarization prompt: user custom (via config) > plugin built-in template
+  local AGENT_NAME="Codex"
+  local PROMPT_FILE=""
+  if [ -n "$MEMSEARCH_CMD" ]; then
+    PROMPT_FILE=$($MEMSEARCH_CMD config get prompts.summarize 2>/dev/null || true)
+  fi
+  local SYSTEM_PROMPT=""
+  if [ -n "$PROMPT_FILE" ] && [ -f "$PROMPT_FILE" ]; then
+    SYSTEM_PROMPT=$(sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "$PROMPT_FILE")
+  elif [ -f "$SCRIPT_DIR/../prompts/summarize.txt" ]; then
+    SYSTEM_PROMPT=$(sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "$SCRIPT_DIR/../prompts/summarize.txt")
+  else
+    SYSTEM_PROMPT="You are a third-person note-taker. Summarize the transcript as 2-6 bullet points. Write in third person. Output ONLY bullet points."
+  fi
+
   local SUMMARY=""
   if command -v codex &>/dev/null; then
     local LLM_PROMPT
-    LLM_PROMPT="You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and Codex CLI. Tool calls are labeled [Codex calls tool] and their results [Tool output].
-
-Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT Codex, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
-
-Output 2-6 bullet points, each starting with '- '. NOTHING else.
-
-Rules:
-- Write in third person: 'User asked...', 'Codex read file X', 'Codex ran command Y'
-- First bullet: what the user asked or wanted (one sentence)
-- Remaining bullets: what Codex did — tools called, files read/edited, commands run, key findings
-- Be specific: mention file names, function names, tool names, and concrete outcomes
-- Do NOT answer the human's question yourself — just note what was discussed
-- Do NOT add any text before or after the bullet points
-- Write in the same language as the human's message (the [Human] line) in the transcript
+    LLM_PROMPT="${SYSTEM_PROMPT}
 
 Here is the transcript:
 

--- a/plugins/codex/prompts/summarize.txt
+++ b/plugins/codex/prompts/summarize.txt
@@ -1,0 +1,14 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
+
+Rules:
+- Write in third person: 'User asked...', '{{AGENT_NAME}} read file X', '{{AGENT_NAME}} ran command Y'
+- First bullet: what the user asked or wanted (one sentence)
+- Remaining bullets: what was done — tools called, files read/edited, commands run, key findings
+- Be specific: mention file names, function names, tool names, and concrete outcomes
+- Do NOT answer the human's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points
+- Write in the same language as the human's message in the transcript

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -517,21 +517,30 @@ export default {
        * Tries: openclaw agent → raw text fallback.
        */
       async function summarizeWithLLM(turnText: string): Promise<string> {
-        const systemPrompt =
-          "You are a third-person note-taker. You will receive a transcript of ONE conversation turn " +
-          "between a human and an AI assistant (OpenClaw). " +
-          "Your job is to record what happened as factual third-person notes. " +
-          "You are an EXTERNAL OBSERVER — you are NOT the assistant. " +
-          "Do NOT answer the human's question, do NOT give suggestions. ONLY record what occurred.\n\n" +
-          "Output 2-6 bullet points, each starting with '- '. NOTHING else.\n\n" +
-          "Rules:\n" +
-          "- Write in third person: 'User asked...', 'OpenClaw replied...', 'OpenClaw ran command Y'\n" +
-          "- First bullet: what the user asked or wanted (one sentence)\n" +
-          "- Remaining bullets: what was done — tools called, files read/edited, key findings\n" +
-          "- Be specific: mention file names, function names, tool names, and concrete outcomes\n" +
-          "- Do NOT answer the human's question yourself — just note what was discussed\n" +
-          "- Do NOT add any text before or after the bullet points\n" +
-          "- Write in the same language as the human's message";
+        // Load summarization prompt: user custom (via config) > plugin built-in template
+        const agentName = "OpenClaw";
+        let systemPrompt = "";
+
+        // Try reading user-custom prompt from config
+        let customPromptFile = "";
+        try {
+          const r = await runCmd([memsearchCmd, "config", "get", "prompts.summarize"], { timeoutMs: 5000 });
+          customPromptFile = r.stdout?.trim() || "";
+        } catch { /* ignore */ }
+
+        if (customPromptFile && existsSync(customPromptFile)) {
+          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+        } else {
+          // Fall back to plugin built-in template
+          const builtinPath = join(PLUGIN_DIR, "prompts", "summarize.txt");
+          if (existsSync(builtinPath)) {
+            systemPrompt = readFileSync(builtinPath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+          } else {
+            systemPrompt =
+              "You are a third-person note-taker. Summarize the transcript as 2-6 bullet points. " +
+              "Write in third person. Output ONLY bullet points.";
+          }
+        }
 
         // 1. Try openclaw agent (uses user's default model)
         try {

--- a/plugins/openclaw/prompts/summarize.txt
+++ b/plugins/openclaw/prompts/summarize.txt
@@ -1,0 +1,14 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
+
+Rules:
+- Write in third person: 'User asked...', '{{AGENT_NAME}} read file X', '{{AGENT_NAME}} ran command Y'
+- First bullet: what the user asked or wanted (one sentence)
+- Remaining bullets: what was done — tools called, files read/edited, commands run, key findings
+- Be specific: mention file names, function names, tool names, and concrete outcomes
+- Do NOT answer the human's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points
+- Write in the same language as the human's message in the transcript

--- a/plugins/opencode/prompts/summarize.txt
+++ b/plugins/opencode/prompts/summarize.txt
@@ -1,0 +1,14 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between a human and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer the human's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-6 bullet points, each starting with '- '. NOTHING else.
+
+Rules:
+- Write in third person: 'User asked...', '{{AGENT_NAME}} read file X', '{{AGENT_NAME}} ran command Y'
+- First bullet: what the user asked or wanted (one sentence)
+- Remaining bullets: what was done — tools called, files read/edited, commands run, key findings
+- Be specific: mention file names, function names, tool names, and concrete outcomes
+- Do NOT answer the human's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points
+- Write in the same language as the human's message in the transcript

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -53,20 +53,41 @@ def ensure_isolated_config():
     return os.path.dirname(isolated)  # /tmp/opencode-memsearch-summarize
 
 
-def summarize_with_llm(turn_text, small_model):
+def _load_summarize_prompt(agent_name, memsearch_cmd=None):
+    """Load summarization prompt: user custom > plugin built-in > inline fallback."""
+    # Try user-custom prompt via config
+    if memsearch_cmd:
+        try:
+            result = subprocess.run(
+                memsearch_cmd.split() + ["config", "get", "prompts.summarize"],
+                capture_output=True, text=True, timeout=5,
+            )
+            custom_path = result.stdout.strip()
+            if custom_path and os.path.isfile(custom_path):
+                template = Path(custom_path).read_text(encoding="utf-8")
+                return template.replace("{{AGENT_NAME}}", agent_name)
+        except Exception:
+            pass
+
+    # Plugin built-in template
+    builtin = Path(__file__).resolve().parent.parent / "prompts" / "summarize.txt"
+    if builtin.is_file():
+        template = builtin.read_text(encoding="utf-8")
+        return template.replace("{{AGENT_NAME}}", agent_name)
+
+    # Inline fallback
+    return (
+        "You are a third-person note-taker. Summarize the transcript as "
+        "2-6 bullet points. Write in third person. Output ONLY bullet points."
+    )
+
+
+def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
     """Summarize using opencode run in isolated env (no plugins -> no recursion)."""
-    # Keep the instruction short and put it AFTER the transcript to avoid
-    # the LLM treating the instruction itself as the conversation content.
-    # Clear delimiters (===) separate the transcript from the task.
+    system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
     full_prompt = (
-        f"===TRANSCRIPT START===\n"
-        f"{turn_text}\n"
-        f"===TRANSCRIPT END===\n\n"
-        f"Summarize the transcript above as 2-6 third-person bullet points (each starting with '- '). "
-        f"Write 'User asked/did...' and 'OpenCode replied/did...'. "
-        f"Be specific (file names, tools, outcomes). "
-        f"Same language as the human. "
-        f"Output ONLY bullet points, nothing else."
+        f"{system_prompt}\n\n"
+        f"Transcript:\n{turn_text}"
     )
     isolated_dir = ensure_isolated_config()
 
@@ -279,7 +300,7 @@ def main():
             for session_id, turn_text, msg_time in new_turns:
                 if turn_text and len(turn_text) > 10:
                     # Summarize with LLM, fallback to raw text
-                    summary = summarize_with_llm(turn_text, small_model)
+                    summary = summarize_with_llm(turn_text, small_model, args.memsearch_cmd)
                     write_capture(memory_dir, summary if summary else turn_text, session_id, db_path)
                     if msg_time > last_msg_time:
                         last_msg_time = msg_time

--- a/scripts/sync-prompts.sh
+++ b/scripts/sync-prompts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Sync shared prompt templates to all plugin directories.
+# Run this after editing plugins/_shared/prompts/*.txt.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHARED_DIR="$REPO_ROOT/plugins/_shared/prompts"
+
+PLUGINS=(claude-code codex openclaw opencode)
+
+for plugin in "${PLUGINS[@]}"; do
+    dest="$REPO_ROOT/plugins/$plugin/prompts"
+    mkdir -p "$dest"
+    cp "$SHARED_DIR"/*.txt "$dest/"
+    echo "  synced → plugins/$plugin/prompts/"
+done
+
+echo "Done. All plugin prompts are in sync."

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -558,8 +558,17 @@ def compact(
     )
 
     prompt_template = prompt
-    if cfg.compact.prompt_file and not prompt_template:
+    # Resolve prompt: CLI --prompt > prompts.compact > compact.prompt_file > built-in
+    if not prompt_template and cfg.prompts.compact:
+        prompt_template = Path(cfg.prompts.compact).expanduser().read_text(encoding="utf-8")
+    if not prompt_template and cfg.compact.prompt_file:
         prompt_template = Path(cfg.compact.prompt_file).read_text(encoding="utf-8")
+
+    # Resolve LLM settings: [llm] > [compact] (deprecated) > defaults
+    eff_provider = cfg.llm.provider or cfg.compact.llm_provider
+    eff_model = cfg.llm.model or cfg.compact.llm_model or None
+    eff_base_url = cfg.llm.base_url or cfg.compact.base_url or None
+    eff_api_key = cfg.llm.api_key or cfg.compact.api_key or None
 
     normalized_source = _normalize_compact_source(source)
 
@@ -569,12 +578,12 @@ def compact(
         summary = _run(
             ms.compact(
                 source=normalized_source,
-                llm_provider=cfg.compact.llm_provider,
-                llm_model=cfg.compact.llm_model or None,
+                llm_provider=eff_provider,
+                llm_model=eff_model,
                 prompt_template=prompt_template,
                 output_dir=output_dir,
-                llm_base_url=cfg.compact.base_url or None,
-                llm_api_key=cfg.compact.api_key or None,
+                llm_base_url=eff_base_url,
+                llm_api_key=eff_api_key,
             )
         )
         if summary:
@@ -762,27 +771,45 @@ def config_init(project: bool) -> None:
         type=int,
     )
 
-    # Compact
-    click.echo("\n── Compact ──")
-    _compact_defaults = {
+    # LLM
+    click.echo("\n── LLM (for compact & plugin summarization) ──")
+    click.echo("  Leave empty to let plugins use their own agent model.")
+    _llm_defaults = {
         "openai": "gpt-4o-mini",
-        "anthropic": "claude-sonnet-4-5-20250929",
+        "anthropic": "claude-haiku-4-5-20251001",
         "gemini": "gemini-2.0-flash",
     }
-    result["compact"] = {}
-    result["compact"]["llm_provider"] = click.prompt(
-        "  LLM provider (openai/anthropic/gemini)",
-        default=current.compact.llm_provider,
+    result["llm"] = {}
+    result["llm"]["provider"] = click.prompt(
+        "  Provider (empty/openai/anthropic/gemini)",
+        default=current.llm.provider,
     )
-    _compact_provider = result["compact"]["llm_provider"]
-    _compact_model_default = current.compact.llm_model or _compact_defaults.get(_compact_provider, "")
-    result["compact"]["llm_model"] = click.prompt(
-        "  LLM model",
-        default=_compact_model_default,
+    _llm_provider = result["llm"]["provider"]
+    _llm_model_default = current.llm.model or _llm_defaults.get(_llm_provider, "")
+    result["llm"]["model"] = click.prompt(
+        "  Model",
+        default=_llm_model_default,
     )
-    result["compact"]["prompt_file"] = click.prompt(
-        "  Prompt file path (empty for built-in)",
-        default=current.compact.prompt_file,
+    result["llm"]["base_url"] = click.prompt(
+        "  Base URL (empty for default, or env:VAR_NAME)",
+        default=current.llm.base_url,
+    )
+    result["llm"]["api_key"] = click.prompt(
+        "  API key (empty for env default, or env:VAR_NAME)",
+        default=current.llm.api_key,
+    )
+
+    # Prompts
+    click.echo("\n── Prompts ──")
+    click.echo("  Leave empty to use built-in defaults.")
+    result["prompts"] = {}
+    result["prompts"]["compact"] = click.prompt(
+        "  Compact prompt file",
+        default=current.prompts.compact,
+    )
+    result["prompts"]["summarize"] = click.prompt(
+        "  Summarize prompt file (for plugin session notes)",
+        default=current.prompts.summarize,
     )
 
     save_config(result, target)

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -71,6 +71,32 @@ class RerankerConfig:
 
 
 @dataclass
+class LLMConfig:
+    """LLM settings for plugin summarization and compact.
+
+    All fields default to empty.  When empty, plugin hooks fall back to
+    their own agent model; the ``compact`` CLI falls back to
+    ``[compact].llm_provider`` (deprecated) or ``"openai"``.
+    """
+
+    provider: str = ""  # empty = plugin decides; "openai"/"anthropic"/"gemini" for explicit
+    model: str = ""
+    base_url: str = ""  # OpenAI-compatible endpoint URL
+    api_key: str = ""  # API key (supports "env:VAR_NAME" syntax)
+
+
+@dataclass
+class PromptsConfig:
+    """Paths to custom prompt template files.
+
+    Empty string means "use built-in default".
+    """
+
+    compact: str = ""  # custom prompt file for memsearch compact
+    summarize: str = ""  # custom prompt file for plugin session summarization
+
+
+@dataclass
 class MemSearchConfig:
     milvus: MilvusConfig = field(default_factory=MilvusConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
@@ -78,6 +104,8 @@ class MemSearchConfig:
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+    prompts: PromptsConfig = field(default_factory=PromptsConfig)
 
 
 # -- Section name → dataclass mapping for typed reconstruction --
@@ -88,6 +116,8 @@ _SECTION_CLASSES: dict[str, type] = {
     "chunking": ChunkingConfig,
     "watch": WatchConfig,
     "reranker": RerankerConfig,
+    "llm": LLMConfig,
+    "prompts": PromptsConfig,
 }
 
 
@@ -177,6 +207,11 @@ def _dict_to_config(d: dict[str, Any]) -> MemSearchConfig:
     return MemSearchConfig(**kwargs)
 
 
+def _has_legacy_compact(global_cfg: dict[str, Any], project_cfg: dict[str, Any]) -> bool:
+    """Check if the user's actual config files contain a [compact] section."""
+    return "compact" in global_cfg or "compact" in project_cfg
+
+
 def resolve_config(cli_overrides: dict[str, Any] | None = None) -> MemSearchConfig:
     """Layer all config sources and return the final MemSearchConfig.
 
@@ -184,12 +219,26 @@ def resolve_config(cli_overrides: dict[str, Any] | None = None) -> MemSearchConf
       defaults → global TOML → project TOML → cli_overrides
     """
     result = _default_dict()
-    result = deep_merge(result, load_config_file(GLOBAL_CONFIG_PATH))
-    result = deep_merge(result, load_config_file(PROJECT_CONFIG_PATH))
+    global_cfg = load_config_file(GLOBAL_CONFIG_PATH)
+    project_cfg = load_config_file(PROJECT_CONFIG_PATH)
+    result = deep_merge(result, global_cfg)
+    result = deep_merge(result, project_cfg)
     if cli_overrides:
         result = deep_merge(result, cli_overrides)
     result = _resolve_env_refs_in_dict(result)
     cfg = _dict_to_config(result)
+
+    # Warn about deprecated [compact] section in user config files
+    if _has_legacy_compact(global_cfg, project_cfg):
+        import warnings
+
+        warnings.warn(
+            "[compact] config section is deprecated. "
+            "Move LLM settings to [llm] and prompt settings to [prompts]. "
+            "See https://memsearch.dev/configuration for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # Fill in the provider's default model when model is empty
     if not cfg.embedding.model:


### PR DESCRIPTION
## Summary

- Add `[llm]` config section for centralized LLM provider/model settings. Empty by default so plugins continue using their own agent model (haiku, codex-mini, etc). When configured, plugins and compact CLI both use it.
- Add `[prompts]` config section with `compact` and `summarize` fields pointing to custom prompt template files. Empty = use built-in defaults.
- Deprecate `[compact]` section with `DeprecationWarning` (will be removed in 1.0). Compact CLI resolves settings as `[llm]` > `[compact]` > defaults for full backward compatibility.
- Unify all four plugin stop hooks (Claude Code, Codex, OpenClaw, OpenCode) to use a shared `summarize.txt` template with `{{AGENT_NAME}}` placeholder, with three-layer fallback: user custom file → plugin built-in template → inline fallback.
- Remove unnecessary transcript label hints from Claude Code stop hook.
- Fix OpenCode prompt/transcript ordering to match other plugins (prompt first, transcript after).
- Add `scripts/sync-prompts.sh` for keeping plugin prompt templates in sync.
- Update docs (cli.md, architecture.md, getting-started.md) with new config keys and normalized score examples.

## Backward compatibility

| Scenario | Behavior |
|----------|----------|
| No config (most users) | Zero change — plugins use own agent, built-in prompts |
| Existing `[compact]` config | Still works, deprecation warning on stderr |
| New CLI + old plugin | Old plugin ignores `[llm]`/`[prompts]`, works as before |
| Old CLI + new plugin | Plugin falls back to built-in template (config get fails gracefully) |

## Test plan

- [x] 120 unit tests pass
- [x] E2E: config get/set for `llm.*` and `prompts.*`
- [x] E2E: deprecation warning triggers only with `[compact]` in user config
- [x] E2E: compact fallback chain (5 config combinations)
- [x] E2E: RRF score normalization (scores in [0, 1])
- [x] E2E: Claude Code plugin default + custom prompt (via `--plugin-dir`)
- [x] E2E: Old CLI (0.3.0) + new plugin fallback
- [x] E2E: OpenClaw plugin on EC2
- [x] E2E: OpenCode prompt loading (3-layer fallback)
- [x] Codex hooks verified (API model access limited by account type)