### PR TITLE
feat(opencode): add turn-level transcript recall

### DIFF
--- a/docs/platforms/opencode/how-it-works.md
+++ b/docs/platforms/opencode/how-it-works.md
@@ -53,7 +53,7 @@ OpenCode stores all conversations in a SQLite database (`~/.local/share/opencode
 
 - **No hook limitations** -- capture works regardless of which hooks OpenCode exposes
 - **Reliable detection** -- new turns are detected by tracking a per-session completed-turn cursor, not by fragile event timing
-- **Crash resilience** -- state is persisted to `.memsearch/opencode-turns.db`, so daemon restarts don't re-capture old turns
+- **Crash resilience** -- derived state is persisted to `.memsearch/opencode-turns.db`, so daemon restarts can replay safely without duplicating captured markdown
 
 ### Daemon Flow
 
@@ -86,8 +86,13 @@ Step by step:
 3. **Extract text** -- reads message `parts` (text content, tool calls with names/paths) into a readable format
 4. **Summarize** -- calls `opencode run` with the turn text and a third-person summarization prompt
 5. **Write to memory** -- appends the summary to `.memsearch/memory/YYYY-MM-DD.md` with `<!-- session:ID turn:ID db:PATH -->` anchors
-6. **Persist state** -- writes the completed-turn cursor to `.memsearch/opencode-turns.db` so restarts don't re-capture
+6. **Persist state** -- writes the completed-turn cursor and derived turn ordering to `.memsearch/opencode-turns.db`
 7. **Re-index** -- triggers `memsearch index` in the background
+
+OpenCode SQLite remains the source of truth for original transcript reads. The
+sidecar database is derived capture state only. If markdown append succeeds and
+the sidecar write fails later, the next daemon replay uses the existing
+session+turn anchor to avoid duplicate memory entries and repair the sidecar.
 
 ### LLM Summarization with Isolation
 
@@ -180,7 +185,7 @@ your-project/.memsearch/memory/
 - Added structured error logging with request ID correlation
 ```
 
-The `<!-- session:... turn:... db:~/.local/share/opencode/opencode.db -->` anchors are used by the `memory_transcript` tool to query the original conversation from OpenCode's SQLite database.
+The `<!-- session:... turn:... db:~/.local/share/opencode/opencode.db -->` anchors are used by the `memory_transcript` tool to query the original conversation from OpenCode's SQLite database. The sidecar database is not required for transcript reads.
 
 ---
 

--- a/docs/platforms/opencode/how-it-works.md
+++ b/docs/platforms/opencode/how-it-works.md
@@ -52,8 +52,8 @@ Unlike Claude Code and Codex (which use hook-based capture), OpenCode uses a **b
 OpenCode stores all conversations in a SQLite database (`~/.local/share/opencode/opencode.db`). The daemon polls this database directly, which means:
 
 - **No hook limitations** -- capture works regardless of which hooks OpenCode exposes
-- **Reliable detection** -- new turns are detected by tracking `last_msg_time`, not by fragile event timing
-- **Crash resilience** -- state is persisted to `.memsearch/.last_msg_time`, so daemon restarts don't re-capture old turns
+- **Reliable detection** -- new turns are detected by tracking a per-session completed-turn cursor, not by fragile event timing
+- **Crash resilience** -- state is persisted to `.memsearch/opencode-turns.db`, so daemon restarts don't re-capture old turns
 
 ### Daemon Flow
 
@@ -67,13 +67,13 @@ sequenceDiagram
 
     loop Every 10 seconds
         Daemon->>DB: Query sessions for project_dir
-        DB->>Daemon: Messages newer than last_msg_time
+        DB->>Daemon: Messages newer than the last completed turn cursor
         alt New turns found
-            Daemon->>Daemon: Group into user+assistant pairs
+            Daemon->>Daemon: Group into turns via user message + assistant descendants
             Daemon->>LLM: Summarize turn (isolated config)
             LLM->>Daemon: 2-6 bullet points
             Daemon->>File: Append with session anchor
-            Daemon->>Daemon: Update last_msg_time (persist to disk)
+            Daemon->>Daemon: Update turn cursor (persist to sidecar DB)
             Daemon->>Index: memsearch index (background)
         end
     end
@@ -81,12 +81,12 @@ sequenceDiagram
 
 Step by step:
 
-1. **Poll SQLite** -- queries the `session` and `message` tables for the current project directory, looking for messages newer than `last_msg_time`
-2. **Group into turns** -- pairs consecutive `user` + `assistant` messages into turns
+1. **Poll SQLite** -- queries the `session` and `message` tables for the current project directory, looking for messages newer than the last completed turn cursor
+2. **Group into turns** -- groups each `user` message with its assistant/tool descendants until the next `user` message
 3. **Extract text** -- reads message `parts` (text content, tool calls with names/paths) into a readable format
 4. **Summarize** -- calls `opencode run` with the turn text and a third-person summarization prompt
-5. **Write to memory** -- appends the summary to `.memsearch/memory/YYYY-MM-DD.md` with `<!-- session:ID db:PATH -->` anchors
-6. **Persist state** -- writes `last_msg_time` to `.memsearch/.last_msg_time` so restarts don't re-capture
+5. **Write to memory** -- appends the summary to `.memsearch/memory/YYYY-MM-DD.md` with `<!-- session:ID turn:ID db:PATH -->` anchors
+6. **Persist state** -- writes the completed-turn cursor to `.memsearch/opencode-turns.db` so restarts don't re-capture
 7. **Re-index** -- triggers `memsearch index` in the background
 
 ### LLM Summarization with Isolation
@@ -97,8 +97,8 @@ The daemon summarizes turns via `opencode run` -- but it must avoid triggering t
 result = subprocess.run(
     ["opencode", "run", "-m", small_model, prompt],
     env={
-        "XDG_CONFIG_HOME": "/tmp/opencode-memsearch-summarize",
-        "XDG_DATA_HOME": "/tmp/opencode-memsearch-summarize/data",
+        "XDG_CONFIG_HOME": "~/.codex/tmp/opencode-memsearch-summarize",
+        "XDG_DATA_HOME": "~/.codex/tmp/opencode-memsearch-summarize/data",
         "MEMSEARCH_NO_WATCH": "1",
     },
 )
@@ -157,14 +157,14 @@ your-project/.memsearch/memory/
 ## Session 14:30
 
 ### 14:30
-<!-- session:ses_abc123 db:~/.local/share/opencode/opencode.db -->
+<!-- session:ses_abc123 turn:msg_123abc db:~/.local/share/opencode/opencode.db -->
 - User asked about authentication flow in the Express API
 - OpenCode explained the OAuth2 implementation in auth.ts
 - OpenCode modified token refresh logic in refresh.ts to handle expired tokens
 - Added error handling for revoked refresh tokens
 
 ### 15:15
-<!-- session:ses_abc123 db:~/.local/share/opencode/opencode.db -->
+<!-- session:ses_abc123 turn:msg_456def db:~/.local/share/opencode/opencode.db -->
 - User reported 500 error on /api/users endpoint
 - OpenCode traced the issue to a missing null check in userController.ts
 - OpenCode added optional chaining and a 404 response for missing users
@@ -173,14 +173,14 @@ your-project/.memsearch/memory/
 ## Session 17:00
 
 ### 17:00
-<!-- session:ses_def456 db:~/.local/share/opencode/opencode.db -->
+<!-- session:ses_def456 turn:msg_789ghi db:~/.local/share/opencode/opencode.db -->
 - User asked to refactor the middleware chain for better error handling
 - OpenCode created a centralized error handler in middleware/errorHandler.ts
 - Removed try/catch blocks from individual route handlers
 - Added structured error logging with request ID correlation
 ```
 
-The `<!-- session:... db:~/.local/share/opencode/opencode.db -->` anchors are used by the `memory_transcript` tool to query the original conversation from OpenCode's SQLite database.
+The `<!-- session:... turn:... db:~/.local/share/opencode/opencode.db -->` anchors are used by the `memory_transcript` tool to query the original conversation from OpenCode's SQLite database.
 
 ---
 

--- a/docs/platforms/opencode/memory-tools.md
+++ b/docs/platforms/opencode/memory-tools.md
@@ -10,7 +10,7 @@ The plugin registers three tools via OpenCode's `tool()` API. All tools are avai
 |------|-----------|-------------|
 | `memory_search` | `query` (string), `top_k` (number, optional) | Semantic search over indexed memories via `memsearch search --json-output`. Returns top-K relevant chunks with scores, dates, and content snippets. Powered by Milvus hybrid search (BM25 + dense vectors + RRF reranking). |
 | `memory_get` | `chunk_hash` (string) | Expand a chunk to full markdown section via `memsearch expand`. Shows the complete section with surrounding context, session anchors, and source file metadata. |
-| `memory_transcript` | `session_id` (string), `turn_id` (string, optional), `context` (number, optional), `limit` (number, optional) | Read original conversation from OpenCode's SQLite database via `parse-transcript.py`. When a turn cursor is available, return that turn plus surrounding context. Otherwise return the latest turns. |
+| `memory_transcript` | `session_id` (string), `turn_id` (string, optional), `context` (number, optional), `limit` (number, optional) | Read original conversation from OpenCode's SQLite database via `parse-transcript.py`. When a turn cursor is available, return that turn plus surrounding context. Otherwise return the latest turns. The sidecar DB is not required for these reads. |
 
 ---
 
@@ -54,6 +54,10 @@ graph TD
 | **L1: Search** | `memory_search` | Top-K chunk snippets with relevance scores | Starting point -- find potentially relevant memories |
 | **L2: Expand** | `memory_get` | Full markdown section with session anchors | When a snippet looks relevant but needs more context |
 | **L3: Transcript** | `memory_transcript` | Original conversation from OpenCode SQLite | When you need the exact exchange -- what was tried, what failed |
+
+`memory_transcript` rebuilds turns from the raw OpenCode SQLite database on
+demand. `.memsearch/opencode-turns.db` only stores derived capture checkpoints
+and stable turn ordering for the daemon.
 
 ### Real-World Example
 

--- a/docs/platforms/opencode/memory-tools.md
+++ b/docs/platforms/opencode/memory-tools.md
@@ -10,7 +10,7 @@ The plugin registers three tools via OpenCode's `tool()` API. All tools are avai
 |------|-----------|-------------|
 | `memory_search` | `query` (string), `top_k` (number, optional) | Semantic search over indexed memories via `memsearch search --json-output`. Returns top-K relevant chunks with scores, dates, and content snippets. Powered by Milvus hybrid search (BM25 + dense vectors + RRF reranking). |
 | `memory_get` | `chunk_hash` (string) | Expand a chunk to full markdown section via `memsearch expand`. Shows the complete section with surrounding context, session anchors, and source file metadata. |
-| `memory_transcript` | `session_id` (string), `limit` (number, optional) | Read original conversation from OpenCode's SQLite database via `parse-transcript.py`. Returns formatted dialogue with `[Human]` and `[Assistant]` labels, including tool call details. |
+| `memory_transcript` | `session_id` (string), `turn_id` (string, optional), `context` (number, optional), `limit` (number, optional) | Read original conversation from OpenCode's SQLite database via `parse-transcript.py`. When a turn cursor is available, return that turn plus surrounding context. Otherwise return the latest turns. |
 
 ---
 
@@ -74,7 +74,7 @@ graph TD
 **L2 -- memory_get:** LLM calls `memory_get("a1b2c3...")`:
 ```markdown
 ### 15:45
-<!-- session:ses_xyz789 db:~/.local/share/opencode/opencode.db -->
+<!-- session:ses_xyz789 turn:msg_xyz789 db:~/.local/share/opencode/opencode.db -->
 - User reported Alembic migration failing on user_preferences table
 - OpenCode found a missing nullable=True on the email column
 - Fixed by adding server_default="" to the column definition

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -62,6 +62,7 @@ OpenCode Session
     ├── chat.message hook ──→ Detect turn completion
     │                              │
     │                              ├── Extract last turn from SQLite
+    │                              ├── Persist turn metadata to .memsearch/opencode-turns.db
     │                              ├── Summarize via LLM (third-person notes)
     │                              └── Append to .memsearch/memory/YYYY-MM-DD.md
     │                                     │
@@ -106,7 +107,7 @@ We discussed the authentication flow before, what was the approach?
 |------|-------------|
 | `memory_search` | Semantic search over past memories. Returns ranked chunks. |
 | `memory_get` | Expand a chunk hash to see the full markdown section. |
-| `memory_transcript` | Read original conversation from OpenCode SQLite DB. |
+| `memory_transcript` | Read original conversation from OpenCode SQLite DB, optionally centered on a turn cursor. |
 
 ## Memory Files
 
@@ -127,7 +128,7 @@ Each file contains timestamped entries with bullet-point summaries:
 ## Session 14:30
 
 ### 14:30
-<!-- session:ses_abc123 db:~/.local/share/opencode/opencode.db -->
+<!-- session:ses_abc123 turn:msg_123abc db:~/.local/share/opencode/opencode.db -->
 - User asked about the authentication flow.
 - Assistant explained the OAuth2 implementation in auth.ts.
 - Assistant modified the token refresh logic in refresh.ts.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -109,6 +109,10 @@ We discussed the authentication flow before, what was the approach?
 | `memory_get` | Expand a chunk hash to see the full markdown section. |
 | `memory_transcript` | Read original conversation from OpenCode SQLite DB, optionally centered on a turn cursor. |
 
+`<project>/.memsearch/opencode-turns.db` stores derived capture checkpoints and
+turn ordering only. It is rebuildable state, not the source of truth for
+transcript recall.
+
 ## Memory Files
 
 Memory is stored as markdown in `<project>/.memsearch/memory/`:
@@ -158,7 +162,7 @@ Leave it empty or unset to keep the current `small_model` / plugin default behav
 
 2. **Index**: The markdown files are indexed by memsearch into a Milvus collection (Milvus Lite by default, runs in-process).
 
-3. **Recall**: When the assistant needs historical context, it calls `memory_search` to find relevant chunks. Results can be expanded with `memory_get` or drilled into with `memory_transcript`.
+3. **Recall**: When the assistant needs historical context, it calls `memory_search` to find relevant chunks. Results can be expanded with `memory_get` or drilled into with `memory_transcript`, which reads the original transcript from OpenCode SQLite.
 
 4. **Cold-start**: At session start, recent memory bullets are injected into the system prompt so the assistant has immediate context.
 

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -285,11 +285,14 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         description:
           "Retrieve the original conversation from a past OpenCode session. " +
           "Use after memory_get when the expanded result contains a session anchor " +
-          "(<!-- session:ID db:PATH -->). Returns the formatted " +
-          "dialogue with [Human] and [Assistant] labels.",
+          "(<!-- session:ID turn:ID db:PATH -->). Returns the formatted " +
+          "dialogue with [Human] and [Assistant] labels. When turn_id is present, " +
+          "the tool returns the target turn plus surrounding context.",
         args: {
           session_id: tool.schema.string().describe("The session ID from the anchor comment"),
-          limit: tool.schema.number().optional().describe("Max number of messages to return (default: 20)"),
+          turn_id: tool.schema.string().optional().describe("Optional turn ID from the anchor comment"),
+          context: tool.schema.number().optional().describe("Turns before/after the target turn (default: 3)"),
+          limit: tool.schema.number().optional().describe("Max number of turns to return when no turn_id is provided (default: 20)"),
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
@@ -297,11 +300,25 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
           try {
             const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.py");
-            const result = spawnSync(
-              "python3",
-              [scriptPath, args.session_id, ...(args.limit ? ["--limit", String(args.limit)] : [])],
-              { encoding: "utf-8", timeout: 15000 }
-            );
+            const scriptArgs = [
+              scriptPath,
+              args.session_id,
+              "--project-dir",
+              dir,
+            ];
+            if (args.turn_id) {
+              scriptArgs.push("--turn", args.turn_id);
+            }
+            if (typeof args.context === "number") {
+              scriptArgs.push("--context", String(args.context));
+            }
+            if (typeof args.limit === "number") {
+              scriptArgs.push("--limit", String(args.limit));
+            }
+            const result = spawnSync("python3", scriptArgs, {
+              encoding: "utf-8",
+              timeout: 15000,
+            });
             return result.stdout?.trim() || result.stderr || "No transcript content found.";
           } catch (e: any) {
             return `Transcript parse failed: ${e.message}`;

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -18,6 +18,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -36,6 +37,8 @@ from opencode_turns import (
     save_turn,
     save_turn_state,
 )
+
+_ANCHOR_RE = re.compile(r"<!-- session:([^ ]+) turn:([^ ]+) db:")
 
 
 def split_memsearch_cmd(memsearch_cmd: str) -> list[str]:
@@ -186,7 +189,49 @@ def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     return [row[0] for row in sessions]
 
 
-def write_capture(memory_dir: str, turn_text: str, session_id: str, turn_id: str, db_path: str = "") -> str:
+def _load_legacy_last_msg_time(project_dir: str) -> int:
+    """Read the pre-sidecar capture checkpoint for upgrade compatibility."""
+    path = Path(project_dir) / ".memsearch" / ".last_msg_time"
+    try:
+        value = int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return 0
+    return max(value, 0)
+
+
+def _make_capture_anchor_key(session_id: str, turn_id: str) -> tuple[str, str]:
+    return (session_id, turn_id)
+
+
+def load_capture_anchor_cache(memory_dir: str) -> set[tuple[str, str]]:
+    if not os.path.isdir(memory_dir):
+        return set()
+
+    anchor_cache: set[tuple[str, str]] = set()
+    for name in os.listdir(memory_dir):
+        if not name.endswith(".md"):
+            continue
+
+        path = os.path.join(memory_dir, name)
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        for session_id, turn_id in _ANCHOR_RE.findall(text):
+            anchor_cache.add(_make_capture_anchor_key(session_id, turn_id))
+
+    return anchor_cache
+
+
+def write_capture(
+    memory_dir: str,
+    turn_text: str,
+    session_id: str,
+    turn_id: str,
+    db_path: str = "",
+    anchor_cache: set[tuple[str, str]] | None = None,
+) -> str:
     """Write a captured turn to the daily memory file."""
     os.makedirs(memory_dir, exist_ok=True)
 
@@ -203,6 +248,9 @@ def write_capture(memory_dir: str, turn_text: str, session_id: str, turn_id: str
 
     with open(memory_file, "a", encoding="utf-8") as f:
         f.write(entry)
+
+    if session_id and anchor_cache is not None:
+        anchor_cache.add(_make_capture_anchor_key(session_id, turn_id))
 
     return memory_file
 
@@ -271,6 +319,10 @@ def capture_session_turns(
     next_turn_index = get_next_turn_index(turn_db, session_id)
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
+    if after_time is None:
+        legacy_after_time = _load_legacy_last_msg_time(str(Path(memory_dir).resolve().parent.parent))
+        if legacy_after_time > 0:
+            after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None
     turns = build_turns(
         conn,

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -4,12 +4,15 @@
 Usage:
   capture-daemon.py <project_dir> <collection_name> [--memsearch-cmd CMD]
 
-The daemon polls the OpenCode SQLite database for new completed messages,
-extracts the last turn, summarizes it as bullet points, and writes to
+The daemon polls the OpenCode SQLite database for completed turns, extracts
+the latest completed turn, summarizes it as bullet points, and writes to
 <project_dir>/.memsearch/memory/YYYY-MM-DD.md.
 
-It also triggers memsearch indexing after writing.
+It also persists derived turn metadata in <project_dir>/.memsearch/opencode-turns.db
+and triggers memsearch indexing after writing.
 """
+
+from __future__ import annotations
 
 import argparse
 import contextlib
@@ -25,13 +28,22 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from opencode_turns import (
+    build_turns,
+    get_db_path,
+    load_turn_state,
+    open_turn_db,
+    save_turn,
+    save_turn_state,
+)
 
-def split_memsearch_cmd(memsearch_cmd):
+
+def split_memsearch_cmd(memsearch_cmd: str) -> list[str]:
     """Split the configured memsearch command preserving quoted arguments."""
     return shlex.split(memsearch_cmd)
 
 
-def get_small_model():
+def get_small_model() -> str:
     """Read small_model from opencode.json config (fallback to model, then empty)."""
     config_paths = [
         os.path.expanduser("~/.config/opencode/opencode.json"),
@@ -40,7 +52,7 @@ def get_small_model():
     for p in config_paths:
         if os.path.exists(p):
             try:
-                with open(p) as f:
+                with open(p, encoding="utf-8") as f:
                     cfg = json.load(f)
                 return cfg.get("small_model", cfg.get("model", ""))
             except Exception:
@@ -48,23 +60,25 @@ def get_small_model():
     return ""
 
 
-def get_plugin_summarize_model(memsearch_cmd=None):
+def get_plugin_summarize_model(memsearch_cmd: str | None = None) -> str:
     """Read the memsearch OpenCode summarize model override."""
     if not memsearch_cmd:
         return ""
     try:
         result = subprocess.run(
             [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.model"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         return result.stdout.strip()
     except Exception:
         return ""
 
 
-def ensure_isolated_config():
+def ensure_isolated_config() -> str:
     """Create isolated config dir without plugins/ to prevent recursion."""
-    isolated = "/tmp/opencode-memsearch-summarize/opencode"
+    isolated = os.path.expanduser("~/.codex/tmp/opencode-memsearch-summarize/opencode")
     os.makedirs(isolated, exist_ok=True)
     # Copy opencode.json (provider config) but NOT plugins/
     src = os.path.expanduser("~/.config/opencode/opencode.json")
@@ -74,17 +88,19 @@ def ensure_isolated_config():
             os.remove(dst)
     if os.path.exists(src) and not os.path.exists(dst):
         shutil.copy2(src, dst)
-    return os.path.dirname(isolated)  # /tmp/opencode-memsearch-summarize
+    return os.path.dirname(isolated)
 
 
-def _load_summarize_prompt(agent_name, memsearch_cmd=None):
+def _load_summarize_prompt(agent_name: str, memsearch_cmd: str | None = None) -> str:
     """Load summarization prompt: user custom > plugin built-in > inline fallback."""
     # Try user-custom prompt via config
     if memsearch_cmd:
         try:
             result = subprocess.run(
                 [*split_memsearch_cmd(memsearch_cmd), "config", "get", "prompts.summarize"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             custom_path = result.stdout.strip()
             if custom_path and os.path.isfile(custom_path):
@@ -106,13 +122,10 @@ def _load_summarize_prompt(agent_name, memsearch_cmd=None):
     )
 
 
-def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
+def summarize_with_llm(turn_text: str, small_model: str, memsearch_cmd: str | None = None) -> str | None:
     """Summarize using opencode run in isolated env (no plugins -> no recursion)."""
     system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
-    full_prompt = (
-        f"{system_prompt}\n\n"
-        f"Transcript:\n{turn_text}"
-    )
+    full_prompt = f"{system_prompt}\n\nTranscript:\n{turn_text}"
     isolated_dir = ensure_isolated_config()
 
     summarize_model = get_plugin_summarize_model(memsearch_cmd) or small_model
@@ -130,10 +143,11 @@ def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
                 "XDG_DATA_HOME": os.path.join(isolated_dir, "data"),
                 "MEMSEARCH_NO_WATCH": "1",
             },
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         output = result.stdout.strip()
-        # Extract bullet points (skip any opencode run header lines)
         lines = output.split("\n")
         bullets = [line for line in lines if line.strip().startswith("- ")]
         if bullets:
@@ -141,32 +155,15 @@ def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
     except Exception:
         pass
 
-    return None  # fallback to raw text
+    return None
 
 
-def get_db_path():
-    """Find the OpenCode SQLite database."""
-    default = os.path.expanduser("~/.local/share/opencode/opencode.db")
-    if os.path.exists(default):
-        return default
-    xdg_data = os.environ.get("XDG_DATA_HOME", "")
-    if xdg_data:
-        alt = os.path.join(xdg_data, "opencode", "opencode.db")
-        if os.path.exists(alt):
-            return alt
-    return default
-
-
-def get_new_completed_turns(conn, project_dir, last_msg_time):
-    """Get new user+assistant pairs from sessions in the project directory.
-
-    Returns a list of (session_id, turn_text, max_msg_time) tuples for
-    turns whose messages are newer than last_msg_time.
-    """
-    # Find all sessions for this project directory
+def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
+    """Find OpenCode sessions that belong to the given project directory."""
     sessions = conn.execute(
         """
-        SELECT s.id FROM session s
+        SELECT s.id
+        FROM session s
         WHERE s.directory = ?
         ORDER BY s.time_updated DESC
         LIMIT 5
@@ -175,10 +172,10 @@ def get_new_completed_turns(conn, project_dir, last_msg_time):
     ).fetchall()
 
     if not sessions:
-        # Fallback: match by basename
         sessions = conn.execute(
             """
-            SELECT s.id FROM session s
+            SELECT s.id
+            FROM session s
             WHERE s.directory LIKE ?
             ORDER BY s.time_updated DESC
             LIMIT 5
@@ -186,75 +183,10 @@ def get_new_completed_turns(conn, project_dir, last_msg_time):
             (f"%{os.path.basename(project_dir)}%",),
         ).fetchall()
 
-    results = []
-    for (session_id,) in sessions:
-        # Get messages newer than last_msg_time, in pairs (user + assistant)
-        messages = conn.execute(
-            """
-            SELECT m.id, m.data, m.time_created
-            FROM message m
-            WHERE m.session_id = ? AND m.time_created > ?
-            ORDER BY m.time_created ASC
-            """,
-            (session_id, last_msg_time),
-        ).fetchall()
-
-        # Group into user+assistant pairs
-        i = 0
-        while i < len(messages):
-            msg_data = json.loads(messages[i][1])
-            role = msg_data.get("role", "")
-            msg_time = messages[i][2]
-
-            if role == "user":
-                user_text = _extract_msg_text(conn, messages[i][0], messages[i][1])
-                assistant_text = ""
-                # Look for following assistant message
-                if i + 1 < len(messages):
-                    next_data = json.loads(messages[i + 1][1])
-                    if next_data.get("role") == "assistant":
-                        assistant_text = _extract_msg_text(conn, messages[i + 1][0], messages[i + 1][1])
-                        msg_time = messages[i + 1][2]
-                        i += 1
-
-                if user_text and len(user_text) > 5:
-                    turn = f"[Human]: {user_text[:2000]}"
-                    if assistant_text:
-                        turn += f"\n\n[Assistant]: {assistant_text[:2000]}"
-                    results.append((session_id, turn, msg_time))
-            i += 1
-
-    return results
+    return [row[0] for row in sessions]
 
 
-def _extract_msg_text(conn, msg_id, msg_json):
-    """Extract readable text from a message's parts."""
-    parts = conn.execute(
-        "SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC",
-        (msg_id,),
-    ).fetchall()
-
-    text_parts = []
-    for (part_json,) in parts:
-        part_data = json.loads(part_json)
-        if part_data.get("type") == "text" and part_data.get("text"):
-            if not part_data.get("synthetic"):
-                text_parts.append(part_data["text"].strip())
-        elif part_data.get("type") == "tool" and part_data.get("state", {}).get("status") == "completed":
-            tool_name = part_data.get("tool", "unknown")
-            tool_input = part_data.get("state", {}).get("input", {})
-            hint = ""
-            if isinstance(tool_input, dict):
-                if "command" in tool_input:
-                    hint = f" `{tool_input['command'][:80]}`"
-                elif "path" in tool_input:
-                    hint = f" {tool_input['path']}"
-            text_parts.append(f"[Tool: {tool_name}{hint}]")
-
-    return "\n".join(text_parts)
-
-
-def write_capture(memory_dir, turn_text, session_id, db_path=""):
+def write_capture(memory_dir: str, turn_text: str, session_id: str, turn_id: str, db_path: str = "") -> str:
     """Write a captured turn to the daily memory file."""
     os.makedirs(memory_dir, exist_ok=True)
 
@@ -263,19 +195,125 @@ def write_capture(memory_dir, turn_text, session_id, db_path=""):
     memory_file = os.path.join(memory_dir, f"{today}.md")
 
     if not os.path.exists(memory_file):
-        with open(memory_file, "w") as f:
+        with open(memory_file, "w", encoding="utf-8") as f:
             f.write(f"# {today}\n\n## Session {now}\n\n")
 
-    anchor = f"<!-- session:{session_id} db:{db_path} -->\n" if session_id else ""
+    anchor = f"<!-- session:{session_id} turn:{turn_id} db:{db_path} -->\n" if session_id else ""
     entry = f"### {now}\n{anchor}{turn_text}\n\n"
 
-    with open(memory_file, "a") as f:
+    with open(memory_file, "a", encoding="utf-8") as f:
         f.write(entry)
 
     return memory_file
 
 
-def main():
+def capture_exists(memory_dir: str, session_id: str, turn_id: str) -> bool:
+    """Check whether a turn anchor was already written to memory markdown."""
+    if not os.path.isdir(memory_dir):
+        return False
+
+    anchor = f"<!-- session:{session_id} turn:{turn_id} "
+    for name in os.listdir(memory_dir):
+        if not name.endswith(".md"):
+            continue
+
+        path = os.path.join(memory_dir, name)
+        try:
+            with open(path, encoding="utf-8") as handle:
+                if anchor in handle.read():
+                    return True
+        except OSError:
+            continue
+
+    return False
+
+
+def load_saved_turn_index(conn: sqlite3.Connection, session_id: str, turn_id: str) -> int | None:
+    """Return an existing saved turn index when replaying a partially persisted turn."""
+    row = conn.execute(
+        """
+        SELECT turn_index
+        FROM turns
+        WHERE session_id = ? AND turn_id = ?
+        """,
+        (session_id, turn_id),
+    ).fetchone()
+    if row is None:
+        return None
+    return int(row["turn_index"])
+
+
+def get_next_turn_index(conn: sqlite3.Connection, session_id: str) -> int:
+    """Return the next monotonically increasing turn index for a session."""
+    row = conn.execute(
+        """
+        SELECT COALESCE(MAX(turn_index), 0) AS max_turn_index
+        FROM turns
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    return int(row["max_turn_index"]) + 1
+
+
+def capture_session_turns(
+    conn: sqlite3.Connection,
+    turn_db: sqlite3.Connection,
+    memory_dir: str,
+    session_id: str,
+    small_model: str,
+    memsearch_cmd: str,
+    db_path: str,
+) -> bool:
+    """Capture all newly completed turns for a single session."""
+    state = load_turn_state(turn_db, session_id)
+    captured_any = False
+    next_turn_index = get_next_turn_index(turn_db, session_id)
+
+    after_time = state.last_completed_time if state.last_completed_time > 0 else None
+    after_message_id = state.last_completed_message_id or None
+    turns = build_turns(
+        conn,
+        session_id,
+        after_time=after_time,
+        after_message_id=after_message_id,
+    )
+
+    for turn in turns:
+        if not turn.complete:
+            break
+
+        saved_turn_index = load_saved_turn_index(turn_db, session_id, turn.turn_id)
+        if saved_turn_index is not None:
+            turn.turn_index = saved_turn_index
+        else:
+            turn.turn_index = next_turn_index
+            next_turn_index += 1
+
+        turn_text = turn.render()
+        if len(turn_text.strip()) <= 10:
+            continue
+
+        summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
+        if not capture_exists(memory_dir, session_id, turn.turn_id):
+            write_capture(
+                memory_dir,
+                summary if summary else turn_text,
+                session_id,
+                turn.turn_id,
+                db_path,
+            )
+        save_turn(turn_db, turn)
+        state.last_completed_time = turn.end_time
+        state.last_completed_message_id = turn.last_message_id
+        state.last_completed_turn_id = turn.turn_id
+        save_turn_state(turn_db, state)
+        captured_any = True
+
+    return captured_any
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description="Capture daemon for OpenCode sessions")
     parser.add_argument("project_dir", help="Project directory")
     parser.add_argument("collection_name", help="Milvus collection name")
@@ -291,13 +329,11 @@ def main():
     memory_dir = os.path.join(args.project_dir, ".memsearch", "memory")
     pid_file = os.path.join(args.project_dir, ".memsearch", ".capture.pid")
 
-    # Write PID file
     os.makedirs(os.path.dirname(pid_file), exist_ok=True)
-    with open(pid_file, "w") as f:
+    with open(pid_file, "w", encoding="utf-8") as f:
         f.write(str(os.getpid()))
 
-    # Clean up on exit
-    def cleanup(signum=None, frame=None):
+    def cleanup(signum=None, frame=None) -> None:
         with contextlib.suppress(OSError):
             os.remove(pid_file)
         sys.exit(0)
@@ -306,41 +342,38 @@ def main():
     signal.signal(signal.SIGINT, cleanup)
 
     small_model = get_small_model()
-    # Track by message time — persisted to disk so daemon restarts don't re-capture
-    state_file = os.path.join(args.project_dir, ".memsearch", ".last_msg_time")
-    last_msg_time = 0
-    if os.path.exists(state_file):
-        with contextlib.suppress(ValueError, OSError), open(state_file) as f:
-            last_msg_time = int(f.read().strip())
+    turn_db = open_turn_db(args.project_dir)
 
     while True:
+        any_new = False
+        conn = None
         try:
             conn = sqlite3.connect(db_path, timeout=5)
+            conn.row_factory = sqlite3.Row
+            for session_id in get_session_ids(conn, args.project_dir):
+                any_new = (
+                    capture_session_turns(
+                        conn,
+                        turn_db,
+                        memory_dir,
+                        session_id,
+                        small_model,
+                        args.memsearch_cmd,
+                        db_path,
+                    )
+                    or any_new
+                )
 
-            new_turns = get_new_completed_turns(conn, args.project_dir, last_msg_time)
-            for session_id, turn_text, msg_time in new_turns:
-                if turn_text and len(turn_text) > 10:
-                    # Summarize with LLM, fallback to raw text
-                    summary = summarize_with_llm(turn_text, small_model, args.memsearch_cmd)
-                    write_capture(memory_dir, summary if summary else turn_text, session_id, db_path)
-                    if msg_time > last_msg_time:
-                        last_msg_time = msg_time
-                        try:
-                            with open(state_file, "w") as sf:
-                                sf.write(str(last_msg_time))
-                        except OSError:
-                            pass
-
-            if new_turns:
-                # Index in background after batch capture
+            if any_new:
                 os.system(
                     f"{args.memsearch_cmd} index '{memory_dir}' "
                     f"--collection {args.collection_name} &"
                 )
-
-            conn.close()
         except Exception:
             pass
+        finally:
+            if conn is not None:
+                conn.close()
 
         time.sleep(args.poll_interval)
 

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -424,10 +424,10 @@ def capture_session_turns(
         if len(turn_text.strip()) <= 10:
             continue
 
-        # Persist markdown first so a later sidecar failure can be repaired by
-        # replay. Existing session+turn anchors are the dedupe signal.
-        summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
+        # Check anchor first so that sidecar rebuilds repair state without
+        # calling the summarizer again for already-captured turns.
         if not capture_exists(memory_dir, session_id, turn.turn_id):
+            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -39,6 +40,16 @@ from opencode_turns import (
 )
 
 _ANCHOR_RE = re.compile(r"<!-- session:([^ ]+) turn:([^ ]+) db:")
+_TAIL_TURN_QUIET_PERIOD_MS = 300_000
+
+
+class TailTurnObservation:
+    __slots__ = ("fingerprint", "stable_since_ms", "turn_id")
+
+    def __init__(self, turn_id: str, fingerprint: str, stable_since_ms: int) -> None:
+        self.turn_id = turn_id
+        self.fingerprint = fingerprint
+        self.stable_since_ms = stable_since_ms
 
 
 def split_memsearch_cmd(memsearch_cmd: str) -> list[str]:
@@ -304,6 +315,69 @@ def get_next_turn_index(conn: sqlite3.Connection, session_id: str) -> int:
     return int(row["max_turn_index"]) + 1
 
 
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _compute_turn_fingerprint(turn) -> str:
+    payload = {
+        "turn_id": turn.turn_id,
+        "last_message_id": turn.last_message_id,
+        "message_count": turn.message_count,
+        "assistant_message_count": turn.assistant_message_count,
+        "complete": turn.complete,
+        "messages": [
+            {
+                "id": message.id,
+                "role": message.role,
+                "parent_id": message.parent_id,
+                "time_created": message.time_created,
+                "finish": message.finish,
+                "text": message.text,
+            }
+            for message in turn.messages
+        ],
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha1(encoded.encode("utf-8")).hexdigest()
+
+
+def _tail_turn_is_stable_for_capture(
+    turn,
+    tail_turn_cache: dict[str, TailTurnObservation],
+) -> bool:
+    if not turn.complete:
+        tail_turn_cache.pop(turn.session_id, None)
+        return False
+
+    fingerprint = _compute_turn_fingerprint(turn)
+    now_ms = _now_ms()
+    observed = tail_turn_cache.get(turn.session_id)
+    if observed is None or observed.turn_id != turn.turn_id or observed.fingerprint != fingerprint:
+        tail_turn_cache[turn.session_id] = TailTurnObservation(
+            turn_id=turn.turn_id,
+            fingerprint=fingerprint,
+            stable_since_ms=now_ms,
+        )
+        return False
+
+    return now_ms - observed.stable_since_ms >= _TAIL_TURN_QUIET_PERIOD_MS
+
+
+def _turn_ready_for_capture(
+    turn,
+    is_tail_turn: bool,
+    tail_turn_cache: dict[str, TailTurnObservation],
+) -> bool:
+    # A non-tail turn has already been closed by a later user message.
+    if not is_tail_turn:
+        tail_turn_cache.pop(turn.session_id, None)
+        return True
+
+    # The final turn must stay textually stable for a quiet window before capture.
+    return _tail_turn_is_stable_for_capture(turn, tail_turn_cache)
+
+
 def capture_session_turns(
     conn: sqlite3.Connection,
     turn_db: sqlite3.Connection,
@@ -312,11 +386,14 @@ def capture_session_turns(
     small_model: str,
     memsearch_cmd: str,
     db_path: str,
+    tail_turn_cache: dict[str, TailTurnObservation] | None = None,
 ) -> bool:
     """Capture all newly completed turns for a single session."""
     state = load_turn_state(turn_db, session_id)
     captured_any = False
     next_turn_index = get_next_turn_index(turn_db, session_id)
+    if tail_turn_cache is None:
+        tail_turn_cache = {}
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
@@ -331,8 +408,9 @@ def capture_session_turns(
         after_message_id=after_message_id,
     )
 
-    for turn in turns:
-        if not turn.complete:
+    for index, turn in enumerate(turns):
+        is_tail_turn = index == len(turns) - 1
+        if not _turn_ready_for_capture(turn, is_tail_turn, tail_turn_cache):
             break
 
         saved_turn_index = load_saved_turn_index(turn_db, session_id, turn.turn_id)
@@ -362,6 +440,7 @@ def capture_session_turns(
         state.last_completed_message_id = turn.last_message_id
         state.last_completed_turn_id = turn.turn_id
         save_turn_state(turn_db, state)
+        tail_turn_cache.pop(session_id, None)
         captured_any = True
 
     return captured_any
@@ -397,6 +476,7 @@ def main() -> None:
 
     small_model = get_small_model()
     turn_db = open_turn_db(args.project_dir)
+    tail_turn_cache: dict[str, TailTurnObservation] = {}
 
     while True:
         any_new = False
@@ -414,6 +494,7 @@ def main() -> None:
                         small_model,
                         args.memsearch_cmd,
                         db_path,
+                        tail_turn_cache,
                     )
                     or any_new
                 )

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -294,6 +294,8 @@ def capture_session_turns(
         if len(turn_text.strip()) <= 10:
             continue
 
+        # Persist markdown first so a later sidecar failure can be repaired by
+        # replay. Existing session+turn anchors are the dedupe signal.
         summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
         if not capture_exists(memory_dir, session_id, turn.turn_id):
             write_capture(

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Shared helpers for OpenCode transcript turn handling.
 
-This module keeps the OpenCode SQLite database as the source of truth and
-stores derived turn metadata in a small sidecar SQLite database under
-<project>/.memsearch/opencode-turns.db.
+The raw OpenCode SQLite database remains the source of truth for transcript
+content. This module also manages a small sidecar SQLite database under
+<project>/.memsearch/opencode-turns.db for derived capture checkpoints and
+stable turn ordering during replay.
 """
 
 from __future__ import annotations

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -351,20 +351,24 @@ def build_turns(
             continue
 
         role = msg_data.get("role", "unknown")
+        parent_id = msg_data.get("parentID")
+        time_created = int(row["time_created"])
+        finish = msg_data.get("finish")
         message_text = extract_message_text(conn, row["id"]).strip()
-        if not message_text:
-            continue
-
-        message = OpenCodeMessage(
-            id=row["id"],
-            role=role,
-            parent_id=msg_data.get("parentID"),
-            time_created=int(row["time_created"]),
-            finish=msg_data.get("finish"),
-            text=message_text,
-        )
 
         if role == "user":
+            if not message_text:
+                continue
+
+            message = OpenCodeMessage(
+                id=row["id"],
+                role=role,
+                parent_id=parent_id,
+                time_created=time_created,
+                finish=finish,
+                text=message_text,
+            )
+
             if current is not None:
                 current.complete = _is_complete(current)
                 turns.append(current)
@@ -386,8 +390,21 @@ def build_turns(
             continue
 
         if role == "assistant" and current is not None:
-            if message.parent_id and message.parent_id not in current_message_ids:
+            if parent_id and parent_id not in current_message_ids:
                 continue
+
+            if not message_text:
+                current_message_ids.add(row["id"])
+                continue
+
+            message = OpenCodeMessage(
+                id=row["id"],
+                role=role,
+                parent_id=parent_id,
+                time_created=time_created,
+                finish=finish,
+                text=message_text,
+            )
 
             current.messages.append(message)
             current_message_ids.add(message.id)

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Shared helpers for OpenCode transcript turn handling.
+
+This module keeps the OpenCode SQLite database as the source of truth and
+stores derived turn metadata in a small sidecar SQLite database under
+<project>/.memsearch/opencode-turns.db.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class OpenCodeMessage:
+    """A single meaningful OpenCode message with rendered text."""
+
+    id: str
+    role: str
+    parent_id: str | None
+    time_created: int
+    finish: str | None
+    text: str
+
+
+@dataclass(slots=True)
+class OpenCodeTurn:
+    """A user turn plus its assistant follow-up messages."""
+
+    session_id: str
+    turn_id: str
+    turn_index: int
+    start_time: int
+    end_time: int
+    first_message_id: str
+    last_message_id: str
+    message_count: int
+    assistant_message_count: int
+    complete: bool
+    messages: list[OpenCodeMessage] = field(default_factory=list)
+
+    def render(self, max_chars: int = 3000) -> str:
+        """Render the turn into readable transcript text."""
+        lines: list[str] = [
+            f"=== Turn {self.turn_index} ({self.turn_id}) ===",
+        ]
+        for message in self.messages:
+            label = "[Human]" if message.role == "user" else "[Assistant]"
+            text = message.text.strip()
+            if len(text) > max_chars:
+                text = text[:max_chars] + "\n..."
+            lines.append(f"{label}: {text}")
+            lines.append("")
+        return "\n".join(lines).strip()
+
+
+@dataclass(slots=True)
+class TurnState:
+    """Persistent capture progress for a session."""
+
+    session_id: str
+    last_completed_time: int
+    last_completed_message_id: str
+    last_completed_turn_id: str
+
+
+def get_db_path() -> str:
+    """Find the OpenCode SQLite database."""
+    default = os.path.expanduser("~/.local/share/opencode/opencode.db")
+    if os.path.exists(default):
+        return default
+
+    xdg_data = os.environ.get("XDG_DATA_HOME", "")
+    if xdg_data:
+        alt = os.path.join(xdg_data, "opencode", "opencode.db")
+        if os.path.exists(alt):
+            return alt
+
+    return default
+
+
+def get_turn_db_path(project_dir: str) -> str:
+    """Return the derived turn metadata database path for a project."""
+    return os.path.join(project_dir, ".memsearch", "opencode-turns.db")
+
+
+def open_turn_db(project_dir: str) -> sqlite3.Connection:
+    """Open the sidecar turn database and ensure its schema exists."""
+    turn_db_path = get_turn_db_path(project_dir)
+    Path(turn_db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(turn_db_path, timeout=5)
+    conn.row_factory = sqlite3.Row
+    ensure_turn_schema(conn)
+    return conn
+
+
+def ensure_turn_schema(conn: sqlite3.Connection) -> None:
+    """Create the sidecar schema if it does not exist yet."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS turns (
+            session_id TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            turn_index INTEGER NOT NULL,
+            start_time INTEGER NOT NULL,
+            start_message_id TEXT NOT NULL,
+            end_time INTEGER NOT NULL,
+            end_message_id TEXT NOT NULL,
+            message_count INTEGER NOT NULL,
+            assistant_message_count INTEGER NOT NULL,
+            complete INTEGER NOT NULL DEFAULT 1,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            PRIMARY KEY (session_id, turn_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS turn_state (
+            session_id TEXT PRIMARY KEY,
+            last_completed_time INTEGER NOT NULL DEFAULT 0,
+            last_completed_message_id TEXT NOT NULL DEFAULT '',
+            last_completed_turn_id TEXT NOT NULL DEFAULT '',
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS turns_session_index_idx ON turns (session_id, turn_index)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS turns_session_time_idx ON turns (session_id, end_time, turn_id)"
+    )
+    conn.commit()
+
+
+def load_turn_state(conn: sqlite3.Connection, session_id: str) -> TurnState:
+    """Load the last completed turn checkpoint for a session."""
+    row = conn.execute(
+        """
+        SELECT session_id, last_completed_time, last_completed_message_id, last_completed_turn_id
+        FROM turn_state
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+
+    if row is None:
+        return TurnState(session_id=session_id, last_completed_time=0, last_completed_message_id="", last_completed_turn_id="")
+
+    return TurnState(
+        session_id=row["session_id"],
+        last_completed_time=int(row["last_completed_time"]),
+        last_completed_message_id=row["last_completed_message_id"] or "",
+        last_completed_turn_id=row["last_completed_turn_id"] or "",
+    )
+
+
+def save_turn_state(conn: sqlite3.Connection, state: TurnState) -> None:
+    """Persist the checkpoint for a session."""
+    now = int(_now_ms())
+    conn.execute(
+        """
+        INSERT INTO turn_state (
+            session_id, last_completed_time, last_completed_message_id, last_completed_turn_id,
+            time_created, time_updated
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            last_completed_time = excluded.last_completed_time,
+            last_completed_message_id = excluded.last_completed_message_id,
+            last_completed_turn_id = excluded.last_completed_turn_id,
+            time_updated = excluded.time_updated
+        """,
+        (
+            state.session_id,
+            state.last_completed_time,
+            state.last_completed_message_id,
+            state.last_completed_turn_id,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+
+
+def save_turn(conn: sqlite3.Connection, turn: OpenCodeTurn) -> None:
+    """Persist derived metadata for a completed turn."""
+    now = int(_now_ms())
+    conn.execute(
+        """
+        INSERT INTO turns (
+            session_id, turn_id, turn_index, start_time, start_message_id, end_time,
+            end_message_id, message_count, assistant_message_count, complete,
+            time_created, time_updated
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(session_id, turn_id) DO UPDATE SET
+            turn_index = excluded.turn_index,
+            start_time = excluded.start_time,
+            start_message_id = excluded.start_message_id,
+            end_time = excluded.end_time,
+            end_message_id = excluded.end_message_id,
+            message_count = excluded.message_count,
+            assistant_message_count = excluded.assistant_message_count,
+            complete = excluded.complete,
+            time_updated = excluded.time_updated
+        """,
+        (
+            turn.session_id,
+            turn.turn_id,
+            turn.turn_index,
+            turn.start_time,
+            turn.first_message_id,
+            turn.end_time,
+            turn.last_message_id,
+            turn.message_count,
+            turn.assistant_message_count,
+            1 if turn.complete else 0,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+
+
+def load_session_turn_rows(conn: sqlite3.Connection, session_id: str) -> list[sqlite3.Row]:
+    """Load cached turn rows for a session."""
+    return conn.execute(
+        """
+        SELECT session_id, turn_id, turn_index, start_time, start_message_id,
+               end_time, end_message_id, message_count, assistant_message_count, complete
+        FROM turns
+        WHERE session_id = ?
+        ORDER BY turn_index ASC
+        """,
+        (session_id,),
+    ).fetchall()
+
+
+def load_messages(
+    conn: sqlite3.Connection,
+    session_id: str,
+    after_time: int | None = None,
+    after_message_id: str | None = None,
+) -> list[sqlite3.Row]:
+    """Load OpenCode messages for a session in chronological order."""
+    query = [
+        "SELECT id, data, time_created FROM message WHERE session_id = ?",
+    ]
+    params: list[object] = [session_id]
+
+    if after_time is not None:
+        if after_message_id:
+            query.append(
+                "AND (time_created > ? OR (time_created = ? AND id > ?))"
+            )
+            params.extend([after_time, after_time, after_message_id])
+        else:
+            query.append("AND time_created > ?")
+            params.append(after_time)
+
+    query.append("ORDER BY time_created ASC, id ASC")
+    return conn.execute(" ".join(query), tuple(params)).fetchall()
+
+
+def extract_message_text(conn: sqlite3.Connection, message_id: str) -> str:
+    """Render a message's parts into readable text."""
+    parts = conn.execute(
+        """
+        SELECT id, data, time_created
+        FROM part
+        WHERE message_id = ?
+        ORDER BY time_created ASC, id ASC
+        """,
+        (message_id,),
+    ).fetchall()
+
+    text_parts: list[str] = []
+    tool_parts: list[str] = []
+
+    for part in parts:
+        try:
+            part_data = json.loads(part["data"])
+        except Exception:
+            continue
+
+        part_type = part_data.get("type", "")
+        if part_type == "text" and part_data.get("text"):
+            if part_data.get("synthetic"):
+                continue
+            text = str(part_data["text"]).strip()
+            if text:
+                text_parts.append(text)
+        elif part_type == "tool" and part_data.get("state"):
+            state = part_data.get("state", {})
+            status = state.get("status", "unknown")
+            tool_name = part_data.get("tool", "unknown")
+
+            if status == "completed":
+                tool_input = state.get("input", {})
+                tool_output = state.get("output", "")
+                if isinstance(tool_output, str) and len(tool_output) > 300:
+                    tool_output = tool_output[:300] + "..."
+
+                input_summary = ""
+                if isinstance(tool_input, dict):
+                    if "command" in tool_input:
+                        input_summary = f" `{tool_input['command']}`"
+                    elif "path" in tool_input:
+                        input_summary = f" {tool_input['path']}"
+                    elif "query" in tool_input:
+                        input_summary = f" '{tool_input['query']}'"
+
+                tool_parts.append(
+                    f"[Tool: {tool_name}{input_summary}] {tool_output}"
+                )
+            elif status == "error":
+                error = state.get("error", "unknown error")
+                tool_parts.append(f"[Tool: {tool_name}] Error: {error}")
+
+    combined = "\n".join(text_parts).strip()
+    if tool_parts:
+        combined = "\n".join([combined, "\n".join(tool_parts)]).strip()
+    return combined
+
+
+def build_turns(
+    conn: sqlite3.Connection,
+    session_id: str,
+    after_time: int | None = None,
+    after_message_id: str | None = None,
+) -> list[OpenCodeTurn]:
+    """Group OpenCode messages into turns."""
+    rows = load_messages(conn, session_id, after_time=after_time, after_message_id=after_message_id)
+
+    turns: list[OpenCodeTurn] = []
+    current: OpenCodeTurn | None = None
+    current_message_ids: set[str] = set()
+
+    for row in rows:
+        try:
+            msg_data = json.loads(row["data"])
+        except Exception:
+            continue
+
+        role = msg_data.get("role", "unknown")
+        message_text = extract_message_text(conn, row["id"]).strip()
+        if not message_text:
+            continue
+
+        message = OpenCodeMessage(
+            id=row["id"],
+            role=role,
+            parent_id=msg_data.get("parentID"),
+            time_created=int(row["time_created"]),
+            finish=msg_data.get("finish"),
+            text=message_text,
+        )
+
+        if role == "user":
+            if current is not None:
+                current.complete = _is_complete(current)
+                turns.append(current)
+
+            current = OpenCodeTurn(
+                session_id=session_id,
+                turn_id=message.id,
+                turn_index=len(turns) + 1,
+                start_time=message.time_created,
+                end_time=message.time_created,
+                first_message_id=message.id,
+                last_message_id=message.id,
+                message_count=1,
+                assistant_message_count=0,
+                complete=False,
+                messages=[message],
+            )
+            current_message_ids = {message.id}
+            continue
+
+        if role == "assistant" and current is not None:
+            if message.parent_id and message.parent_id not in current_message_ids:
+                continue
+
+            current.messages.append(message)
+            current_message_ids.add(message.id)
+            current.end_time = message.time_created
+            current.last_message_id = message.id
+            current.message_count += 1
+            current.assistant_message_count += 1
+
+    if current is not None:
+        current.complete = _is_complete(current)
+        turns.append(current)
+
+    for index, turn in enumerate(turns, start=1):
+        turn.turn_index = index
+
+    return turns
+
+
+def _is_complete(turn: OpenCodeTurn) -> bool:
+    """Heuristically decide whether a grouped turn has finished."""
+    assistant_finishes = [msg.finish for msg in turn.messages if msg.role == "assistant"]
+    if not assistant_finishes:
+        return False
+    last_finish = assistant_finishes[-1]
+    return last_finish != "tool-calls"
+
+
+def find_turn_index(turns: list[OpenCodeTurn], target_turn_id: str) -> int:
+    """Find a turn index by exact or prefix match."""
+    if not target_turn_id:
+        return -1
+
+    for index, turn in enumerate(turns):
+        if turn.turn_id == target_turn_id:
+            return index
+        if turn.turn_id.startswith(target_turn_id) or target_turn_id.startswith(turn.turn_id[:8]):
+            return index
+    return -1
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)

--- a/plugins/opencode/scripts/parse-transcript.py
+++ b/plugins/opencode/scripts/parse-transcript.py
@@ -2,191 +2,104 @@
 """Parse OpenCode SQLite transcript for a given session.
 
 Usage:
-  parse-transcript.py <session_id> [--limit N] [--last-turn]
+  parse-transcript.py <session_id> [--limit N] [--turn TURN_ID] [--context N] [--project-dir PATH]
 
 Options:
-  --limit N       Max number of messages to return (default: 20)
-  --last-turn     Only return the last user+assistant turn (for capture)
+  --limit N        Max number of turns to return when no turn is targeted (default: 20)
+  --turn TURN_ID   Return the target turn plus surrounding context turns
+  --context N      Number of turns before/after the target turn (default: 3)
+  --project-dir    OpenCode project directory (reserved for sidecar cache lookup)
 
 The script reads from the OpenCode SQLite database at:
   ~/.local/share/opencode/opencode.db
 """
 
-import sqlite3
-import json
-import sys
-import os
+from __future__ import annotations
+
 import argparse
+import os
+import sqlite3
+import sys
+
+from opencode_turns import build_turns, find_turn_index, get_db_path
 
 
-def get_db_path():
-    """Find the OpenCode SQLite database."""
-    # Default path
-    default = os.path.expanduser("~/.local/share/opencode/opencode.db")
-    if os.path.exists(default):
-        return default
-
-    # Check XDG_DATA_HOME
-    xdg_data = os.environ.get("XDG_DATA_HOME", "")
-    if xdg_data:
-        alt = os.path.join(xdg_data, "opencode", "opencode.db")
-        if os.path.exists(alt):
-            return alt
-
-    return default
+def _emit(text: str = "", *, err: bool = False) -> None:
+    """Write a line of output without relying on print()."""
+    stream = sys.stderr if err else sys.stdout
+    stream.write(text)
+    if not text.endswith("\n"):
+        stream.write("\n")
 
 
-def parse_session(session_id, limit=20, last_turn=False):
-    """Parse messages and parts for a session, formatted as [Human]/[Assistant]."""
+def parse_session(
+    session_id: str,
+    limit: int = 20,
+    turn_id: str | None = None,
+    context: int = 3,
+) -> None:
+    """Parse messages for a session, grouped into turns."""
     db_path = get_db_path()
     if not os.path.exists(db_path):
-        print(f"Error: OpenCode database not found at {db_path}", file=sys.stderr)
+        _emit(f"Error: OpenCode database not found at {db_path}", err=True)
         sys.exit(1)
 
     conn = sqlite3.connect(db_path, timeout=5)
     conn.row_factory = sqlite3.Row
 
     try:
-        # Get messages for the session, ordered by creation time
-        messages = conn.execute(
-            """
-            SELECT id, data, time_created
-            FROM message
-            WHERE session_id = ?
-            ORDER BY time_created ASC
-            """,
-            (session_id,),
-        ).fetchall()
-
-        if not messages:
-            print(f"No messages found for session {session_id}")
-            return
-
-        # Build structured turns
-        turns = []
-        for msg in messages:
-            msg_data = json.loads(msg["data"])
-            role = msg_data.get("role", "unknown")
-            msg_id = msg["id"]
-
-            # Get parts for this message
-            parts = conn.execute(
-                """
-                SELECT id, data, time_created
-                FROM part
-                WHERE message_id = ?
-                ORDER BY time_created ASC
-                """,
-                (msg_id,),
-            ).fetchall()
-
-            text_parts = []
-            tool_parts = []
-
-            for part in parts:
-                part_data = json.loads(part["data"])
-                part_type = part_data.get("type", "")
-
-                if part_type == "text" and part_data.get("text"):
-                    text = part_data["text"].strip()
-                    # Skip synthetic parts (e.g. "The following tool was executed by the user")
-                    if part_data.get("synthetic"):
-                        continue
-                    if text:
-                        text_parts.append(text)
-
-                elif part_type == "tool" and part_data.get("state"):
-                    state = part_data["state"]
-                    tool_name = part_data.get("tool", "unknown")
-                    status = state.get("status", "unknown")
-
-                    if status == "completed":
-                        tool_input = state.get("input", {})
-                        tool_output = state.get("output", "")
-                        # Truncate long output
-                        if isinstance(tool_output, str) and len(tool_output) > 300:
-                            tool_output = tool_output[:300] + "..."
-
-                        input_summary = ""
-                        if isinstance(tool_input, dict):
-                            # Summarize common tool inputs
-                            if "command" in tool_input:
-                                input_summary = f" `{tool_input['command']}`"
-                            elif "path" in tool_input:
-                                input_summary = f" {tool_input['path']}"
-                            elif "query" in tool_input:
-                                input_summary = f" '{tool_input['query']}'"
-
-                        tool_parts.append(
-                            f"[Tool: {tool_name}{input_summary}] {tool_output}"
-                        )
-                    elif status == "error":
-                        error = state.get("error", "unknown error")
-                        tool_parts.append(f"[Tool: {tool_name}] Error: {error}")
-
-            # Combine text and tool parts
-            combined = "\n".join(text_parts)
-            if tool_parts:
-                combined += "\n" + "\n".join(tool_parts)
-
-            if combined.strip():
-                turns.append({"role": role, "text": combined.strip()})
-
+        turns = build_turns(conn, session_id)
         if not turns:
-            print(f"No meaningful content found for session {session_id}")
+            _emit(f"No messages found for session {session_id}")
             return
 
-        # If --last-turn, extract only the last user+assistant exchange
-        if last_turn:
-            turns = extract_last_turn(turns)
+        if turn_id:
+            target_idx = find_turn_index(turns, turn_id)
+            if target_idx < 0:
+                _emit(f"Turn not found: {turn_id}", err=True)
+                sys.exit(1)
 
-        # Apply limit
-        if limit and not last_turn:
-            turns = turns[-limit:]
+            start = max(0, target_idx - context)
+            end = min(len(turns), target_idx + context + 1)
+            selected = turns[start:end]
+        elif limit and limit > 0:
+            selected = turns[-limit:]
+        else:
+            selected = turns
 
-        # Format output
-        for turn in turns:
-            role_label = "[Human]" if turn["role"] == "user" else "[Assistant]"
-            text = turn["text"]
-            # Truncate very long turns
-            if len(text) > 3000:
-                text = text[:3000] + "\n..."
-            print(f"{role_label}: {text}\n")
+        if not selected:
+            _emit(f"No meaningful content found for session {session_id}")
+            return
+
+        for turn in selected:
+            _emit(turn.render())
+            _emit()
 
     finally:
         conn.close()
 
 
-def extract_last_turn(turns):
-    """Extract the last user+assistant pair from turns."""
-    if not turns:
-        return []
-
-    # Find the last user message (threshold 5 chars to support CJK)
-    last_user_idx = -1
-    for i in range(len(turns) - 1, -1, -1):
-        if turns[i]["role"] == "user" and len(turns[i]["text"]) > 5:
-            last_user_idx = i
-            break
-
-    if last_user_idx == -1:
-        return []
-
-    return turns[last_user_idx:]
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Parse OpenCode session transcript")
     parser.add_argument("session_id", help="Session ID to parse")
-    parser.add_argument("--limit", type=int, default=20, help="Max messages to return")
+    parser.add_argument("--limit", type=int, default=20, help="Max turns to return")
+    parser.add_argument("--turn", default=None, help="Target turn ID (prefix match)")
+    parser.add_argument("--context", type=int, default=3, help="Turns before/after target")
     parser.add_argument(
-        "--last-turn",
-        action="store_true",
-        help="Only return the last user+assistant turn",
+        "--project-dir",
+        default=os.getcwd(),
+        help="OpenCode project directory (reserved for the turn sidecar cache)",
     )
     args = parser.parse_args()
 
-    parse_session(args.session_id, limit=args.limit, last_turn=args.last_turn)
+    # The turn sidecar is currently maintained by the capture daemon. The raw
+    # OpenCode SQLite database remains the source of truth for transcript reads.
+    parse_session(
+        args.session_id,
+        limit=args.limit,
+        turn_id=args.turn,
+        context=args.context,
+    )
 
 
 if __name__ == "__main__":

--- a/plugins/opencode/scripts/parse-transcript.py
+++ b/plugins/opencode/scripts/parse-transcript.py
@@ -8,7 +8,7 @@ Options:
   --limit N        Max number of turns to return when no turn is targeted (default: 20)
   --turn TURN_ID   Return the target turn plus surrounding context turns
   --context N      Number of turns before/after the target turn (default: 3)
-  --project-dir    OpenCode project directory (reserved for sidecar cache lookup)
+  --project-dir    OpenCode project directory (unused for transcript reads; kept for tool compatibility)
 
 The script reads from the OpenCode SQLite database at:
   ~/.local/share/opencode/opencode.db
@@ -88,12 +88,12 @@ def main() -> None:
     parser.add_argument(
         "--project-dir",
         default=os.getcwd(),
-        help="OpenCode project directory (reserved for the turn sidecar cache)",
+        help="OpenCode project directory (unused for transcript reads; kept for tool compatibility)",
     )
     args = parser.parse_args()
 
-    # The turn sidecar is currently maintained by the capture daemon. The raw
-    # OpenCode SQLite database remains the source of truth for transcript reads.
+    # The capture daemon may maintain a turn sidecar for replay-safe progress,
+    # but transcript reads always rebuild from the raw OpenCode SQLite database.
     parse_session(
         args.session_id,
         limit=args.limit,

--- a/plugins/opencode/skills/memory-recall/SKILL.md
+++ b/plugins/opencode/skills/memory-recall/SKILL.md
@@ -25,7 +25,8 @@ Search for memories relevant to: $ARGUMENTS
 3. **Expand**: For each relevant result, run `memsearch expand <chunk_hash> --collection <collection name above>` to get the full markdown section with surrounding context.
 
 4. **Deep drill (optional)**: If an expanded chunk contains transcript anchors (HTML comments with session info), and the original conversation seems critical:
-   - If the anchor contains `db:`, run `python3 __INSTALL_DIR__/scripts/parse-transcript.py <session_id> --limit 10` to retrieve the original conversation turns from the SQLite database.
+   - If the anchor contains `turn:`, run `python3 __INSTALL_DIR__/scripts/parse-transcript.py <session_id> --turn <turn_id> --context 3` to retrieve the original conversation around that turn.
+   - If the anchor only contains `db:` / `session:` with no turn cursor, run `python3 __INSTALL_DIR__/scripts/parse-transcript.py <session_id> --limit 10` to retrieve the most recent turns from the SQLite database.
    - If the anchor format is unfamiliar (e.g. `transcript:`, `rollout:` instead of `db:`), try reading the referenced file directly to explore its structure and locate the relevant conversation by the session or turn identifiers in the anchor.
 
 5. **Return results**: Output a curated summary of the most relevant memories. Be concise — only include information that is genuinely useful for the user's current question.

--- a/tests/test_opencode_parse_transcript.py
+++ b/tests/test_opencode_parse_transcript.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sqlite3
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+def _make_opencode_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _insert_message(
+    conn: sqlite3.Connection,
+    message_id: str,
+    session_id: str,
+    time_created: int,
+    role: str,
+    text: str,
+    parent_id: str | None = None,
+    finish: str = "stop",
+) -> None:
+    payload: dict[str, object] = {
+        "role": role,
+        "time": {"created": time_created},
+        "finish": finish,
+    }
+    if parent_id:
+        payload["parentID"] = parent_id
+    conn.execute(
+        """
+        INSERT INTO message (id, session_id, time_created, time_updated, data)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (message_id, session_id, time_created, time_created, json.dumps(payload)),
+    )
+    conn.execute(
+        """
+        INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            f"{message_id}-p1",
+            message_id,
+            session_id,
+            time_created,
+            time_created,
+            json.dumps({"type": "text", "text": text}),
+        ),
+    )
+
+
+def _load_parse_transcript_module():
+    script_dir = Path("plugins/opencode/scripts").resolve()
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+
+    script = script_dir / "parse-transcript.py"
+    spec = importlib.util.spec_from_file_location("opencode_parse_transcript", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_transcript_help_describes_project_dir_as_non_source_of_truth() -> None:
+    script = Path("plugins/opencode/scripts/parse-transcript.py").resolve()
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    normalized_stdout = " ".join(result.stdout.split())
+
+    assert result.returncode == 0
+    assert "unused for transcript reads" in normalized_stdout
+    assert "sidecar cache" not in normalized_stdout
+
+
+def test_parse_transcript_reads_from_opencode_sqlite_without_sidecar(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_sqlite_only"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", text="Answer", parent_id="u1")
+    conn.commit()
+    conn.close()
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    module = _load_parse_transcript_module()
+    monkeypatch.setattr(module, "get_db_path", lambda: str(db_path))
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        module.parse_session(session_id, limit=1)
+
+    output = stdout.getvalue()
+
+    assert "[Human]: Question" in output
+    assert "[Assistant]: Answer" in output

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -723,3 +723,65 @@ def test_capture_session_turns_does_not_advance_sidecar_when_markdown_write_fail
 
     turn_db.close()
     conn.close()
+
+
+def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    summarize_calls = {"count": 0}
+
+    def tracking_summarize(*args, **kwargs):
+        summarize_calls["count"] += 1
+        return "- summarized"
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", tracking_summarize)
+
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_rebuild"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    _insert_message(conn, "u2", session_id, 200, "user", text="Follow-up")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    assert summarize_calls["count"] == 1
+    content = next(memory_dir.glob("*.md")).read_text(encoding="utf-8")
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+
+    turn_db.close()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    assert summarize_calls["count"] == 1
+
+    content = next(memory_dir.glob("*.md")).read_text(encoding="utf-8")
+    assert content.count(f"<!-- session:{session_id} turn:u1 db:{db_path} -->") == 1
+
+    turn_db.close()
+    conn.close()

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "plugins" / "opencode" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+CAPTURE_DAEMON_PATH = SCRIPT_DIR / "capture-daemon.py"
+CAPTURE_DAEMON_SPEC = importlib.util.spec_from_file_location(
+    "capture_daemon",
+    CAPTURE_DAEMON_PATH,
+)
+assert CAPTURE_DAEMON_SPEC is not None
+assert CAPTURE_DAEMON_SPEC.loader is not None
+capture_daemon = importlib.util.module_from_spec(CAPTURE_DAEMON_SPEC)
+CAPTURE_DAEMON_SPEC.loader.exec_module(capture_daemon)
+
+from opencode_turns import (  # noqa: E402
+    OpenCodeTurn,
+    TurnState,
+    build_turns,
+    get_turn_db_path,
+    load_session_turn_rows,
+    load_turn_state,
+    open_turn_db,
+    save_turn,
+    save_turn_state,
+)
+
+
+def _make_opencode_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _insert_message(
+    conn: sqlite3.Connection,
+    message_id: str,
+    session_id: str,
+    time_created: int,
+    role: str,
+    parent_id: str | None = None,
+    finish: str = "stop",
+    text: str = "",
+    tool_output: str | None = None,
+) -> None:
+    payload: dict[str, object] = {
+        "role": role,
+        "time": {"created": time_created},
+        "finish": finish,
+    }
+    if parent_id:
+        payload["parentID"] = parent_id
+    conn.execute(
+        """
+        INSERT INTO message (id, session_id, time_created, time_updated, data)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (message_id, session_id, time_created, time_created, json.dumps(payload)),
+    )
+
+    part_id = f"{message_id}-p1"
+    if text:
+        conn.execute(
+            """
+            INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                part_id,
+                message_id,
+                session_id,
+                time_created,
+                time_created,
+                json.dumps({"type": "text", "text": text}),
+            ),
+        )
+
+    if tool_output is not None:
+        conn.execute(
+            """
+            INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"{message_id}-tool",
+                message_id,
+                session_id,
+                time_created,
+                time_created,
+                json.dumps(
+                    {
+                        "type": "tool",
+                        "tool": "Bash",
+                        "state": {
+                            "status": "completed",
+                            "input": {"command": "ls"},
+                            "output": tool_output,
+                        },
+                    }
+                ),
+            ),
+        )
+
+
+def test_build_turns_groups_multi_message_assistant_turns(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_test"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Plan the change")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="tool-calls", text="Checking")
+    _insert_message(
+        conn,
+        "a2",
+        session_id,
+        120,
+        "assistant",
+        parent_id="u1",
+        finish="stop",
+        text="Done",
+        tool_output="output.txt",
+    )
+    _insert_message(conn, "u2", session_id, 130, "user", text="Thanks")
+    _insert_message(conn, "a3", session_id, 140, "assistant", parent_id="u2", finish="stop", text="You're welcome")
+    conn.commit()
+
+    turns = build_turns(conn, session_id)
+
+    assert len(turns) == 2
+    assert turns[0].turn_id == "u1"
+    assert turns[0].assistant_message_count == 2
+    assert turns[0].complete is True
+    assert "Plan the change" in turns[0].render()
+    assert "[Tool: Bash" in turns[0].render()
+    assert turns[1].turn_id == "u2"
+    assert turns[1].complete is True
+
+    conn.close()
+
+
+def test_build_turns_keeps_assistant_descendants_in_same_turn(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_descendants"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Investigate the failure")
+    _insert_message(
+        conn,
+        "a1",
+        session_id,
+        110,
+        "assistant",
+        parent_id="u1",
+        finish="tool-calls",
+        text="Running checks",
+    )
+    _insert_message(
+        conn,
+        "a2",
+        session_id,
+        120,
+        "assistant",
+        parent_id="a1",
+        finish="stop",
+        text="Found the root cause",
+    )
+    _insert_message(conn, "u2", session_id, 130, "user", text="Apply the fix")
+    conn.commit()
+
+    turns = build_turns(conn, session_id)
+
+    assert len(turns) == 2
+    assert turns[0].turn_id == "u1"
+    assert turns[0].assistant_message_count == 2
+    assert turns[0].complete is True
+    assert [message.id for message in turns[0].messages] == ["u1", "a1", "a2"]
+
+    conn.close()
+
+
+def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    turn_db = open_turn_db(str(project_dir))
+    turn = OpenCodeTurn(
+        session_id="ses_1",
+        turn_id="u1",
+        turn_index=1,
+        start_time=100,
+        end_time=150,
+        first_message_id="u1",
+        last_message_id="a1",
+        message_count=2,
+        assistant_message_count=1,
+        complete=True,
+        messages=[],
+    )
+
+    save_turn(turn_db, turn)
+    save_turn_state(
+        turn_db,
+        TurnState(
+            session_id="ses_1",
+            last_completed_time=150,
+            last_completed_message_id="a1",
+            last_completed_turn_id="u1",
+        ),
+    )
+
+    rows = load_session_turn_rows(turn_db, "ses_1")
+    state = load_turn_state(turn_db, "ses_1")
+
+    assert get_turn_db_path(str(project_dir)).endswith(".memsearch/opencode-turns.db")
+    assert len(rows) == 1
+    assert rows[0]["turn_id"] == "u1"
+    assert state.last_completed_turn_id == "u1"
+    assert state.last_completed_message_id == "a1"
+
+    turn_db.close()
+
+
+def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_capture"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question one")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    _insert_message(conn, "u2", session_id, 200, "user", text="Question two")
+    _insert_message(conn, "a2", session_id, 210, "assistant", parent_id="u2", finish="stop", text="Answer two")
+    conn.commit()
+
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+
+    assert [(row["turn_id"], row["turn_index"]) for row in rows] == [("u1", 1), ("u2", 2)]
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_crash"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    conn.commit()
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+
+    original_save_turn_state = capture_daemon.save_turn_state
+    failed_once = {"value": False}
+
+    def flaky_save_turn_state(*args, **kwargs):
+        if not failed_once["value"]:
+            failed_once["value"] = True
+            raise RuntimeError("simulated crash before cursor persisted")
+        return original_save_turn_state(*args, **kwargs)
+
+    turn_db = open_turn_db(str(project_dir))
+    monkeypatch.setattr(capture_daemon, "save_turn_state", flaky_save_turn_state)
+
+    try:
+        capture_daemon.capture_session_turns(
+            conn,
+            turn_db,
+            str(memory_dir),
+            session_id,
+            "",
+            "memsearch",
+            str(db_path),
+        )
+    except RuntimeError:
+        pass
+
+    monkeypatch.setattr(capture_daemon, "save_turn_state", original_save_turn_state)
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    files = sorted(memory_dir.glob("*.md"))
+    assert len(files) == 1
+    content = files[0].read_text(encoding="utf-8")
+    assert content.count(f"<!-- session:{session_id} turn:u1 db:{db_path} -->") == 1
+
+    state = load_turn_state(turn_db, session_id)
+    assert state.last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -295,6 +295,8 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     memory_dir = project_dir / ".memsearch" / "memory"
 
     monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+    current_time_ms = {"value": 0}
+    monkeypatch.setattr(capture_daemon.time, "time", lambda: current_time_ms["value"] / 1000)
 
     _insert_message(conn, "u1", session_id, 100, "user", text="Question one")
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
@@ -311,8 +313,26 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
         str(db_path),
     )
 
+    assert load_session_turn_rows(turn_db, session_id) == []
+
     _insert_message(conn, "u2", session_id, 200, "user", text="Question two")
     _insert_message(conn, "a2", session_id, 210, "assistant", parent_id="u2", finish="stop", text="Answer two")
+    conn.commit()
+
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert [(row["turn_id"], row["turn_index"]) for row in rows] == [("u1", 1)]
+
+    _insert_message(conn, "u3", session_id, 300, "user", text="Question three")
     conn.commit()
 
     capture_daemon.capture_session_turns(
@@ -346,6 +366,7 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
 
     _insert_message(conn, "u1", session_id, 100, "user", text="Question")
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    _insert_message(conn, "u2", session_id, 200, "user", text="Follow-up")
     conn.commit()
 
     monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
@@ -391,6 +412,207 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
 
     state = load_turn_state(turn_db, session_id)
     assert state.last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_tail_wait"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+    tail_cache: dict[str, object] = {}
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+    current_time_ms = {"value": 0}
+    monkeypatch.setattr(capture_daemon.time, "time", lambda: current_time_ms["value"] / 1000)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    current_time_ms["value"] = 299_999
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    current_time_ms["value"] = 300_000
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert [(row["turn_id"], row["turn_index"]) for row in rows] == [("u1", 1)]
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_resets_tail_stability_when_content_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_tail_reset"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+    tail_cache: dict[str, object] = {}
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+    current_time_ms = {"value": 0}
+    monkeypatch.setattr(capture_daemon.time, "time", lambda: current_time_ms["value"] / 1000)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Draft answer")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    _insert_message(conn, "a2", session_id, 120, "assistant", parent_id="a1", finish="stop", text="Final answer")
+    conn.commit()
+
+    current_time_ms["value"] = 250_000
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    current_time_ms["value"] = 549_999
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    current_time_ms["value"] = 550_000
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert [(row["turn_id"], row["turn_index"]) for row in rows] == [("u1", 1)]
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_next_user"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+    tail_cache: dict[str, object] = {}
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+    current_time_ms = {"value": 0}
+    monkeypatch.setattr(capture_daemon.time, "time", lambda: current_time_ms["value"] / 1000)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question one")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+    assert load_session_turn_rows(turn_db, session_id) == []
+
+    _insert_message(conn, "u2", session_id, 200, "user", text="Question two")
+    conn.commit()
+
+    current_time_ms["value"] = 1_000
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        tail_cache,
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert [(row["turn_id"], row["turn_index"]) for row in rows] == [("u1", 1)]
 
     turn_db.close()
     conn.close()
@@ -451,70 +673,6 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
     state = load_turn_state(turn_db, session_id)
     assert state.last_completed_turn_id == "u2"
     assert state.last_completed_time == 210
-
-    turn_db.close()
-    conn.close()
-
-
-def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    db_path = tmp_path / "opencode.db"
-    conn = _make_opencode_db(db_path)
-    session_id = "ses_turn_save"
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    memory_dir = project_dir / ".memsearch" / "memory"
-
-    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
-    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
-    conn.commit()
-
-    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
-
-    original_save_turn = capture_daemon.save_turn
-    failed_once = {"value": False}
-
-    def flaky_save_turn(*args, **kwargs):
-        if not failed_once["value"]:
-            failed_once["value"] = True
-            raise RuntimeError("simulated crash before turn row persisted")
-        return original_save_turn(*args, **kwargs)
-
-    turn_db = open_turn_db(str(project_dir))
-    monkeypatch.setattr(capture_daemon, "save_turn", flaky_save_turn)
-
-    with suppress(RuntimeError):
-        capture_daemon.capture_session_turns(
-            conn,
-            turn_db,
-            str(memory_dir),
-            session_id,
-            "",
-            "memsearch",
-            str(db_path),
-        )
-
-    monkeypatch.setattr(capture_daemon, "save_turn", original_save_turn)
-    capture_daemon.capture_session_turns(
-        conn,
-        turn_db,
-        str(memory_dir),
-        session_id,
-        "",
-        "memsearch",
-        str(db_path),
-    )
-
-    files = sorted(memory_dir.glob("*.md"))
-    assert len(files) == 1
-    content = files[0].read_text(encoding="utf-8")
-    assert content.count(f"<!-- session:{session_id} turn:u1 db:{db_path} -->") == 1
-
-    rows = load_session_turn_rows(turn_db, session_id)
-    assert len(rows) == 1
-    assert rows[0]["turn_id"] == "u1"
 
     turn_db.close()
     conn.close()

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sqlite3
 import sys
@@ -205,6 +206,38 @@ def test_build_turns_keeps_assistant_descendants_in_same_turn(tmp_path: Path) ->
     assert turns[0].assistant_message_count == 2
     assert turns[0].complete is True
     assert [message.id for message in turns[0].messages] == ["u1", "a1", "a2"]
+
+    conn.close()
+
+
+def test_build_turns_keeps_descendants_through_textless_assistant_nodes(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_textless_descendants"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Investigate the failure")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="tool-calls")
+    _insert_message(
+        conn,
+        "a2",
+        session_id,
+        120,
+        "assistant",
+        parent_id="a1",
+        finish="stop",
+        text="Found the root cause",
+    )
+    _insert_message(conn, "u2", session_id, 130, "user", text="Apply the fix")
+    conn.commit()
+
+    turns = build_turns(conn, session_id)
+
+    assert len(turns) == 2
+    assert turns[0].turn_id == "u1"
+    assert turns[0].assistant_message_count == 1
+    assert turns[0].complete is True
+    assert [message.id for message in turns[0].messages] == ["u1", "a2"]
+    assert "Found the root cause" in turns[0].render()
 
     conn.close()
 

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.util
-import io
 import json
 import sqlite3
 import sys
@@ -395,9 +394,69 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
 
     turn_db.close()
     conn.close()
+def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_upgrade"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+    legacy_state_file = project_dir / ".memsearch" / ".last_msg_time"
+    legacy_state_file.write_text("150", encoding="utf-8")
+
+    today = capture_daemon.datetime.now().strftime("%Y-%m-%d")
+    legacy_memory = memory_dir / f"{today}.md"
+    legacy_memory.write_text(
+        f"# {today}\n\n"
+        "## Session 00:00\n\n"
+        "### 00:00\n"
+        f"<!-- session:{session_id} db:{db_path} -->\n"
+        "- legacy summary for turn u1\n\n",
+        encoding="utf-8",
+    )
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question one")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
+    _insert_message(conn, "u2", session_id, 200, "user", text="Question two")
+    _insert_message(conn, "a2", session_id, 210, "assistant", parent_id="u2", finish="stop", text="Answer two")
+    _insert_message(conn, "u3", session_id, 300, "user", text="Question three")
+    conn.commit()
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+
+    turn_db = open_turn_db(str(project_dir))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert [row["turn_id"] for row in rows] == ["u2"]
+
+    content = legacy_memory.read_text(encoding="utf-8")
+    assert f"<!-- session:{session_id} db:{db_path} -->" in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" not in content
+    assert f"<!-- session:{session_id} turn:u2 db:{db_path} -->" in content
+    assert "Question two" in content
+
+    state = load_turn_state(turn_db, session_id)
+    assert state.last_completed_turn_id == "u2"
+    assert state.last_completed_time == 210
+
+    turn_db.close()
+    conn.close()
 
 
-def test_capture_session_turns_repairs_sidecar_after_partial_turn_save_failure(
+def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     tmp_path: Path,
     monkeypatch,
 ) -> None:

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sqlite3
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "plugins" / "opencode" / "scripts"
@@ -329,7 +330,7 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
     turn_db = open_turn_db(str(project_dir))
     monkeypatch.setattr(capture_daemon, "save_turn_state", flaky_save_turn_state)
 
-    try:
+    with suppress(RuntimeError):
         capture_daemon.capture_session_turns(
             conn,
             turn_db,
@@ -339,8 +340,6 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
             "memsearch",
             str(db_path),
         )
-    except RuntimeError:
-        pass
 
     monkeypatch.setattr(capture_daemon, "save_turn_state", original_save_turn_state)
     capture_daemon.capture_session_turns(
@@ -360,6 +359,117 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
 
     state = load_turn_state(turn_db, session_id)
     assert state.last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_repairs_sidecar_after_partial_turn_save_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_turn_save"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    conn.commit()
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+
+    original_save_turn = capture_daemon.save_turn
+    failed_once = {"value": False}
+
+    def flaky_save_turn(*args, **kwargs):
+        if not failed_once["value"]:
+            failed_once["value"] = True
+            raise RuntimeError("simulated crash before turn row persisted")
+        return original_save_turn(*args, **kwargs)
+
+    turn_db = open_turn_db(str(project_dir))
+    monkeypatch.setattr(capture_daemon, "save_turn", flaky_save_turn)
+
+    with suppress(RuntimeError):
+        capture_daemon.capture_session_turns(
+            conn,
+            turn_db,
+            str(memory_dir),
+            session_id,
+            "",
+            "memsearch",
+            str(db_path),
+        )
+
+    monkeypatch.setattr(capture_daemon, "save_turn", original_save_turn)
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+
+    files = sorted(memory_dir.glob("*.md"))
+    assert len(files) == 1
+    content = files[0].read_text(encoding="utf-8")
+    assert content.count(f"<!-- session:{session_id} turn:u1 db:{db_path} -->") == 1
+
+    rows = load_session_turn_rows(turn_db, session_id)
+    assert len(rows) == 1
+    assert rows[0]["turn_id"] == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_does_not_advance_sidecar_when_markdown_write_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_write_fail"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
+    conn.commit()
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        capture_daemon,
+        "write_capture",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    turn_db = open_turn_db(str(project_dir))
+
+    with suppress(OSError):
+        capture_daemon.capture_session_turns(
+            conn,
+            turn_db,
+            str(memory_dir),
+            session_id,
+            "",
+            "memsearch",
+            str(db_path),
+        )
+
+    state = load_turn_state(turn_db, session_id)
+    rows = load_session_turn_rows(turn_db, session_id)
+
+    assert state.last_completed_turn_id == ""
+    assert state.last_completed_message_id == ""
+    assert state.last_completed_time == 0
+    assert rows == []
 
     turn_db.close()
     conn.close()


### PR DESCRIPTION
Closes #505

## Summary
- add turn anchors and `turn_id`/`context` transcript drill-down for the OpenCode plugin
- keep transcript recall sourced from the OpenCode SQLite DB while treating `.memsearch/opencode-turns.db` as derived capture state for checkpoints and stable replay ordering
- clarify markdown-first replay semantics and add regression coverage for partial sidecar failures

## Test Plan
- `uv run python -m pytest tests/test_opencode_turns.py tests/test_opencode_parse_transcript.py -v`
- `uv run ruff check tests/test_opencode_turns.py tests/test_opencode_parse_transcript.py plugins/opencode/scripts/parse-transcript.py plugins/opencode/scripts/opencode_turns.py plugins/opencode/scripts/capture-daemon.py`