### PR TITLE
fix(plugins): derive collection from MEMSEARCH_DIR when explicitly set

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -27,6 +27,9 @@ if [ -n "$_GIT_ROOT" ]; then
 else
   _PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 fi
+# When MEMSEARCH_DIR is explicitly set, use global scope (shared dir + collection).
+# Otherwise, default to per-project isolation.
+_MEMSEARCH_DIR_EXPLICIT="${MEMSEARCH_DIR:+true}"
 MEMSEARCH_DIR="${MEMSEARCH_DIR:-$_PROJECT_DIR/.memsearch}"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
@@ -44,8 +47,13 @@ _detect_memsearch
 # Short command prefix for injected instructions (falls back to "memsearch" even if unavailable)
 MEMSEARCH_CMD_PREFIX="${MEMSEARCH_CMD:-memsearch}"
 
-# Derive per-project collection name from project directory
-COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$_PROJECT_DIR" 2>/dev/null || true)
+# Derive collection name: from MEMSEARCH_DIR when explicitly set (global scope),
+# otherwise from project directory (per-project isolation).
+if [ "$_MEMSEARCH_DIR_EXPLICIT" = "true" ]; then
+  COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$MEMSEARCH_DIR" 2>/dev/null || true)
+else
+  COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$_PROJECT_DIR" 2>/dev/null || true)
+fi
 
 # --- JSON helpers (jq preferred, python3 fallback) ---
 

--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -9,7 +9,7 @@ You are a memory retrieval agent for memsearch. Your job is to search past memor
 
 ## Project Collection
 
-Collection: !`bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$root"; else bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh"; fi'`
+Collection: !`bash -c 'if [ -n "${MEMSEARCH_DIR:-}" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$MEMSEARCH_DIR"; else root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$root"; else bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh"; fi; fi'`
 
 ## Your Task
 
@@ -35,9 +35,9 @@ Search for memories relevant to: $ARGUMENTS
 
 If the user's question is vague or you can't form a concrete search query, explore the raw markdown first — it is the source of truth for memory:
 
-- `ls -t $(git rev-parse --show-toplevel)/.memsearch/memory/ | head -10` — recent daily logs
-- `grep -h "^## " $(git rev-parse --show-toplevel)/.memsearch/memory/*.md | sort -u | tail -40` — session headings across all days
-- `cat $(git rev-parse --show-toplevel)/.memsearch/memory/<YYYY-MM-DD>.md` — read a specific day
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; ls -t "$MDIR/memory/" | head -10` — recent daily logs
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; grep -h "^## " "$MDIR/memory/"*.md | sort -u | tail -40` — session headings across all days
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; cat "$MDIR/memory/<YYYY-MM-DD>.md"` — read a specific day
 
 Once a concrete topic jumps out, go back to `memsearch search` with a specific query.
 

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -92,7 +92,9 @@ if [ -n "$_GIT_ROOT" ]; then
   PROJECT_DIR="$_GIT_ROOT"
 fi
 
-# Memory directory and memsearch state directory are project-scoped
+# When MEMSEARCH_DIR is explicitly set, use global scope (shared dir + collection).
+# Otherwise, default to per-project isolation.
+_MEMSEARCH_DIR_EXPLICIT="${MEMSEARCH_DIR:+true}"
 MEMSEARCH_DIR="${MEMSEARCH_DIR:-${PROJECT_DIR}/.memsearch}"
 MEMORY_DIR="$MEMSEARCH_DIR/memory"
 
@@ -119,8 +121,13 @@ _memsearch() {
   "${MEMSEARCH_CMD[@]}" "$@"
 }
 
-# Derive per-project collection name from project directory
-COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$PROJECT_DIR" 2>/dev/null || true)
+# Derive collection name: from MEMSEARCH_DIR when explicitly set (global scope),
+# otherwise from project directory (per-project isolation).
+if [ "$_MEMSEARCH_DIR_EXPLICIT" = "true" ]; then
+  COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$MEMSEARCH_DIR" 2>/dev/null || true)
+else
+  COLLECTION_NAME=$("$(dirname "${BASH_SOURCE[0]}")/../scripts/derive-collection.sh" "$PROJECT_DIR" 2>/dev/null || true)
+fi
 
 # Helper: ensure memory directory exists
 ensure_memory_dir() {

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -9,7 +9,7 @@ You are performing memory retrieval for memsearch. Search past memories and retu
 
 Determine the collection name by running:
 ```
-bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi'
+bash -c 'if [ -n "${MEMSEARCH_DIR:-}" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$MEMSEARCH_DIR"; else root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi; fi'
 ```
 
 ## Steps
@@ -34,9 +34,9 @@ bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$ro
 
 If the user's question is vague or you can't form a concrete search query, explore the raw markdown first — it is the source of truth for memory:
 
-- `ls -t .memsearch/memory/ | head -10` — recent daily logs
-- `grep -h "^## " .memsearch/memory/*.md | sort -u | tail -40` — session headings across all days
-- `cat .memsearch/memory/<YYYY-MM-DD>.md` — read a specific day
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; ls -t "$MDIR/memory/" | head -10` — recent daily logs
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; grep -h "^## " "$MDIR/memory/"*.md | sort -u | tail -40` — session headings across all days
+- `MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"; cat "$MDIR/memory/<YYYY-MM-DD>.md"` — read a specific day
 
 Once a concrete topic jumps out, go back to `memsearch search` with a specific query.
 


### PR DESCRIPTION
## Summary

When `MEMSEARCH_DIR` is explicitly set via environment variable (e.g. for cross-project global memory), the Milvus collection name is now derived from `MEMSEARCH_DIR` instead of the project directory. This ensures that both the markdown files **and** the vector index share the same scope.

**Problem:** PR #408 added support for `MEMSEARCH_DIR` override, which correctly routes markdown files to a shared directory. However, the collection name is still derived from `$_PROJECT_DIR` (git root), so memories written in Project A are not searchable from Project B — the vector index remains per-project even though the files are global.

**Fix:** Check whether `MEMSEARCH_DIR` was explicitly set before the default assignment. When explicit, derive the collection from `MEMSEARCH_DIR`. Default behavior (no env var) is unchanged.

Applied to both Claude Code and Codex plugins.

Relates to #337

## Test plan

- [ ] Set `export MEMSEARCH_DIR="$HOME/.memsearch/global"` in shell profile
- [ ] Start a Claude Code session in Project A, generate a memory
- [ ] Start a Claude Code session in Project B, search for the memory from Project A
- [ ] Verify the same collection name is used in both projects
- [ ] Without `MEMSEARCH_DIR` set, verify per-project isolation still works (different collection names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)