### PR TITLE
fix(plugins): guard session-start find|sort|head against SIGPIPE

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -152,7 +152,7 @@ fi
 context=""
 
 # Find the 2 most recent daily log files (sorted by filename descending).
-recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | sort -r | head -2)
+recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | sort -r | head -2 || true)
 
 if [ -n "$recent_files" ]; then
   context="# Recent Memory\n\n"


### PR DESCRIPTION
Fixes #521.

## Summary

`plugins/claude-code/hooks/session-start.sh` runs under `set -euo pipefail` (inherited from `common.sh`). The pipeline at line 155:

```bash
find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' -print | sort -r | head -2
```

exits 141 on projects with enough memory files that `sort` is still writing when `head -2` closes the pipe. With `pipefail` + `set -e`, the script aborts before emitting its JSON output — no `[memsearch vX.Y.Z]` status line, no recent-memory cold-start context. Memory indexing via `watch`/`Stop` is unaffected; only the SessionStart surface breaks.

## Fix

Append `|| true` to the pipeline. Mirrors the existing guard at line 166 (`grep ... | head -40 || true`) which exists for the same reason.

## Test plan

Verified locally on a project with 186 `.md` files in `.memsearch/memory/`:

**Before:**
```
$ echo '{}' | bash hooks/session-start.sh; echo "EXIT=$?"
EXIT=141
(no stdout)
```

**After:**
```
$ echo '{}' | bash hooks/session-start.sh; echo "EXIT=$?"
{"systemMessage": "[memsearch v0.4.1] embedding: google/gemini-embedding-001 | milvus: ~/.memsearch/milvus.db | collection: ms_...", "hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "# Recent Memory\\n\\n## ..."}}
EXIT=0
```

Standalone reproduction:
```bash
mkdir -p /tmp/mem && for i in $(seq 1 200); do : > /tmp/mem/$i.md; done
bash -c 'set -euo pipefail; find /tmp/mem -maxdepth 1 -type f -name "*.md" | sort -r | head -2'; echo "EXIT=$?"
# Before this patch's pattern: EXIT=141. With `|| true`: EXIT=0.
```