### PR TITLE
Add plugin summarize model configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -287,8 +287,20 @@ llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
 
-[llm]                                  # LLM for compact & plugin summarization
-provider = ""                          # empty = plugin decides
+[llm]                                  # LLM for memsearch compact
+provider = ""                          # empty = compact defaults to openai
+model = ""
+
+[plugins.claude-code.summarize]        # optional plugin summarize model overrides
+model = ""                             # empty = plugin default/native model
+
+[plugins.codex.summarize]
+model = ""
+
+[plugins.opencode.summarize]
+model = ""
+
+[plugins.openclaw.summarize]
 model = ""
 
 [prompts]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,6 +178,18 @@ prompt_file = ""
 provider = ""
 model = ""
 
+[plugins.claude-code.summarize]
+model = ""
+
+[plugins.codex.summarize]
+model = ""
+
+[plugins.opencode.summarize]
+model = ""
+
+[plugins.openclaw.summarize]
+model = ""
+
 [prompts]
 compact = ""
 summarize = ""
@@ -212,10 +224,14 @@ provider = "openai"
 | `compact.llm_provider` | string | `openai` | *(deprecated)* LLM provider for compact — use `llm.provider` instead |
 | `compact.llm_model` | string | `""` | *(deprecated)* LLM model — use `llm.model` instead |
 | `compact.prompt_file` | string | `""` | *(deprecated)* Prompt file — use `prompts.compact` instead |
-| `llm.provider` | string | `""` | LLM provider (empty = plugin decides / compact defaults to openai) |
-| `llm.model` | string | `""` | LLM model override |
+| `llm.provider` | string | `""` | LLM provider for `memsearch compact` (empty = compact defaults to openai) |
+| `llm.model` | string | `""` | LLM model override for `memsearch compact` |
 | `llm.base_url` | string | `""` | OpenAI-compatible API base URL |
 | `llm.api_key` | string | `""` | API key (supports `env:VAR_NAME` syntax) |
+| `plugins.claude-code.summarize.model` | string | `""` | Claude Code plugin summarize model override (empty = plugin default) |
+| `plugins.codex.summarize.model` | string | `""` | Codex plugin summarize model override (empty = plugin default) |
+| `plugins.opencode.summarize.model` | string | `""` | OpenCode plugin summarize model override (empty = `small_model` / plugin default) |
+| `plugins.openclaw.summarize.model` | string | `""` | OpenClaw plugin summarize model override (empty = default agent model) |
 | `prompts.compact` | string | `""` | Custom prompt file for `memsearch compact` |
 | `prompts.summarize` | string | `""` | Custom prompt file for plugin session summarization |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -565,9 +565,21 @@ llm_provider = "openai"
 llm_model = ""
 prompt_file = ""
 
-[llm]                        # LLM settings for compact & plugin summarization
-provider = ""                # empty = plugin decides; "openai"/"anthropic"/"gemini"
+[llm]                        # LLM settings for memsearch compact
+provider = ""                # empty = compact defaults to openai
 model = ""
+
+[plugins.claude-code.summarize] # optional plugin-specific summarize model overrides
+model = ""                    # empty = Claude Code plugin default
+
+[plugins.codex.summarize]
+model = ""                    # empty = Codex plugin default
+
+[plugins.opencode.summarize]
+model = ""                    # empty = OpenCode small_model/default behavior
+
+[plugins.openclaw.summarize]
+model = ""                    # empty = OpenClaw default agent model
 
 [prompts]                    # custom prompt template files
 compact = ""                 # for memsearch compact

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -74,6 +74,20 @@ memsearch config list          # show all settings
 memsearch config get milvus.uri  # show specific value
 ```
 
+## Plugin Summarization Models
+
+Plugins keep their existing native/default summarization model unless you set a
+platform-specific override. These settings do not fall back to `llm.model`.
+
+```bash
+memsearch config set plugins.claude-code.summarize.model haiku
+memsearch config set plugins.codex.summarize.model gpt-5.1-codex-mini
+memsearch config set plugins.opencode.summarize.model anthropic/claude-haiku
+memsearch config set plugins.openclaw.summarize.model qwen3-coder
+```
+
+Leave the value empty or unset to preserve the current plugin behavior.
+
 ## Platform-Specific Config
 
 Each plugin may have additional configuration. See:

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -135,7 +135,7 @@ Step by step:
     [Claude Code] The issue is in the get_orders function...
     ```
 
-4. **Haiku summarization** -- the extracted turn is piped to `claude -p --model haiku` with a system prompt instructing it to write 2-6 third-person bullet points. The third-person framing ("User asked about...", "Agent implemented...") makes the summaries more useful as memory entries than first-person notes.
+4. **Haiku summarization** -- the extracted turn is piped to `claude -p --model haiku` with a system prompt instructing it to write 2-6 third-person bullet points. Set `plugins.claude-code.summarize.model` to override only this capture model; empty or unset keeps the Haiku default. The third-person framing ("User asked about...", "Agent implemented...") makes the summaries more useful as memory entries than first-person notes.
 
 5. **Append with anchors** -- the summary is written to `.memsearch/memory/YYYY-MM-DD.md` under a `### HH:MM` heading with an HTML comment anchor:
     ```markdown

--- a/docs/platforms/codex/how-it-works.md
+++ b/docs/platforms/codex/how-it-works.md
@@ -135,6 +135,8 @@ MEMSEARCH_NO_WATCH=1 \
 
 This avoids assuming `~/.codex/auth.json` exists. Installations that authenticate through Codex's default keyring flow still work, and the child `codex exec` cannot recurse because hooks are disabled explicitly.
 
+Set `plugins.codex.summarize.model` to override only this capture model. Empty or unset keeps the built-in Codex plugin default, and this setting does not fall back to `llm.model`.
+
 ### Local Fallback
 
 If `codex exec` is unavailable or returns empty output, the hook falls back to raw text truncation:

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -18,6 +18,13 @@ memsearch provides plugins for 4 AI coding agent platforms. All plugins share th
 | **Embedding default** | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) |
 | **API key required** | No (ONNX default) | No (ONNX default) | No (ONNX default) | No (ONNX default) |
 
+Each plugin keeps its current summarization model when the plugin-specific model
+setting is empty. To override one plugin only, set
+`plugins.<platform>.summarize.model`, for example
+`plugins.claude-code.summarize.model`, `plugins.codex.summarize.model`,
+`plugins.opencode.summarize.model`, or `plugins.openclaw.summarize.model`.
+These plugin settings do not fall back to `llm.model`.
+
 ---
 
 ## Shared Architecture

--- a/docs/platforms/openclaw/how-it-works.md
+++ b/docs/platforms/openclaw/how-it-works.md
@@ -12,11 +12,11 @@
 
 ## TypeScript Plugin Architecture
 
-The plugin is a single `index.ts` file that registers tools, hooks, and a CLI subcommand using OpenClaw's plugin API:
+The plugin source is `index.ts`, built to `index.js` for OpenClaw 2026.5+ runtime loading. It registers tools, hooks, and a CLI subcommand using OpenClaw's plugin API:
 
 ```mermaid
 graph TB
-    subgraph "Plugin Registration (index.ts)"
+    subgraph "Plugin Registration (index.ts -> index.js)"
         TOOLS["registerTool (factory pattern)<br/>memory_search · memory_get · memory_transcript"]
         HOOKS["Event hooks<br/>before_agent_start · agent_end · session_start"]
         CLI["registerCli<br/>openclaw memsearch search/index/status"]
