### PR TITLE
fix(codex): use current hooks feature flag

### DIFF
--- a/docs/platforms/codex/how-it-works.md
+++ b/docs/platforms/codex/how-it-works.md
@@ -101,7 +101,7 @@ graph TD
     D -->|No| E2["history.jsonl + last_assistant_message<br/>Recover latest user turn"]
     E --> F{"codex exec available?"}
     E2 --> F
-    F -->|Yes| G["codex exec --ephemeral<br/>-s read-only -c features.codex_hooks=false<br/>-m gpt-5.1-codex-mini"]
+    F -->|Yes| G["codex exec --ephemeral<br/>-s read-only -c features.hooks=false<br/>-m gpt-5.1-codex-mini"]
     F -->|No| H["Local fallback<br/>Truncate raw text"]
     G --> I["Append to YYYY-MM-DD.md<br/>with rollout anchors"]
     H --> I
@@ -128,7 +128,7 @@ The Stop hook calls `codex exec` for LLM summarization. To prevent **hook recurs
 ```bash
 MEMSEARCH_NO_WATCH=1 \
   codex exec --ephemeral --skip-git-repo-check -s read-only \
-  -c features.codex_hooks=false \
+  -c features.hooks=false \
   -c model_reasoning_effort='"low"' \
   -m gpt-5.1-codex-mini "$LLM_PROMPT"
 ```
