### PR TITLE
docs: add agent user use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ memsearch config set milvus.uri http://localhost:19530
 
 > 📖 Full configuration guide: [Configuration](https://zilliztech.github.io/memsearch/home/configuration/) · [Platform comparison](https://zilliztech.github.io/memsearch/platforms/)
 
+### What can you use it for?
+
+- **Resume debugging threads** — ask how a similar Redis, Docker, database, or deployment issue was fixed last time.
+- **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
+- **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
+- **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+
 ---
 
 ## 🛠️ For Agent Developers

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -2,6 +2,14 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them, and recalls relevant context — all automatically.
 
+## What can you use it for?
+
+- **Resume debugging threads** — ask how a similar Redis, Docker, database, or deployment issue was fixed last time.
+- **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
+- **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
+- **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+
 ## Choose Your Platform
 
 | Platform | Install | Maturity |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,14 @@
 
 Pick your platform, install the plugin, and you're done. memsearch captures conversations, indexes them with hybrid search, and recalls relevant context when your agent needs it.
 
+### What can you use it for?
+
+- **Resume debugging threads** — ask how a similar Redis, Docker, database, or deployment issue was fixed last time.
+- **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
+- **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
+- **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+
 ### Claude Code Plugin
 
 The most mature plugin. Marketplace install, zero config.


### PR DESCRIPTION
## Summary
- add concrete use cases to the README agent users section
- mirror the same guidance in the docs overview and agent users page

## Testing
- mkdocs build --strict