### PR TITLE
fix(opencode): use symlinks for credentials in isolated summarization env

### DIFF
--- a/docs/platforms/opencode/how-it-works.md
+++ b/docs/platforms/opencode/how-it-works.md
@@ -17,7 +17,7 @@
 graph TB
     subgraph "Capture"
         SQLITE[("OpenCode SQLite<br/>~/.local/share/opencode/opencode.db")] --> DAEMON["capture-daemon.py<br/>(background poller, 10s interval)"]
-        DAEMON --> SUMMARIZE["opencode run<br/>(isolated XDG_CONFIG_HOME)"]
+        DAEMON --> SUMMARIZE["opencode run<br/>(isolated env + symlinked credentials)"]
         SUMMARIZE --> MD["memory/YYYY-MM-DD.md"]
     end
 
@@ -70,7 +70,7 @@ sequenceDiagram
         DB->>Daemon: Messages newer than last_msg_time
         alt New turns found
             Daemon->>Daemon: Group into user+assistant pairs
-            Daemon->>LLM: Summarize turn (isolated config)
+            Daemon->>LLM: Summarize turn (isolated env with symlinked credentials)
             LLM->>Daemon: 2-6 bullet points
             Daemon->>File: Append with session anchor
             Daemon->>Daemon: Update last_msg_time (persist to disk)
@@ -91,7 +91,7 @@ Step by step:
 
 ### LLM Summarization with Isolation
 
-The daemon summarizes turns via `opencode run` -- but it must avoid triggering the memsearch plugin recursively. It achieves this with **XDG isolation**:
+The daemon summarizes turns via `opencode run` -- but it must avoid triggering the memsearch plugin recursively. It achieves this with **XDG isolation** combined with **symlinked credentials**:
 
 ```python
 result = subprocess.run(
@@ -104,9 +104,7 @@ result = subprocess.run(
 )
 ```
 
-The isolated `XDG_CONFIG_HOME` contains a copy of `opencode.json` (for provider/model config) but **no `plugins/` directory** -- so the memsearch plugin doesn't load in the summarization subprocess. The `MEMSEARCH_NO_WATCH` env var provides an additional guard.
-
-The daemon also reads `small_model` from `opencode.json` config, using a lighter model for summarization when available.
+The isolated `XDG_CONFIG_HOME` and `XDG_DATA_HOME` ensure the summarization subprocess writes to a temporary SQLite database invisible to the daemon, preventing feedback loops. Inside the isolated config directory, `opencode.json` and `auth.json` are **symlinked** (not copied) from the user's real config — so provider credentials and model settings are always up-to-date without manual synchronization. The `plugins/` directory is intentionally absent from the isolated config, so the memsearch plugin doesn't load in the summarization subprocess. The `MEMSEARCH_NO_WATCH` env var provides an additional guard.
 
 ### Daemon Self-Management
 
@@ -193,7 +191,7 @@ The `<!-- session:... db:~/.local/share/opencode/opencode.db -->` anchors are us
 | **L3 source** | OpenCode SQLite DB | Claude Code JSONL | OpenClaw JSONL | Codex rollout JSONL |
 | **Recall trigger** | Tool-based (LLM decides) | Skill in forked subagent (`context: fork`) | Tool-based (LLM decides) | Skill-based (main context) |
 | **Install** | npm + opencode.json | Plugin marketplace | `openclaw plugins install` | `install.sh` + hooks.json |
