### PR TITLE
fix(plugin): isolate stop-hook summarizer from MCP config

### DIFF
--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -110,6 +110,7 @@ if command -v claude &>/dev/null; then
     fi
   fi
   SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
+    --strict-mcp-config \
     --model "$SUMMARIZE_MODEL" \
     --no-session-persistence \
     --no-chrome \


### PR DESCRIPTION
## Summary

The stop-hook summarizer should not inherit user/project MCP configuration. For users with many MCP servers configured, loading those tools can overflow the summarizer context and produce an error string instead of a memory summary.

This change adds `--strict-mcp-config` to the child summarizer invocation so capture remains isolated from user MCP configuration while preserving the existing authentication path.

## Validation

- Verified the child summarizer can run without loading user MCP configuration.
- Resolved the current branch conflict with plugin-specific summarize model configuration.