@@ -81,7 +81,9 @@ sequenceDiagram
     Plugin->>Plugin: memsearch index (background)
 ```
 
-The plugin extracts the last user question and assistant response from `event.messages`, summarizes them via LLM, and appends the summary to the daily markdown file. No debounce or noise filtering is needed — `agent_end` provides a clean, complete message history for each turn.
+The plugin extracts the last user question and assistant response from `event.messages`, summarizes them via LLM, and appends the summary to the daily markdown file. Set `plugins.openclaw.summarize.model` to override only this capture model; empty or unset keeps the default OpenClaw agent model, with no fallback to `llm.model`. No debounce or noise filtering is needed — `agent_end` provides a clean, complete message history for each turn.
+
+OpenClaw 2026.5+ requires third-party plugins to opt in before reading raw conversation content from `agent_end`. The installer sets `plugins.entries.memsearch.hooks.allowConversationAccess = true` for capture and `plugins.entries.memsearch.hooks.allowPromptInjection = true` for recent-memory injection.
 
 !!! note "Known limitations"
 
@@ -186,7 +188,8 @@ The `<!-- session:... transcript:... -->` anchors enable L3 drill-down: the `mem
 plugins/openclaw/
 ├── package.json                    # npm package with openclaw peer dependency
 ├── openclaw.plugin.json            # Plugin config schema (kind: memory)
-├── index.ts                        # Main plugin: tools, hooks, helpers (~800 lines)
+├── index.ts                        # Main plugin source: tools, hooks, helpers
+├── index.js                        # Built runtime entry loaded by OpenClaw
 ├── install.sh                      # Installation script
 ├── skills/
 │   └── memory-recall/
@@ -200,7 +203,8 @@ plugins/openclaw/
 |------|---------|
 | `package.json` | npm package with `openclaw >=2026.3.11` as peer dependency |
 | `openclaw.plugin.json` | Plugin configuration schema: `provider`, `autoCapture`, `autoRecall` settings |
-| `index.ts` | Main plugin entry. Registers 3 tools (factory pattern), 3 event hooks, and CLI subcommand |
+| `index.ts` | Main plugin source. Registers 3 tools (factory pattern), 3 event hooks, and CLI subcommand |
+| `index.js` | Built runtime entry required by OpenClaw 2026.5+ plugin installs |
 | `install.sh` | Installation script: checks memsearch availability, registers plugin |
 | `SKILL.md` | Memory recall skill guide -- helps the LLM decide when and how to use the memory tools |
 | `derive-collection.sh` | Generates deterministic per-agent Milvus collection names |

