### PR TITLE
fix(docs): fix mermaid state diagram note rendering

### DIFF
--- a/docs/platforms/codex/how-it-works.md
+++ b/docs/platforms/codex/how-it-works.md
@@ -47,7 +47,10 @@ stateDiagram-v2
     StartWatch --> Prompting
     OneTimeIndex --> Prompting
 
-    note right of Prompting: No SessionEnd hook\nOrphans cleaned at next SessionStart
+    note right of Prompting
+      No SessionEnd hook.
+      Orphans cleaned at next SessionStart.
+    end note
 ```
 
 ---


### PR DESCRIPTION
The `\n` escape in the Codex how-it-works state diagram note was rendered as literal text. Replace with proper multi-line note block syntax.