### PR TITLE
chore: bump Claude Code plugin to 0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }


### PR DESCRIPTION
## Summary
- bump the Claude Code plugin manifest to 0.4.1
- update marketplace metadata for the memsearch Claude Code plugin to 0.4.1

## Test Plan
- `python3 -m json.tool plugins/claude-code/.claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `git diff --check -- plugins/claude-code/.claude-plugin/plugin.json .claude-plugin/marketplace.json`
