### PR TITLE
chore: bump memsearch 0.4.0, claude-code 0.4.0, openclaw 0.3.0, opencode 0.2.0

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "openclaw": {

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",
@@ -11,6 +11,7 @@
     "index.ts",
     "scripts/",
     "skills/",
+    "prompts/",
     "README.md"
   ],
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.3.1"
+version = "0.4.0"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the unified prompt templates and `[llm]`+`[prompts]` config release (#497).

| Component | Old | New |
|-----------|-----|-----|
| memsearch (PyPI) | 0.3.1 | 0.4.0 |
| Claude Code plugin | 0.3.6 | 0.4.0 |
| OpenClaw plugin | 0.2.1 | 0.3.0 |
| OpenCode plugin | 0.1.2 | 0.2.0 |

Also adds `prompts/` to OpenCode's npm `files` list so the template is included in the package.