### PR TITLE
Bump memsearch to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.0"
+version = "0.4.1"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump the memsearch package version to 0.4.1
- refresh uv.lock for the release version

## Testing
- uv lock --check
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest --cov --cov-report=term-missing
- uv build
- uvx pip-audit --desc off
- inspected wheel METADATA for Version: 0.4.1 and Requires-Dist: setuptools<81,>=78.1.1