-| **Recursion prevention** | XDG_CONFIG_HOME isolation | `CLAUDECODE=` env var | `MEMSEARCH_NO_WATCH` flag | Isolated CODEX_HOME |
+| **Recursion prevention** | Isolated env + symlinked credentials | `CLAUDECODE=` env var | `MEMSEARCH_NO_WATCH` flag | Isolated CODEX_HOME |
 
 ---
 

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -11,15 +11,14 @@ extracts the last turn, summarizes it as bullet points, and writes to
 It also triggers memsearch indexing after writing.
 """
 
-import sqlite3
-import json
-import sys
-import os
-import time
-import shutil
-import subprocess
 import argparse
+import json
+import os
 import signal
+import sqlite3
+import subprocess
+import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -41,16 +40,39 @@ def get_small_model():
     return ""
 
 
+def _ensure_symlink(src, dst):
+    """Ensure dst is a symlink pointing to src. Recreate if broken or wrong target."""
+    if not os.path.exists(src):
+        return
+    if os.path.lexists(dst) and os.path.islink(dst) and os.readlink(dst) == src:
+        return  # Already correct
+    if os.path.lexists(dst):
+        os.remove(dst)
+    os.symlink(src, dst)
+
+
 def ensure_isolated_config():
-    """Create isolated config dir without plugins/ to prevent recursion."""
-    isolated = "/tmp/opencode-memsearch-summarize/opencode"
-    os.makedirs(isolated, exist_ok=True)
-    # Copy opencode.json (provider config) but NOT plugins/
-    src = os.path.expanduser("~/.config/opencode/opencode.json")
-    dst = os.path.join(isolated, "opencode.json")
-    if os.path.exists(src) and not os.path.exists(dst):
-        shutil.copy2(src, dst)
-    return os.path.dirname(isolated)  # /tmp/opencode-memsearch-summarize
+    """Create isolated config dir with symlinks to required files (no plugins/)."""
+    isolated_base = "/tmp/opencode-memsearch-summarize"
+    isolated_config = os.path.join(isolated_base, "opencode")
+    isolated_data = os.path.join(isolated_base, "data", "opencode")
+
+    os.makedirs(isolated_config, exist_ok=True)
+    os.makedirs(isolated_data, exist_ok=True)
+
+    # Symlink config files
+    _ensure_symlink(
+        os.path.expanduser("~/.config/opencode/opencode.json"),
+        os.path.join(isolated_config, "opencode.json"),
+    )
+
+    # Symlink auth credentials
+    _ensure_symlink(
+        os.path.expanduser("~/.local/share/opencode/auth.json"),
+        os.path.join(isolated_data, "auth.json"),
+    )
+
+    return isolated_base
 
 
 def _load_summarize_prompt(agent_name, memsearch_cmd=None):
@@ -60,7 +82,9 @@ def _load_summarize_prompt(agent_name, memsearch_cmd=None):
         try:
             result = subprocess.run(
                 memsearch_cmd.split() + ["config", "get", "prompts.summarize"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             custom_path = result.stdout.strip()
             if custom_path and os.path.isfile(custom_path):
@@ -85,10 +109,7 @@ def _load_summarize_prompt(agent_name, memsearch_cmd=None):
 def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
     """Summarize using opencode run in isolated env (no plugins -> no recursion)."""
     system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
-    full_prompt = (
-        f"{system_prompt}\n\n"
-        f"Transcript:\n{turn_text}"
-    )
+    full_prompt = f"{system_prompt}\n\nTranscript:\n{turn_text}"
     isolated_dir = ensure_isolated_config()
 
     cmd = ["opencode", "run"]
@@ -105,12 +126,14 @@ def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
                 "XDG_DATA_HOME": os.path.join(isolated_dir, "data"),
                 "MEMSEARCH_NO_WATCH": "1",
             },
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         output = result.stdout.strip()
         # Extract bullet points (skip any opencode run header lines)
         lines = output.split("\n")
-        bullets = [l for l in lines if l.strip().startswith("- ")]
+        bullets = [line for line in lines if line.strip().startswith("- ")]
         if bullets:
             return "\n".join(bullets)
     except Exception:
@@ -312,10 +335,7 @@ def main():
 
             if new_turns:
                 # Index in background after batch capture
-                os.system(
-                    f"{args.memsearch_cmd} index '{memory_dir}' "
-                    f"--collection {args.collection_name} &"
-                )
+                os.system(f"{args.memsearch_cmd} index '{memory_dir}' --collection {args.collection_name} &")
 
             conn.close()
         except Exception:


### PR DESCRIPTION
## Problem

The OpenCode capture daemon (`capture-daemon.py`) creates an isolated environment
for `opencode run` summarization to prevent recursive plugin loading. However,
the isolation was incomplete:

- `auth.json` (provider credentials) was **not** available in the isolated env
- `opencode.json` was copied **once** on first run, so config changes were never
  picked up
- This prevented `opencode run` from using `small_model` configurations that
  rely on credentials registered with the OpenCode CLI

## Solution

Replace file copying with **symlinks** for all required files in the isolated
environment:

| File | Symlink target |
|---|---|
| `~/.config/opencode/opencode.json` | `.../opencode/opencode.json` |
| `~/.local/share/opencode/auth.json` | `.../data/opencode/auth.json` |

Benefits:
- ✅ Provider credentials always available (`auth.json`)
- ✅ Config changes reflected immediately (symlinks, not stale copies)
- ✅ Still fully isolated (`XDG_CONFIG_HOME` + `XDG_DATA_HOME` separate)
- ✅ No recursion loop (daemon and subprocess use different SQLite DBs)

## Files changed

- `plugins/opencode/scripts/capture-daemon.py`: Rewrite `ensure_isolated_config()`
  to use symlinks; add `_ensure_symlink()` helper
- `docs/platforms/opencode/how-it-works.md`: Update architecture diagram and
  isolation explanation to reflect symlink approach

## Testing

Tested locally:
- Daemon starts successfully and creates correct symlinks
- `opencode run` in isolated env resolves models configured in `small_model`
- Summarization output appears as bullet points in `.memsearch/memory/YYYY-MM-DD.md`