### PR TITLE
docs: add session resume use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ memsearch config set milvus.uri http://localhost:19530
 - **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
 - **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
 
 ---

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -8,6 +8,7 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
 - **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
 
 ## Choose Your Platform

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Recover decision rationale** — find why the project chose one architecture, library, migration path, or API design over another.
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
+- **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
 - **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
 
 ### Claude Code Plugin


### PR DESCRIPTION
## Summary
- add a session resume use case to README and docs overview pages

## Testing
- mkdocs build --strict