### PR TITLE
docs: update plugin install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ We discussed Redis caching before, what was the TTL we chose?
 
 > 📖 [Claude Code Plugin docs](https://zilliztech.github.io/memsearch/platforms/claude-code/) · [Troubleshooting](https://zilliztech.github.io/memsearch/platforms/claude-code/troubleshooting/)
 
+### For Codex CLI Users
+
+```bash
+# Install
+bash memsearch/plugins/codex/scripts/install.sh
+codex --yolo  # needed for ONNX model network access
+```
+
+After installing, chat as usual. Hooks capture and summarize each turn.
+
+**Verify it's working:**
+
+```bash
+ls .memsearch/memory/
+```
+
+**Recall memories** — use the skill:
+
+```
+$memory-recall what did we discuss about deployment?
+```
+
+> 📖 [Codex CLI Plugin docs](https://zilliztech.github.io/memsearch/platforms/codex/)
+
 ### For OpenClaw Users
 
 ```bash
@@ -99,10 +123,9 @@ Or just ask naturally — the LLM auto-invokes memory tools when it senses the q
 We discussed batch size limits before, what did we decide?
 ```
 
-> 📖 [OpenClaw Plugin docs](https://zilliztech.github.io/memsearch/platforms/openclaw/)
+> 📖 [OpenClaw Plugin docs](https://zilliztech.github.io/memsearch/platforms/openclaw/) · [Browse on ClawHub](https://clawhub.ai/plugins/memsearch)
 
-<details>
-<summary><b>🔧 For OpenCode Users</b></summary>
+### For OpenCode Users
 
 ```json
 // In ~/.config/opencode/opencode.json
@@ -128,35 +151,6 @@ We discussed the authentication flow before, what was the approach?
 ```
 
 > 📖 [OpenCode Plugin docs](https://zilliztech.github.io/memsearch/platforms/opencode/)
-
-</details>
-
-<details>
-<summary><b>🔧 For Codex CLI Users</b></summary>
-
-```bash
-# Install
-bash memsearch/plugins/codex/scripts/install.sh
-codex --yolo  # needed for ONNX model network access
-```
-
-After installing, chat as usual. Hooks capture and summarize each turn.
-
-**Verify it's working:**
-
-```bash
-ls .memsearch/memory/
-```
-
-**Recall memories** — use the skill:
-
-```
-$memory-recall what did we discuss about deployment?
-```
-
-> 📖 [Codex CLI Plugin docs](https://zilliztech.github.io/memsearch/platforms/codex/)
-
-</details>
 
 ### ⚙️ Configuration (all platforms)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ openclaw gateway restart
 Three tools (`memory_search`, `memory_get`, `memory_transcript`) with per-workspace isolation. Point an agent's workspace at a project directory to share memories with other platforms automatically.
 
 [:octicons-arrow-right-24: OpenClaw Plugin docs](platforms/openclaw/index.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Browse on ClawHub](https://clawhub.ai/plugins/memsearch){ .md-button }
 
 ### OpenCode Plugin
 

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -2,6 +2,9 @@
 
 **Semantic memory for [OpenClaw](https://github.com/openclaw/openclaw) agents.** A TypeScript plugin with `kind: memory` that replaces OpenClaw's built-in memory-core with hybrid semantic search.
 
+[Browse on ClawHub](https://clawhub.ai/plugins/memsearch){ .md-button .md-button--primary }
+[Install](installation.md){ .md-button }
+
 ---
 
 ## Why memsearch over memory-core?

--- a/docs/platforms/openclaw/installation.md
+++ b/docs/platforms/openclaw/installation.md
@@ -8,6 +8,8 @@
 
 ## Install from ClawHub (recommended)
 
+The plugin is published on [ClawHub](https://clawhub.ai/plugins/memsearch).
+
 ```bash
 # 1. Install the plugin
 openclaw plugins install clawhub:memsearch


### PR DESCRIPTION
## Summary
- reorder README plugin install sections so Codex CLI appears before OpenClaw
- expand all four README plugin install sections instead of folding OpenCode and Codex
- add ClawHub links for the OpenClaw plugin in README and docs

## Test Plan
- mkdocs build --strict
- git diff --check README.md