### PR TITLE
fix(plugins): make stop hook summary model configurable

### DIFF
--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -99,10 +99,17 @@ fi
 # Summarize the last turn into structured bullet points.
 # Default: use claude -p (plugin's own agent). If [llm] is configured, still
 # use claude -p since it's the most reliable path for Claude Code plugin.
+# Model priority: [llm].model config > haiku (default).
+_SUMMARY_MODEL=""
+if [ -n "$MEMSEARCH_CMD" ]; then
+  _SUMMARY_MODEL=$($MEMSEARCH_CMD config get llm.model 2>/dev/null || true)
+fi
+: "${_SUMMARY_MODEL:=haiku}"
+
 SUMMARY=""
 if command -v claude &>/dev/null; then
   SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
-    --model haiku \
+    --model "$_SUMMARY_MODEL" \
     --no-session-persistence \
     --no-chrome \
     --system-prompt "$SYSTEM_PROMPT" \


### PR DESCRIPTION
## Summary

- The stop hook hardcoded `--model haiku` when calling `claude -p` for session summarization
- This breaks for users who cannot directly access Claude API endpoints (e.g. users in China behind proxies using `ANTHROPIC_BASE_URL` to route to alternative models)
- The project already has a `[llm]` config section used by `compact.py`, but `stop.sh` ignored it
- Now reads model from `[llm].model` config, falling back to `haiku` when unset

## Why

Users in regions with restricted Claude API access often configure `ANTHROPIC_BASE_URL` to route through a proxy, and may need to use a different model instead of haiku. The hardcoded `haiku` made this impossible — the only workaround was to edit the hook script locally, which is fragile across updates.

The `[llm]` config section already exists for `compact.py` summarization. Using it here is consistent and requires no new config surface.

## Usage

Set the model in `~/.memsearch/config.toml`:

```toml
[llm]
model = "glm-5.1"
```

Or via CLI: `memsearch config set llm.model glm-5.1`

Unset = haiku (no behavior change for existing users).

## Test plan

- [x] Verified diff is minimal (8 insertions, 1 deletion)
- [x] Change is shell-only, no Python lint/test impact
- [x] Manual: set `llm.model` to a non-haiku value, verify `stop.sh` uses it → outputs configured model name
- [x] Manual: leave `llm.model` unset, verify fallback to `haiku` works → outputs `haiku`

🤖 Generated with [Claude Code](https://claude.com/claude-code)