@@ -253,7 +253,7 @@ When the `rollout:` anchor is populated, the memory-recall skill can use `parse-
 |--------|-------------|-------------------|
 | **SessionEnd hook** | Not available -- orphans cleaned at next SessionStart | Available -- clean shutdown |
 | **Summarizer** | `codex exec -m gpt-5.1-codex-mini` | `claude -p --model haiku` |
-| **Recursion prevention** | `features.codex_hooks=false` on child `codex exec` | `stop_hook_active` flag + `CLAUDECODE=` |
+| **Recursion prevention** | `features.hooks=false` on child `codex exec` | `stop_hook_active` flag + `CLAUDECODE=` |
 | **Skill context** | Main context (no `context: fork`) | Forked subagent (`context: fork`) |
 | **Milvus Lite** | One-time index + skip re-index in Stop | Same approach via `start_watch()` logic |
 | **Auto-install** | Bootstrap installs `uv` if missing | Requires pre-installed memsearch |

--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -22,7 +22,7 @@ memsearch fills this gap with a shell-hook-based plugin that gives Codex the sam
 Codex CLI runs in a sandboxed environment by default. The memsearch plugin requires file system access to write memory files and run the `memsearch` CLI. The recommended approach:
 
 - **Install option**: The `install.sh` script configures `hooks.json` which works in any mode
-- **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only -c features.codex_hooks=false` so summarization reuses normal auth without recursing into hooks
+- **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only -c features.hooks=false` so summarization reuses normal auth without recursing into hooks
 
 If you experience issues with the Stop hook in strict sandbox mode, see [Troubleshooting](../../platforms/claude-code/troubleshooting.md) for diagnostic steps.
 

--- a/docs/platforms/codex/installation.md
+++ b/docs/platforms/codex/installation.md
@@ -20,7 +20,7 @@ The installer:
 
 1. Copies the memory-recall skill to `~/.agents/skills/`
 2. Installs or updates memsearch hooks in `~/.codex/hooks.json`
-3. Enables `codex_hooks = true` in `~/.codex/config.toml`
+3. Enables `hooks = true` in `~/.codex/config.toml`
 4. Makes all scripts executable
 
 ## Usage

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -22,7 +22,7 @@ bash plugins/codex/scripts/install.sh
 The installer sets up everything automatically:
 - Copies the **memory-recall** skill to `~/.agents/skills/`
 - Installs or updates memsearch hook entries in `~/.codex/hooks.json`
-- Enables the `codex_hooks` feature flag
+- Enables the `hooks` feature flag
 
 ## Usage
 

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -116,7 +116,7 @@ ${CONTENT}"
         --ephemeral \
         --skip-git-repo-check \
         -s read-only \
-        -c features.codex_hooks=false \
+        -c features.hooks=false \
         -c model_reasoning_effort='"low"' \
         -m "$SUMMARIZE_MODEL" \
         "$LLM_PROMPT" 2>/dev/null || true)
@@ -125,7 +125,7 @@ ${CONTENT}"
         --ephemeral \
         --skip-git-repo-check \
         -s read-only \
-        -c features.codex_hooks=false \
+        -c features.hooks=false \
         -c model_reasoning_effort='"low"' \
         -m "$SUMMARIZE_MODEL" \
         "$LLM_PROMPT" 2>/dev/null || true)
@@ -178,7 +178,7 @@ fi
 source "$SCRIPT_DIR/common.sh"
 
 # Defense-in-depth against recursion: the worker's `codex exec` passes
-# `features.codex_hooks=false`, but if a future build ignores that flag the
+# `features.hooks=false`, but if a future build ignores that flag the
 # nested Stop hook would spawn another worker. MEMSEARCH_IN_STOP_WORKER is
 # exported across the exec boundary so the nested invocation no-ops here.
 if [ -n "${MEMSEARCH_IN_STOP_WORKER:-}" ]; then

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -27,7 +27,7 @@ path.write_text(text.replace(old, new))
 PY
 }
 
-ensure_codex_hooks_enabled() {
+ensure_hooks_enabled() {
   local config_file="$1"
 
   python3 - "$config_file" <<'PY'
@@ -37,19 +37,28 @@ import sys
 
 path = Path(sys.argv[1])
 if not path.exists():
-    path.write_text("[features]\ncodex_hooks = true\n")
+    path.write_text("[features]\nhooks = true\n")
     raise SystemExit
 
 text = path.read_text()
 
-if re.search(r"(?m)^codex_hooks\s*=", text):
-    text = re.sub(r"(?m)^codex_hooks\s*=.*$", "codex_hooks = true", text)
-elif re.search(r"(?m)^\[features\]\s*$", text):
-    text = re.sub(r"(?m)^\[features\]\s*$", "[features]\ncodex_hooks = true", text, count=1)
+features_match = re.search(r"(?m)^\[features\]\s*$", text)
+if features_match:
+    next_section = re.search(r"(?m)^\[[^]]+\]\s*$", text[features_match.end():])
+    block_end = len(text) if next_section is None else features_match.end() + next_section.start()
+    block = text[features_match.end():block_end]
+    block = re.sub(r"(?m)^codex_hooks\s*=.*\n?", "", block)
+    if re.search(r"(?m)^hooks\s*=", block):
+        block = re.sub(r"(?m)^hooks\s*=.*$", "hooks = true", block)
+    else:
+        if block and not block.startswith("\n"):
+            block = "\n" + block
+        block = "\nhooks = true" + block
+    text = text[:features_match.end()] + block + text[block_end:]
 else:
     if text and not text.endswith("\n"):
         text += "\n"
-    text += "\n[features]\ncodex_hooks = true\n"
+    text += "\n[features]\nhooks = true\n"
 
 path.write_text(text)
 PY
@@ -211,11 +220,11 @@ fi
 install_or_update_hooks_file "$HOOKS_FILE" "$INSTALL_DIR"
 echo "  ✓ Installed memsearch hooks in $HOOKS_FILE"
 
-# --- 5. Enable codex_hooks feature flag ---
-echo "[5/6] Enabling codex_hooks feature flag..."
+# --- 5. Enable hooks feature flag ---
+echo "[5/6] Enabling hooks feature flag..."
 CONFIG_FILE="$CODEX_DIR/config.toml"
-ensure_codex_hooks_enabled "$CONFIG_FILE"
-echo "  ✓ Ensured codex_hooks = true in $CONFIG_FILE"
+ensure_hooks_enabled "$CONFIG_FILE"
+echo "  ✓ Ensured hooks = true in $CONFIG_FILE"
 
 # --- 6. Make scripts executable ---
 echo "[6/6] Setting permissions..."
@@ -237,6 +246,6 @@ echo ""
 echo "Memory files:   <project>/.memsearch/memory/*.md"
 echo "Hooks config:   $HOOKS_FILE"
 echo "Skill location: $SKILL_DST"
-echo "Feature flag:   codex_hooks = true in $CONFIG_FILE"
+echo "Feature flag:   hooks = true in $CONFIG_FILE"
 echo ""
 echo "To verify: start a new codex session and check for [memsearch] status line."


### PR DESCRIPTION
## Summary
- enable the current Codex hooks feature flag during install
- migrate stale codex_hooks entries to hooks in config.toml
- disable hooks with features.hooks=false for nested summarization runs
- update Codex plugin documentation

## Validation
- bash -n plugins/codex/scripts/install.sh plugins/codex/hooks/stop.sh
- uv run mkdocs build --strict
- temporary HOME installer migration test
- codex exec --profile zilliz --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check in a temporary project

Closes #535