--- a/docs/platforms/openclaw/installation.md
+++ b/docs/platforms/openclaw/installation.md
@@ -12,9 +12,13 @@ The plugin is published on [ClawHub](https://clawhub.ai/plugins/memsearch).
 
 ```bash
 # 1. Install the plugin
-openclaw plugins install clawhub:memsearch
+openclaw plugins install --force clawhub:memsearch
 
-# 2. Restart the gateway
+# 2. Allow memsearch to read conversation turns and inject recall context
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
+
+# 3. Restart the gateway
 openclaw gateway restart
 ```
 
@@ -25,9 +29,13 @@ openclaw gateway restart
 git clone https://github.com/zilliztech/memsearch.git
 
 # 2. Install the OpenClaw plugin
-openclaw plugins install ./memsearch/plugins/openclaw
+openclaw plugins install --force ./memsearch/plugins/openclaw
 
-# 3. Restart the gateway
+# 3. Allow memsearch to read conversation turns and inject recall context
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
+
+# 4. Restart the gateway
 openclaw gateway restart
 ```
 
@@ -50,7 +58,9 @@ For Milvus backend configuration, run `memsearch config set milvus.uri <uri>`.
 For ClawHub installs, install the plugin again and restart the gateway:
 
 ```bash
-openclaw plugins install clawhub:memsearch
+openclaw plugins install --force clawhub:memsearch
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
 openclaw gateway restart
 ```
 
@@ -59,7 +69,9 @@ For source installs, pull the latest repo, reinstall from the local plugin direc
 ```bash
 cd memsearch
 git pull
-openclaw plugins install ./plugins/openclaw
+openclaw plugins install --force ./plugins/openclaw
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
 openclaw gateway restart
 ```
 

--- a/docs/platforms/opencode/how-it-works.md
+++ b/docs/platforms/opencode/how-it-works.md
@@ -106,7 +106,7 @@ result = subprocess.run(
 
 The isolated `XDG_CONFIG_HOME` contains a copy of `opencode.json` (for provider/model config) but **no `plugins/` directory** -- so the memsearch plugin doesn't load in the summarization subprocess. The `MEMSEARCH_NO_WATCH` env var provides an additional guard.
 
-The daemon also reads `small_model` from `opencode.json` config, using a lighter model for summarization when available.
+The daemon also reads `small_model` from `opencode.json` config, using a lighter model for summarization when available. Set `plugins.opencode.summarize.model` to override only this capture model; empty or unset keeps the current `small_model` / plugin default behavior. This setting does not fall back to `llm.model`.
 
 ### Daemon Self-Management
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -180,7 +180,7 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
 1. **Guards against recursion.** Checks `stop_hook_active` to prevent infinite loops (since the hook itself calls `claude -p`).
 2. **Validates the transcript.** Skips if the transcript file is missing or has fewer than 3 lines.
 3. **Extracts the last turn.** Calls `parse-transcript.sh` (Python3 inline, no `jq` dependency), which finds the last real user message and extracts everything from there to EOF. Skips progress, `file-history-snapshot`, system, and thinking blocks. Formats output with clear role labels (`[Human]`, `[Claude Code]`, `[Claude Code calls tool]`, `[Tool output]`/`[Tool error]`) so the summarizer treats the content as a third-party transcript. Tool results are truncated to 1000 characters (configurable via `MEMSEARCH_MAX_RESULT_CHARS`).
-4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with an external-observer system prompt requesting 2-6 third-person bullet points in the same language as the user's message.
+4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with an external-observer system prompt requesting 2-6 third-person bullet points in the same language as the user's message. To override only this plugin's summarize model, set `plugins.claude-code.summarize.model`; empty or unset keeps the Haiku default.
 5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. Then runs `memsearch index` to ensure immediate indexing.
 
 #### SessionEnd

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -97,12 +97,20 @@ else
 fi
 
 # Summarize the last turn into structured bullet points.
-# Default: use claude -p (plugin's own agent). If [llm] is configured, still
-# use claude -p since it's the most reliable path for Claude Code plugin.
+# Default: use claude -p with the plugin default model. A plugin-specific
+# summarize model override can replace the model without changing provider
+# routing.
 SUMMARY=""
 if command -v claude &>/dev/null; then
+  SUMMARIZE_MODEL="haiku"
+  if [ -n "$MEMSEARCH_CMD" ]; then
+    CONFIG_MODEL=$($MEMSEARCH_CMD config get plugins.claude-code.summarize.model 2>/dev/null || true)
+    if [ -n "$CONFIG_MODEL" ]; then
+      SUMMARIZE_MODEL="$CONFIG_MODEL"
+    fi
+  fi
   SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
-    --model haiku \
+    --model "$SUMMARIZE_MODEL" \
     --no-session-persistence \
     --no-chrome \
     --system-prompt "$SYSTEM_PROMPT" \

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -85,6 +85,16 @@ Default is Milvus Lite (local `.db` file). For larger memory stores or team shar
 memsearch config set milvus.uri http://localhost:19530
 ```
 
+### Summarization model
+
+The Stop hook uses its built-in Codex summarize model by default. To override only this plugin's capture model:
+
+```bash
+memsearch config set plugins.codex.summarize.model gpt-5.1-codex-mini
+```
+
+Leave it empty or unset to keep the current default. This setting does not fall back to `llm.model`.
+
 ## Memory files
 
 Each project stores memory under `<project>/.memsearch/memory/`:

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -102,6 +102,14 @@ run_worker() {
 Here is the transcript:
 
 ${CONTENT}"
+    local SUMMARIZE_MODEL="gpt-5.1-codex-mini"
+    if [ -n "$MEMSEARCH_CMD" ]; then
+      local CONFIG_MODEL
+      CONFIG_MODEL=$($MEMSEARCH_CMD config get plugins.codex.summarize.model 2>/dev/null || true)
+      if [ -n "$CONFIG_MODEL" ]; then
+        SUMMARIZE_MODEL="$CONFIG_MODEL"
+      fi
+    fi
 
     if command -v timeout &>/dev/null; then
       SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_IN_STOP_WORKER=1 timeout 30 codex exec \
@@ -110,7 +118,7 @@ ${CONTENT}"
         -s read-only \
         -c features.codex_hooks=false \
         -c model_reasoning_effort='"low"' \
-        -m gpt-5.1-codex-mini \
+        -m "$SUMMARIZE_MODEL" \
         "$LLM_PROMPT" 2>/dev/null || true)
     else
       SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_IN_STOP_WORKER=1 codex exec \
@@ -119,7 +127,7 @@ ${CONTENT}"
         -s read-only \
         -c features.codex_hooks=false \
         -c model_reasoning_effort='"low"' \
-        -m gpt-5.1-codex-mini \
+        -m "$SUMMARIZE_MODEL" \
         "$LLM_PROMPT" 2>/dev/null || true)
     fi
   fi

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -16,9 +16,13 @@ Automatic persistent memory for [OpenClaw](https://github.com/openclaw/openclaw)
 uv tool install "memsearch[onnx]"
 
 # 2. Install the plugin from ClawHub
-openclaw plugins install clawhub:memsearch
+openclaw plugins install --force clawhub:memsearch
 
-# 3. Restart the gateway
+# 3. Allow memsearch to read conversation turns and inject recall context
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
+
+# 4. Restart the gateway
 openclaw gateway restart
 ```
 
@@ -31,9 +35,13 @@ uv tool install "memsearch[onnx]"
 # 2. Clone the repo and install the plugin
 git clone https://github.com/zilliztech/memsearch.git
 cd memsearch
-openclaw plugins install ./plugins/openclaw
+openclaw plugins install --force ./plugins/openclaw
 
-# 3. Restart the gateway
+# 3. Allow memsearch to read conversation turns and inject recall context
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true
+
+# 4. Restart the gateway
 openclaw gateway restart
 ```
 
@@ -97,6 +105,14 @@ Optional settings via `openclaw plugins config memsearch`:
 | `provider` | `onnx` | Embedding provider (onnx, openai, google, voyage, jina, mistral, ollama) |
 | `autoCapture` | `true` | Auto-capture conversation summaries after each turn |
 | `autoRecall` | `true` | Auto-inject recent memories at agent start |
+
+To override only the OpenClaw capture summarization model:
+
+```bash
+memsearch config set plugins.openclaw.summarize.model qwen3-coder
+```
+
+Leave it empty or unset to keep the default OpenClaw agent model. This setting does not fall back to `llm.model`.
 
 ## Memory files
 

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -1,0 +1,595 @@
+import {
+  readFileSync,
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  writeFileSync,
+  unlinkSync
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+function getMemsearchDir(projectDir) {
+  return join(projectDir, ".memsearch");
+}
+function getMemoryDir(projectDir) {
+  return join(getMemsearchDir(projectDir), "memory");
+}
+function ensureDir(dir) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+function getRecentMemories(memDir, count = 2, maxLinesPerFile = 30) {
+  if (!existsSync(memDir)) return "";
+  const files = readdirSync(memDir).filter((f) => f.endsWith(".md")).sort().slice(-count);
+  if (files.length === 0) return "";
+  const summary = [];
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(memDir, file), "utf-8");
+      const lines = content.split("\n").filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- ")).slice(0, maxLinesPerFile);
+      if (lines.length > 0) {
+        summary.push(`[${file}]`, ...lines);
+      }
+    } catch {
+    }
+  }
+  if (summary.length === 0) {
+    return `You have ${files.length} past memory file(s). Use the memory_search tool when the user's question could benefit from historical context.`;
+  }
+  return `Recent memories (use memory_search for full search):
+${summary.join("\n")}`;
+}
+function shellEscape(s) {
+  return s.replace(/'/g, "'\\''");
+}
+const NOISE_PATTERNS = [
+  /^\[plugins\]/,
+  /^\[tools\]/,
+  /^\[agent\//,
+  /^Config warnings/,
+  /^\[memsearch\]/,
+  /^WARNING:/,
+  /^Error:/,
+  /^Config invalid/,
+  /^Config overwrite/,
+  /plugins\.allow is empty/,
+  /Plugin loaded\./,
+  /autoCapture:/,
+  /^Sender \(untrusted/,
+  /^```json$/,
+  /^```$/,
+  /^"label":/,
+  /^"id":/,
+  /^"name":/,
+  /^"username":/,
+  /^\{$/,
+  /^\}$/,
+  /^# Recent Memory/,
+  /^## \d{4}-\d{2}-\d{2}\.md/,
+  /^## Session \d/,
+  /^### \d{2}:\d{2}$/,
+  /^\[\[reply_to_\w+\]\]/
+];
+function isNoiseLine(line) {
+  const trimmed = line.trim();
+  return NOISE_PATTERNS.some((pat) => pat.test(trimmed));
+}
+function extractText(content) {
+  let raw;
+  if (typeof content === "string") {
+    raw = content;
+  } else if (Array.isArray(content)) {
+    raw = content.filter((c) => c.type === "text").map((c) => c.text || "").join("\n");
+  } else {
+    return "";
+  }
+  return raw.split("\n").filter((line) => !isNoiseLine(line)).join("\n").trim();
+}
+function stripInjectedContext(text) {
+  let cleaned = text.replace(/Recent memories \(use memory_search for full search\):[\s\S]*?(?=\n\n(?!\s|-)|\n*$)/g, "");
+  cleaned = cleaned.replace(/Conversation info \(untrusted metadata\):[\s\S]*?(?=\n\n(?!\s|")|\n*$)/g, "");
+  cleaned = cleaned.replace(/\[message_id:.*?\]\n/g, "");
+  return cleaned.trim();
+}
+function extractLastTurn(messages) {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    const role = msg?.role || msg?.message?.role;
+    if (role === "user") {
+      const content = msg?.content || msg?.message?.content;
+      const text = extractText(content);
+      if (text.length > 10) {
+        lastUserIdx = i;
+        break;
+      }
+    }
+  }
+  if (lastUserIdx === -1) return null;
+  const parts = [];
+  for (let i = lastUserIdx; i < messages.length; i++) {
+    const msg = messages[i];
+    const role = msg?.role || msg?.message?.role;
+    const content = msg?.content || msg?.message?.content;
+    let text = extractText(content);
+    if (!text || text.length < 5) continue;
+    if (role === "user") {
+      text = stripInjectedContext(text);
+      if (!text || text.length < 5) continue;
+      parts.push(`[Human]: ${text}`);
+    } else if (role === "assistant") {
+      parts.push(`[Assistant]: ${text.slice(0, 3e3)}`);
+    }
+  }
+  if (parts.length === 0) return null;
+  return parts.join("\n\n");
+}
+function envWithOverrides(overrides) {
+  const env = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== void 0) env[k] = v;
+  }
+  return { ...env, ...overrides };
+}
+var index_default = {
+  id: "memsearch",
+  name: "memsearch",
+  description: "Semantic memory search \u2014 remembers what you worked on across sessions",
+  kind: "memory",
+  register(api) {
+    const pluginConfig = api.pluginConfig || {};
+    const isChildProcess = !!process.env.MEMSEARCH_NO_WATCH;
+    const autoCapture = pluginConfig.autoCapture !== false && !isChildProcess;
+    const autoRecall = pluginConfig.autoRecall !== false && !isChildProcess;
+    const logger = api.logger;
+    const home = process.env.HOME || "~";
+    async function runCmd(argv, opts) {
+      return api.runtime.system.runCommandWithTimeout(argv, opts || {});
+    }
+    let _memsearchCmd = null;
+    async function getMemsearchCmd() {
+      if (_memsearchCmd) return _memsearchCmd;
+      const h = process.env.HOME || "";
+      try {
+        const r = await runCmd(["which", "memsearch"], { timeoutMs: 5e3 });
+        if (r.code === 0) {
+          _memsearchCmd = "memsearch";
+          return _memsearchCmd;
+        }
+      } catch {
+      }
+      const uvxPath = join(h, ".local", "bin", "uvx");
+      if (existsSync(uvxPath)) {
+        _memsearchCmd = `${uvxPath} --from 'memsearch[onnx]' memsearch`;
+        return _memsearchCmd;
+      }
+      try {
+        const r = await runCmd(["which", "uvx"], { timeoutMs: 5e3 });
+        if (r.code === 0) {
+          _memsearchCmd = "uvx --from 'memsearch[onnx]' memsearch";
+          return _memsearchCmd;
+        }
+      } catch {
+      }
+      _memsearchCmd = "memsearch";
+      return _memsearchCmd;
+    }
+    async function getMemsearchConfigValue(key) {
+      const cmd = await getMemsearchCmd();
+      const r = await runCmd(
+        ["bash", "-c", `${cmd} config get '${shellEscape(key)}'`],
+        { timeoutMs: 5e3 }
+      );
+      return r.stdout?.trim() || "";
+    }
+    let _collectionNameFor = "";
+    let _collectionName = "ms_openclaw_default";
+    async function getCollectionName() {
+      if (_collectionNameFor === projectDir) return _collectionName;
+      const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
+      try {
+        const r = await runCmd(["bash", script, projectDir], { timeoutMs: 5e3 });
+        if (r.code === 0 && r.stdout?.trim()) {
+          _collectionName = r.stdout.trim();
+        } else {
+          _collectionName = "ms_openclaw_default";
+        }
+      } catch {
+        _collectionName = "ms_openclaw_default";
+      }
+      _collectionNameFor = projectDir;
+      return _collectionName;
+    }
+    let agentId = "main";
+    let projectDir = join(home, ".openclaw", "workspace");
+    let memsearchDir = join(projectDir, ".memsearch");
+    let memoryDir = join(memsearchDir, "memory");
+    function updateAgentContext(ctx) {
+      const newId = ctx?.agentId;
+      const newWorkspace = ctx?.workspaceDir;
+      if (newId && (newId !== agentId || newWorkspace && newWorkspace !== projectDir)) {
+        agentId = newId;
+        projectDir = newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
+        memsearchDir = join(projectDir, ".memsearch");
+        memoryDir = join(memsearchDir, "memory");
+        _collectionNameFor = "";
+        logger?.info?.(
+          `[memsearch] Agent context updated: ${agentId}, dir: ${projectDir}`
+        );
+      }
+    }
+    api.registerTool(
+      (ctx) => {
+        updateAgentContext(ctx);
+        return {
+          name: "memory_search",
+          label: "Memory Search",
+          description: "Search past conversation memories using memsearch semantic search. Returns relevant chunks from past sessions, including dates, topics discussed, and code referenced. Powered by Milvus hybrid search (BM25 + dense vectors + RRF reranking).",
+          parameters: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: "Search query \u2014 describe what you want to find"
+              },
+              top_k: {
+                type: "number",
+                description: "Number of results to return (default: 5)"
+              }
+            },
+            required: ["query"]
+          },
+          async execute(_toolCallId, params) {
+            const topK = params.top_k || 5;
+            try {
+              const cmd = await getMemsearchCmd();
+              const collection = await getCollectionName();
+              const result = await runCmd(
+                [
+                  "bash",
+                  "-c",
+                  `${cmd} search '${shellEscape(params.query)}' --top-k ${topK} --json-output --collection ${collection}`
+                ],
+                { timeoutMs: 3e4 }
+              );
+              const output = result.stdout || result.stderr || "No results";
+              return { content: [{ type: "text", text: output }] };
+            } catch (e) {
+              return {
+                content: [
+                  { type: "text", text: `Search failed: ${e.message}` }
+                ]
+              };
+            }
+          }
+        };
+      },
+      { name: "memory_search" }
+    );
+    api.registerTool(
+      (ctx) => {
+        updateAgentContext(ctx);
+        return {
+          name: "memory_get",
+          label: "Memory Get",
+          description: "Expand a memory chunk to see the full markdown section with surrounding context. Use after memory_search to get details about a specific result.",
+          parameters: {
+            type: "object",
+            properties: {
+              chunk_hash: {
+                type: "string",
+                description: "The chunk_hash from a search result to expand"
+              }
+            },
+            required: ["chunk_hash"]
+          },
+          async execute(_toolCallId, params) {
+            try {
+              const cmd = await getMemsearchCmd();
+              const collection = await getCollectionName();
+              const result = await runCmd(
+                [
+                  "bash",
+                  "-c",
+                  `${cmd} expand '${shellEscape(params.chunk_hash)}' --collection ${collection}`
+                ],
+                { timeoutMs: 15e3 }
+              );
+              const output = result.stdout || result.stderr || "No content";
+              return { content: [{ type: "text", text: output }] };
+            } catch (e) {
+              return {
+                content: [
+                  { type: "text", text: `Expand failed: ${e.message}` }
+                ]
+              };
+            }
+          }
+        };
+      },
+      { name: "memory_get" }
+    );
+    api.registerTool(
+      (ctx) => {
+        updateAgentContext(ctx);
+        return {
+          name: "memory_transcript",
+          label: "Memory Transcript",
+          description: "Retrieve the original conversation from a past session transcript. Use after memory_get when the expanded result contains a transcript anchor (<!-- session:UUID transcript:PATH -->). Returns the formatted dialogue with [Human] and [Assistant] labels.",
+          parameters: {
+            type: "object",
+            properties: {
+              transcript_path: {
+                type: "string",
+                description: "Path to the .jsonl transcript file (from the anchor comment)"
+              }
+            },
+            required: ["transcript_path"]
+          },
+          async execute(_toolCallId, params) {
+            try {
+              const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.sh");
+              const result = await runCmd(
+                ["bash", scriptPath, params.transcript_path],
+                { timeoutMs: 15e3 }
+              );
+              const output = result.stdout?.trim() || result.stderr || "No transcript content";
+              return { content: [{ type: "text", text: output }] };
+            } catch (e) {
+              return {
+                content: [
+                  { type: "text", text: `Transcript parse failed: ${e.message}` }
+                ]
+              };
+            }
+          }
+        };
+      },
+      { name: "memory_transcript" }
+    );
+    if (autoRecall) {
+      api.on("before_agent_start", async () => {
+        try {
+          const context = getRecentMemories(memoryDir);
+          if (context) {
+            return { prependContext: context };
+          }
+        } catch (e) {
+          logger?.warn?.(
+            `[memsearch] Failed to inject memories: ${e.message}`
+          );
+        }
+        return {};
+      });
+    }
+    if (autoCapture) {
+      async function summarizeWithLLM(turnText) {
+        const agentName = "OpenClaw";
+        let systemPrompt = "";
+        let customPromptFile = "";
+        try {
+          customPromptFile = await getMemsearchConfigValue("prompts.summarize");
+        } catch {
+        }
+        if (customPromptFile && existsSync(customPromptFile)) {
+          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+        } else {
+          const builtinPath = join(PLUGIN_DIR, "prompts", "summarize.txt");
+          if (existsSync(builtinPath)) {
+            systemPrompt = readFileSync(builtinPath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+          } else {
+            systemPrompt = "You are a third-person note-taker. Summarize the transcript as 2-6 bullet points. Write in third person. Output ONLY bullet points.";
+          }
+        }
+        let summarizeModel = "";
+        try {
+          summarizeModel = await getMemsearchConfigValue("plugins.openclaw.summarize.model");
+        } catch {
+        }
+        try {
+          const msgText = `${systemPrompt}
+
+Transcript:
+${turnText}`;
+          const tmpFile = `/tmp/memsearch-summarize-${Date.now()}.txt`;
+          const modelArg = summarizeModel ? ` --model ${JSON.stringify(summarizeModel)}` : "";
+          const shellCmd = `openclaw agent --local --session-id memsearch-summarize${modelArg} -m ${JSON.stringify(msgText)} > ${JSON.stringify(tmpFile)} 2>/dev/null`;
+          await runCmd(["bash", "-c", shellCmd], {
+            timeoutMs: 6e4,
+            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" })
+          });
+          if (existsSync(tmpFile)) {
+            const raw = readFileSync(tmpFile, "utf-8");
+            try {
+              unlinkSync(tmpFile);
+            } catch {
+            }
+            const output = raw.split("\n").filter((line) => !line.startsWith("[plugins]") && !line.startsWith("[agents]")).join("\n").trim();
+            if (output && output.includes("- ")) {
+              return output;
+            }
+          }
+        } catch {
+        }
+        return turnText.length > 1500 ? turnText.slice(0, 1500) + "\n..." : turnText;
+      }
+      async function writeTurnCapture(turnText, sessionId) {
+        try {
+          if (turnText.length < 1) return;
+          ensureDir(memoryDir);
+          const today = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
+          const now = (/* @__PURE__ */ new Date()).toTimeString().slice(0, 5);
+          const memoryFile = join(memoryDir, `${today}.md`);
+          if (!existsSync(memoryFile)) {
+            writeFileSync(
+              memoryFile,
+              `# ${today}
+
+## Session ${now}
+
+`,
+              "utf-8"
+            );
+          }
+          let summary;
+          try {
+            summary = await summarizeWithLLM(turnText);
+          } catch {
+            summary = turnText;
+          }
+          const cleanSummary = summary.split("\n").filter((line) => !isNoiseLine(line)).join("\n").trim();
+          if (!cleanSummary) return;
+          let anchor = "";
+          if (sessionId) {
+            const transcriptPath = `${home}/.openclaw/agents/${agentId}/sessions/${sessionId}.jsonl`;
+            anchor = `<!-- session:${sessionId} transcript:${transcriptPath} -->
+`;
+          }
+          const entry = `### ${now}
+${anchor}${cleanSummary}
+
+`;
+          appendFileSync(memoryFile, entry, "utf-8");
+          const cmd = await getMemsearchCmd();
+          const collection = await getCollectionName();
+          runCmd(
+            [
+              "bash",
+              "-c",
+              `${cmd} index '${shellEscape(memoryDir)}' --collection ${collection}`
+            ],
+            { timeoutMs: 6e4 }
+          ).catch((err) => {
+            logger?.warn?.(`[memsearch] Index failed: ${err.message}`);
+          });
+          logger?.info?.(`[memsearch] Captured turn summary \u2192 ${memoryFile}`);
+        } catch (e) {
+          logger?.warn?.(`[memsearch] Capture failed: ${e.message}`);
+        }
+      }
+      api.on("agent_end", async (event) => {
+        const messages = event.messages || [];
+        if (messages.length < 2) return;
+        const lastTurn = extractLastTurn(messages);
+        if (!lastTurn || lastTurn.length < 50) return;
+        const sessionId = event.sessionId || "";
+        writeTurnCapture(lastTurn, sessionId);
+      });
+    }
+    api.on("session_start", async () => {
+      try {
+        const cmd = await getMemsearchCmd();
+        const collection = await getCollectionName();
+        const configFile = join(home, ".memsearch", "config.toml");
+        const localConfig = join(projectDir, ".memsearch.toml");
+        if (!existsSync(configFile) && !existsSync(localConfig)) {
+          try {
+            await runCmd(
+              ["bash", "-c", `${cmd} config set embedding.provider onnx`],
+              { timeoutMs: 5e3 }
+            );
+          } catch {
+          }
+        }
+        if (existsSync(memoryDir)) {
+          runCmd(
+            [
+              "bash",
+              "-c",
+              `${cmd} index '${shellEscape(memoryDir)}' --collection ${collection}`
+            ],
+            { timeoutMs: 12e4 }
+          ).catch((err) => {
+            logger?.warn?.(
+              `[memsearch] Initial index failed: ${err.message}`
+            );
+          });
+        }
+      } catch (e) {
+        logger?.warn?.(`[memsearch] session_start failed: ${e.message}`);
+      }
+    });
+    api.registerCli(({ program }) => {
+      const cmd = program.command("memsearch").description("Semantic memory search and management");
+      cmd.command("search <query>").description("Search past memories").option("-k, --top-k <n>", "Number of results", "5").action(async (query, opts) => {
+        try {
+          const memsearch = await getMemsearchCmd();
+          const collection = await getCollectionName();
+          const result = await runCmd(
+            [
+              "bash",
+              "-c",
+              `${memsearch} search '${shellEscape(query)}' --top-k ${opts.topK || 5} --collection ${collection}`
+            ],
+            { timeoutMs: 3e4 }
+          );
+          if (result.stdout) process.stdout.write(result.stdout);
+          if (result.stderr) process.stderr.write(result.stderr);
+        } catch (e) {
+          console.error(`Search failed: ${e.message}`);
+        }
+      });
+      cmd.command("index [directory]").description("Index memory files").action(async (directory) => {
+        const dir = directory || memoryDir;
+        try {
+          const memsearch = await getMemsearchCmd();
+          const collection = await getCollectionName();
+          const result = await runCmd(
+            [
+              "bash",
+              "-c",
+              `${memsearch} index '${shellEscape(dir)}' --collection ${collection}`
+            ],
+            { timeoutMs: 12e4 }
+          );
+          if (result.stdout) process.stdout.write(result.stdout);
+          if (result.stderr) process.stderr.write(result.stderr);
+        } catch (e) {
+          console.error(`Index failed: ${e.message}`);
+        }
+      });
+      cmd.command("status").description("Show memsearch status").action(async () => {
+        const memsearch = await getMemsearchCmd();
+        const collection = await getCollectionName();
+        console.log(`Agent:       ${agentId}`);
+        console.log(`Collection:  ${collection}`);
+        console.log(`Memory dir:  ${memoryDir}`);
+        console.log(`Provider:    ${pluginConfig.provider || "onnx"}`);
+        console.log(`CLI:         ${memsearch}`);
+        console.log(`AutoCapture: ${autoCapture}`);
+        console.log(`AutoRecall:  ${autoRecall}`);
+        try {
+          const result = await runCmd(
+            ["bash", "-c", `${memsearch} stats --collection ${collection}`],
+            { timeoutMs: 1e4 }
+          );
+          if (result.stdout) process.stdout.write(result.stdout);
+        } catch {
+          console.log("Stats: (unavailable \u2014 collection may not exist yet)");
+        }
+      });
+    }, {
+      descriptors: [{
+        name: "memsearch",
+        description: "Semantic memory search and management",
+        hasSubcommands: true
+      }]
+    });
+    getCollectionName().then((name) => {
+      logger?.info?.(
+        `[memsearch] Plugin loaded. Collection: ${name}, autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`
+      );
+    }).catch(() => {
+      logger?.info?.(
+        `[memsearch] Plugin loaded. autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`
+      );
+    });
+  }
+};
+export {
+  index_default as default
+};

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -293,6 +293,15 @@ export default {
       return _memsearchCmd;
     }
 
+    async function getMemsearchConfigValue(key: string): Promise<string> {
+      const cmd = await getMemsearchCmd();
+      const r = await runCmd(
+        ["bash", "-c", `${cmd} config get '${shellEscape(key)}'`],
+        { timeoutMs: 5000 }
+      );
+      return r.stdout?.trim() || "";
+    }
+
     // --- Lazy-cached collection name derivation ---
     let _collectionNameFor = "";
     let _collectionName = "ms_openclaw_default";
@@ -544,8 +553,7 @@ export default {
         // Try reading user-custom prompt from config
         let customPromptFile = "";
         try {
-          const r = await runCmd([memsearchCmd, "config", "get", "prompts.summarize"], { timeoutMs: 5000 });
-          customPromptFile = r.stdout?.trim() || "";
+          customPromptFile = await getMemsearchConfigValue("prompts.summarize");
         } catch { /* ignore */ }
 
         if (customPromptFile && existsSync(customPromptFile)) {
@@ -562,13 +570,19 @@ export default {
           }
         }
 
-        // 1. Try openclaw agent (uses user's default model)
+        let summarizeModel = "";
+        try {
+          summarizeModel = await getMemsearchConfigValue("plugins.openclaw.summarize.model");
+        } catch { /* ignore */ }
+
+        // 1. Try openclaw agent (uses user's default model unless overridden)
         // Redirect stdout to a temp file because runCommandWithTimeout
         // truncates stdout before the LLM response arrives.
         try {
           const msgText = `${systemPrompt}\n\nTranscript:\n${turnText}`;
           const tmpFile = `/tmp/memsearch-summarize-${Date.now()}.txt`;
-          const shellCmd = `openclaw agent --local --session-id memsearch-summarize -m ${JSON.stringify(msgText)} > ${JSON.stringify(tmpFile)} 2>/dev/null`;
+          const modelArg = summarizeModel ? ` --model ${JSON.stringify(summarizeModel)}` : "";
+          const shellCmd = `openclaw agent --local --session-id memsearch-summarize${modelArg} -m ${JSON.stringify(msgText)} > ${JSON.stringify(tmpFile)} 2>/dev/null`;
           await runCmd(["bash", "-c", shellCmd], {
             timeoutMs: 60000,
             env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" }),

--- a/plugins/openclaw/install.sh
+++ b/plugins/openclaw/install.sh
@@ -14,6 +14,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "=== memsearch OpenClaw plugin installer ==="
 
+for p in "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/bin" "/usr/local/bin"; do
+  [[ -d "$p" ]] && [[ ":$PATH:" != *":$p:"* ]] && export PATH="$p:$PATH"
+done
+
 # 1. Ensure memsearch is available
 if command -v memsearch &>/dev/null; then
   echo "[OK] memsearch found: $(memsearch --version 2>/dev/null || echo 'unknown')"
@@ -46,7 +50,12 @@ fi
 # 3. Install the plugin
 echo ""
 echo "Installing memsearch plugin into OpenClaw..."
-openclaw plugins install "$SCRIPT_DIR"
+openclaw plugins install --force "$SCRIPT_DIR"
+
+# OpenClaw 2026.5+ requires non-bundled plugins to explicitly opt in before
+# they can read conversation content in agent_end or mutate prompt context.
+openclaw config set plugins.entries.memsearch.hooks.allowConversationAccess true >/dev/null
+openclaw config set plugins.entries.memsearch.hooks.allowPromptInjection true >/dev/null
 
 echo ""
 echo "=== Installation complete ==="

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -3,8 +3,11 @@
   "version": "0.3.2",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
+  "scripts": {
+    "build": "esbuild index.ts --platform=node --format=esm --outfile=index.js"
+  },
   "openclaw": {
-    "extensions": ["./index.ts"],
+    "extensions": ["./index.js"],
     "compat": {
       "pluginApi": ">=2026.3.11"
     },
@@ -15,5 +18,8 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.3.11"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.1"
   }
 }

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -143,6 +143,14 @@ memsearch config set embedding.provider openai
 export OPENAI_API_KEY=sk-...
 ```
 
+To override only the OpenCode capture summarization model:
+
+```bash
+memsearch config set plugins.opencode.summarize.model anthropic/claude-haiku
+```
+
+Leave it empty or unset to keep the current `small_model` / plugin default behavior. This setting does not fall back to `llm.model`.
+
 ## How It Works
 
 1. **Capture**: After each conversation turn, the plugin extracts the user+assistant exchange, summarizes it via LLM, and appends to a daily markdown file.

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -11,17 +11,24 @@ extracts the last turn, summarizes it as bullet points, and writes to
 It also triggers memsearch indexing after writing.
 """
 
-import sqlite3
-import json
-import sys
-import os
-import time
-import shutil
-import subprocess
 import argparse
+import contextlib
+import json
+import os
+import shlex
+import shutil
 import signal
+import sqlite3
+import subprocess
+import sys
+import time
 from datetime import datetime
 from pathlib import Path
+
+
+def split_memsearch_cmd(memsearch_cmd):
+    """Split the configured memsearch command preserving quoted arguments."""
+    return shlex.split(memsearch_cmd)
 
 
 def get_small_model():
@@ -41,6 +48,20 @@ def get_small_model():
     return ""
 
 
+def get_plugin_summarize_model(memsearch_cmd=None):
+    """Read the memsearch OpenCode summarize model override."""
+    if not memsearch_cmd:
+        return ""
+    try:
+        result = subprocess.run(
+            [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.model"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
 def ensure_isolated_config():
     """Create isolated config dir without plugins/ to prevent recursion."""
     isolated = "/tmp/opencode-memsearch-summarize/opencode"
@@ -48,6 +69,9 @@ def ensure_isolated_config():
     # Copy opencode.json (provider config) but NOT plugins/
     src = os.path.expanduser("~/.config/opencode/opencode.json")
     dst = os.path.join(isolated, "opencode.json")
+    if os.path.islink(dst) or (os.path.lexists(dst) and not os.path.isfile(dst)):
+        with contextlib.suppress(OSError):
+            os.remove(dst)
     if os.path.exists(src) and not os.path.exists(dst):
         shutil.copy2(src, dst)
     return os.path.dirname(isolated)  # /tmp/opencode-memsearch-summarize
@@ -59,7 +83,7 @@ def _load_summarize_prompt(agent_name, memsearch_cmd=None):
     if memsearch_cmd:
         try:
             result = subprocess.run(
-                memsearch_cmd.split() + ["config", "get", "prompts.summarize"],
+                [*split_memsearch_cmd(memsearch_cmd), "config", "get", "prompts.summarize"],
                 capture_output=True, text=True, timeout=5,
             )
             custom_path = result.stdout.strip()
@@ -91,9 +115,10 @@ def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
     )
     isolated_dir = ensure_isolated_config()
 
+    summarize_model = get_plugin_summarize_model(memsearch_cmd) or small_model
     cmd = ["opencode", "run"]
-    if small_model:
-        cmd += ["-m", small_model]
+    if summarize_model:
+        cmd += ["-m", summarize_model]
     cmd.append(full_prompt)
 
     try:
@@ -110,7 +135,7 @@ def summarize_with_llm(turn_text, small_model, memsearch_cmd=None):
         output = result.stdout.strip()
         # Extract bullet points (skip any opencode run header lines)
         lines = output.split("\n")
-        bullets = [l for l in lines if l.strip().startswith("- ")]
+        bullets = [line for line in lines if line.strip().startswith("- ")]
         if bullets:
             return "\n".join(bullets)
     except Exception:
@@ -260,7 +285,7 @@ def main():
 
     db_path = get_db_path()
     if not os.path.exists(db_path):
-        print(f"OpenCode database not found at {db_path}", file=sys.stderr)
+        sys.stderr.write(f"OpenCode database not found at {db_path}\n")
         sys.exit(1)
 
     memory_dir = os.path.join(args.project_dir, ".memsearch", "memory")
@@ -273,10 +298,8 @@ def main():
 
     # Clean up on exit
     def cleanup(signum=None, frame=None):
-        try:
+        with contextlib.suppress(OSError):
             os.remove(pid_file)
-        except OSError:
-            pass
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, cleanup)
@@ -287,10 +310,8 @@ def main():
     state_file = os.path.join(args.project_dir, ".memsearch", ".last_msg_time")
     last_msg_time = 0
     if os.path.exists(state_file):
-        try:
-            last_msg_time = int(open(state_file).read().strip())
-        except (ValueError, OSError):
-            pass
+        with contextlib.suppress(ValueError, OSError), open(state_file) as f:
+            last_msg_time = int(f.read().strip())
 
     while True:
         try:

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -772,8 +772,8 @@ def config_init(project: bool) -> None:
     )
 
     # LLM
-    click.echo("\n── LLM (for compact & plugin summarization) ──")
-    click.echo("  Leave empty to let plugins use their own agent model.")
+    click.echo("\n── LLM (for memsearch compact) ──")
+    click.echo("  Plugin summarization uses plugins.<platform>.summarize.model.")
     _llm_defaults = {
         "openai": "gpt-4o-mini",
         "anthropic": "claude-haiku-4-5-20251001",
@@ -797,6 +797,32 @@ def config_init(project: bool) -> None:
     result["llm"]["api_key"] = click.prompt(
         "  API key (empty for env default, or env:VAR_NAME)",
         default=current.llm.api_key,
+    )
+
+    # Plugin summarize model overrides
+    click.echo("\n── Plugin summarize models ──")
+    click.echo("  Leave empty to keep each plugin's current default/native model.")
+    result["plugins"] = {
+        "claude-code": {"summarize": {}},
+        "codex": {"summarize": {}},
+        "opencode": {"summarize": {}},
+        "openclaw": {"summarize": {}},
+    }
+    result["plugins"]["claude-code"]["summarize"]["model"] = click.prompt(
+        "  Claude Code summarize model",
+        default=current.plugins.claude_code.summarize.model,
+    )
+    result["plugins"]["codex"]["summarize"]["model"] = click.prompt(
+        "  Codex summarize model",
+        default=current.plugins.codex.summarize.model,
+    )
+    result["plugins"]["opencode"]["summarize"]["model"] = click.prompt(
+        "  OpenCode summarize model",
+        default=current.plugins.opencode.summarize.model,
+    )
+    result["plugins"]["openclaw"]["summarize"]["model"] = click.prompt(
+        "  OpenClaw summarize model",
+        default=current.plugins.openclaw.summarize.model,
     )
 
     # Prompts

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -72,14 +72,13 @@ class RerankerConfig:
 
 @dataclass
 class LLMConfig:
-    """LLM settings for plugin summarization and compact.
+    """LLM settings for memsearch-managed summarization jobs.
 
-    All fields default to empty.  When empty, plugin hooks fall back to
-    their own agent model; the ``compact`` CLI falls back to
+    All fields default to empty.  When empty, the ``compact`` CLI falls back to
     ``[compact].llm_provider`` (deprecated) or ``"openai"``.
     """
 
-    provider: str = ""  # empty = plugin decides; "openai"/"anthropic"/"gemini" for explicit
+    provider: str = ""  # empty = compact defaults to openai; "openai"/"anthropic"/"gemini" for explicit
     model: str = ""
     base_url: str = ""  # OpenAI-compatible endpoint URL
     api_key: str = ""  # API key (supports "env:VAR_NAME" syntax)
@@ -97,6 +96,33 @@ class PromptsConfig:
 
 
 @dataclass
+class PluginSummarizeConfig:
+    """Plugin summarization settings."""
+
+    model: str = ""  # empty = keep plugin default/native model selection
+
+
+@dataclass
+class PluginPlatformConfig:
+    """Settings for one platform plugin."""
+
+    summarize: PluginSummarizeConfig = field(default_factory=PluginSummarizeConfig)
+
+
+@dataclass
+class PluginsConfig:
+    """Platform plugin settings.
+
+    Python field names use underscores where TOML keys use hyphens.
+    """
+
+    claude_code: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
+    codex: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
+    opencode: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
+    openclaw: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
+
+
+@dataclass
 class MemSearchConfig:
     milvus: MilvusConfig = field(default_factory=MilvusConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
@@ -106,6 +132,7 @@ class MemSearchConfig:
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
+    plugins: PluginsConfig = field(default_factory=PluginsConfig)
 
 
 # -- Section name → dataclass mapping for typed reconstruction --
@@ -118,6 +145,21 @@ _SECTION_CLASSES: dict[str, type] = {
     "reranker": RerankerConfig,
     "llm": LLMConfig,
     "prompts": PromptsConfig,
+    "plugins": PluginsConfig,
+}
+
+_PLUGIN_KEY_TO_FIELD = {
+    "claude-code": "claude_code",
+    "claude_code": "claude_code",
+    "codex": "codex",
+    "opencode": "opencode",
+    "openclaw": "openclaw",
+}
+_PLUGIN_FIELD_TO_KEY = {
+    "claude_code": "claude-code",
+    "codex": "codex",
+    "opencode": "opencode",
+    "openclaw": "openclaw",
 }
 
 
@@ -165,7 +207,37 @@ def _resolve_env_refs_in_dict(d: dict[str, Any]) -> dict[str, Any]:
 
 def _default_dict() -> dict[str, Any]:
     """Return MemSearchConfig defaults as a nested dict."""
-    return asdict(MemSearchConfig())
+    return config_to_dict(MemSearchConfig())
+
+
+def _plugins_to_dict(cfg: PluginsConfig) -> dict[str, Any]:
+    """Convert plugin config to TOML-facing keys."""
+    data = asdict(cfg)
+    return {_PLUGIN_FIELD_TO_KEY[key]: value for key, value in data.items()}
+
+
+def _dict_to_plugins_config(section_data: dict[str, Any]) -> PluginsConfig:
+    """Convert a TOML plugins table to PluginsConfig."""
+    kwargs: dict[str, Any] = {}
+    valid_platform_fields = {f.name for f in fields(PluginPlatformConfig)}
+    valid_summarize_fields = {f.name for f in fields(PluginSummarizeConfig)}
+
+    for raw_platform, raw_platform_data in section_data.items():
+        platform = _PLUGIN_KEY_TO_FIELD.get(raw_platform)
+        if not platform or not isinstance(raw_platform_data, dict):
+            continue
+
+        platform_kwargs: dict[str, Any] = {}
+        summarize_data = raw_platform_data.get("summarize", {})
+        if isinstance(summarize_data, dict):
+            summarize_filtered = {k: v for k, v in summarize_data.items() if k in valid_summarize_fields}
+            platform_kwargs["summarize"] = PluginSummarizeConfig(**summarize_filtered)
+
+        filtered = {k: v for k, v in raw_platform_data.items() if k in valid_platform_fields and k != "summarize"}
+        platform_kwargs.update(filtered)
+        kwargs[platform] = PluginPlatformConfig(**platform_kwargs)
+
+    return PluginsConfig(**kwargs)
 
 
 def load_config_file(path: Path | str) -> dict[str, Any]:
@@ -200,6 +272,9 @@ def _dict_to_config(d: dict[str, Any]) -> MemSearchConfig:
     for section_name, cls in _SECTION_CLASSES.items():
         section_data = d.get(section_name, {})
         if not isinstance(section_data, dict):
+            continue
+        if section_name == "plugins":
+            kwargs[section_name] = _dict_to_plugins_config(section_data)
             continue
         valid = {f.name for f in fields(cls)}
         filtered = {k: v for k, v in section_data.items() if k in valid}
@@ -259,7 +334,9 @@ def save_config(cfg_dict: dict[str, Any], path: Path | str) -> None:
 
 def config_to_dict(cfg: MemSearchConfig) -> dict[str, Any]:
     """Convert a MemSearchConfig to a nested dict (for saving)."""
-    return asdict(cfg)
+    data = asdict(cfg)
+    data["plugins"] = _plugins_to_dict(cfg.plugins)
+    return data
 
 
 def get_config_value(key: str, cfg: MemSearchConfig | None = None) -> Any:
@@ -269,7 +346,7 @@ def get_config_value(key: str, cfg: MemSearchConfig | None = None) -> Any:
     """
     if cfg is None:
         cfg = resolve_config()
-    d = asdict(cfg)
+    d = config_to_dict(cfg)
     parts = key.split(".")
     current: Any = d
     for part in parts:
@@ -296,21 +373,42 @@ def set_config_value(key: str, value: Any, *, project: bool = False) -> None:
     existing = load_config_file(path)
 
     parts = key.split(".")
-    if len(parts) != 2:
+    if len(parts) < 2:
         raise ValueError(f"Key must be section.field (got {key!r})")
-    section, field_name = parts
+    section = parts[0]
 
     # Validate key
     if section not in _SECTION_CLASSES:
         raise KeyError(f"Unknown config section: {section}")
-    cls = _SECTION_CLASSES[section]
-    valid = {f.name for f in fields(cls)}
-    if field_name not in valid:
-        raise KeyError(f"Unknown config field: {field_name} in section {section}")
+    if section == "plugins":
+        if len(parts) != 4:
+            raise ValueError(f"Plugin config keys must be plugins.<platform>.summarize.model (got {key!r})")
+        platform, subsection, field_name = parts[1:]
+        if platform not in _PLUGIN_KEY_TO_FIELD:
+            raise KeyError(f"Unknown plugin platform: {platform}")
+        if subsection != "summarize":
+            raise KeyError(f"Unknown plugin config section: {subsection} in platform {platform}")
+        if field_name != "model":
+            raise KeyError(f"Unknown plugin summarize field: {field_name} in platform {platform}")
+    else:
+        if len(parts) != 2:
+            raise ValueError(f"Key must be section.field (got {key!r})")
+        field_name = parts[1]
+        cls = _SECTION_CLASSES[section]
+        valid = {f.name for f in fields(cls)}
+        if field_name not in valid:
+            raise KeyError(f"Unknown config field: {field_name} in section {section}")
 
     # Auto-convert int fields
     if field_name in _INT_FIELDS and isinstance(value, str):
         value = int(value)
 
-    existing.setdefault(section, {})[field_name] = value
+    current: dict[str, Any] = existing
+    for part in parts[:-1]:
+        next_value = current.setdefault(part, {})
+        if not isinstance(next_value, dict):
+            next_value = {}
+            current[part] = next_value
+        current = next_value
+    current[parts[-1]] = value
     save_config(existing, path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ import tomli_w
 from memsearch.config import (
     EmbeddingConfig,
     MemSearchConfig,
+    PluginsConfig,
     _dict_to_config,
     deep_merge,
     get_config_value,
@@ -31,6 +32,8 @@ def test_default_config():
     assert cfg.chunking.overlap_lines == 2
     assert cfg.watch.debounce_ms == 1500
     assert cfg.compact.llm_provider == "openai"
+    assert cfg.plugins.claude_code.summarize.model == ""
+    assert cfg.plugins.codex.summarize.model == ""
 
 
 def test_load_toml_file(tmp_path: Path):
@@ -127,6 +130,52 @@ def test_set_get_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert get_config_value("milvus.uri", cfg) == "http://roundtrip:19530"
 
 
+def test_plugin_summarize_model_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Plugin summarize models should be addressable by platform dotted keys."""
+    cfg_path = tmp_path / "config.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    set_config_value("plugins.claude-code.summarize.model", "claude-haiku-4-5")
+    set_config_value("plugins.codex.summarize.model", "gpt-5.1-codex-mini")
+    set_config_value("plugins.opencode.summarize.model", "anthropic/claude-haiku")
+    set_config_value("plugins.openclaw.summarize.model", "qwen3-coder")
+
+    cfg = resolve_config()
+    assert cfg.plugins.claude_code.summarize.model == "claude-haiku-4-5"
+    assert cfg.plugins.codex.summarize.model == "gpt-5.1-codex-mini"
+    assert cfg.plugins.opencode.summarize.model == "anthropic/claude-haiku"
+    assert cfg.plugins.openclaw.summarize.model == "qwen3-coder"
+    assert get_config_value("plugins.claude-code.summarize.model", cfg) == "claude-haiku-4-5"
+
+    saved = load_config_file(cfg_path)
+    assert saved["plugins"]["claude-code"]["summarize"]["model"] == "claude-haiku-4-5"
+
+
+def test_plugin_summarize_model_empty_preserves_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Empty plugin summarize values should remain empty in resolved config."""
+    cfg_file = tmp_path / "config.toml"
+    save_config(
+        {
+            "llm": {"model": "global-model-should-not-apply"},
+            "plugins": {
+                "claude-code": {"summarize": {"model": ""}},
+                "codex": {"summarize": {}},
+            },
+        },
+        cfg_file,
+    )
+
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    cfg = resolve_config()
+    assert cfg.llm.model == "global-model-should-not-apply"
+    assert cfg.plugins.claude_code.summarize.model == ""
+    assert cfg.plugins.codex.summarize.model == ""
+    assert get_config_value("plugins.codex.summarize.model", cfg) == ""
+
+
 def test_set_config_value_int_conversion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """set_config_value should auto-convert int fields from strings."""
     cfg_path = tmp_path / "config.toml"
@@ -156,6 +205,12 @@ def test_set_config_value_writes_to_project_config_when_requested(tmp_path: Path
     [
         ("milvus", "x", ValueError, "Key must be section\\.field"),
         ("bad.uri", "x", KeyError, "Unknown config section: bad"),
+        (
+            "plugins.bad.summarize.model",
+            "x",
+            KeyError,
+            "Unknown plugin platform: bad",
+        ),
         (
             "milvus.not_a_field",
             "x",
@@ -286,6 +341,15 @@ def test_embedding_config_new_fields():
     assert cfg.api_key == ""
 
 
+def test_plugins_config_defaults():
+    """PluginsConfig should expose the supported platform summarize model keys."""
+    cfg = PluginsConfig()
+    assert cfg.claude_code.summarize.model == ""
+    assert cfg.codex.summarize.model == ""
+    assert cfg.opencode.summarize.model == ""
+    assert cfg.openclaw.summarize.model == ""
+
+
 def test_compact_config_new_fields():
     """CompactConfig should have base_url and api_key fields with empty defaults."""
     from memsearch.config import CompactConfig
@@ -346,6 +410,13 @@ def test_dict_to_config_ignores_unknown_fields_and_non_dict_sections() -> None:
                 "llm_model": "claude-3-7-sonnet",
                 "extra": True,
             },
+            "plugins": {
+                "claude-code": {
+                    "summarize": {"model": "haiku", "provider": "ignored"},
+                    "future": "ignored",
+                },
+                "unknown-plugin": {"summarize": {"model": "ignored"}},
+            },
             "unknown_section": {"foo": "bar"},
         }
     )
@@ -355,6 +426,8 @@ def test_dict_to_config_ignores_unknown_fields_and_non_dict_sections() -> None:
     assert cfg.milvus.uri == "~/.memsearch/milvus.db"
     assert cfg.compact.llm_provider == "anthropic"
     assert cfg.compact.llm_model == "claude-3-7-sonnet"
+    assert cfg.plugins.claude_code.summarize.model == "haiku"
+    assert cfg.plugins.codex.summarize.model == ""
 
 
 def test_dict_to_config_accepts_empty_section_dicts() -> None:


### PR DESCRIPTION
## Summary
- Add platform-specific summarize model settings under plugin config
- Keep existing default behavior when no plugin setting is provided
- Update plugin docs, setup notes, and OpenClaw runtime packaging

## Validation
- bash syntax checks for plugin scripts
- node syntax check and build output comparison for OpenClaw runtime
- ruff check and Python compile checks
- pytest tests/test_config.py tests/test_cli_config_helpers.py tests/test_cli_help.py tests/test_transcript.py
- pytest --ignore=tests/test_embeddings_openai.py
- mkdocs build --strict