### PR TITLE
fix: load reopened Milvus collections

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,6 +25,26 @@ This deletes the indexed chunks in Milvus, but it does **not** delete your sourc
 
 For command details, see the [CLI reference](cli.md#memsearch-reset).
 
+## Why do I see "collection is in state 'released'" with Milvus Lite?
+
+Milvus requires a collection to be loaded before `search`, `query`, or `get` operations. Some newer Milvus Lite / PyMilvus combinations reopen an existing local collection in a released state, especially across separate CLI invocations such as:
+
+```bash
+memsearch index .
+memsearch search "my query"
+```
+
+Current memsearch versions explicitly load an existing collection before search/query operations. If you still see this error, upgrade memsearch first.
+
+If the error started after upgrading Milvus Lite itself, also check whether you are reusing a local `.db` file created by an older Milvus Lite release. Milvus Lite 3.x was rewritten with a new pure-Python storage engine, and old `.db` files from the previous storage format are not compatible with the new engine. In that case, move the old `.db` file aside and rebuild from your source markdown files:
+
+```bash
+mv ~/.memsearch/milvus.db ~/.memsearch/milvus.db.bak
+memsearch index . --force
+```
+
+If you do not want to rebuild the local database, keep using the older Milvus Lite environment that created it. For a more stable shared or long-running backend, use Milvus Server via Docker or Zilliz Cloud.
+
 ## How do I see what is indexed?
 
 Start with index stats:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,6 +61,25 @@ On Windows, use one of these options instead:
 
 See [Getting Started — Milvus Backends](getting-started.md#milvus-backends).
 
+## Milvus Lite collection is released
+
+If `memsearch search`, `memsearch index`, or `memsearch expand` fails with an error like this:
+
+```text
+Collection '...' is in state 'released'; call load() before search/get/query
+```
+
+Upgrade memsearch first. Current memsearch versions explicitly load existing Milvus collections before query/search operations.
+
+If this started after upgrading Milvus Lite, check whether the local `.db` file was created by an older Milvus Lite release. Milvus Lite 3.x uses a new pure-Python storage engine and cannot read `.db` files from the previous storage format. Move the old `.db` file aside, then rebuild the index from source markdown:
+
+```bash
+mv ~/.memsearch/milvus.db ~/.memsearch/milvus.db.bak
+memsearch index . --force
+```
+
+Alternatively, keep using the older Milvus Lite environment that created the `.db` file, or switch to Milvus Server via Docker / Zilliz Cloud.
+
 ## Rebuild from source markdown
 
 To wipe the current collection and rebuild from markdown files:

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -51,7 +51,18 @@ class MilvusStore:
         connect_kwargs: dict[str, Any] = {"uri": resolved}
         if token:
             connect_kwargs["token"] = token
-        self._client = MilvusClient(**connect_kwargs)
+        try:
+            self._client = MilvusClient(**connect_kwargs)
+        except Exception as exc:
+            if is_local:
+                raise RuntimeError(
+                    "Failed to open the local Milvus Lite database. If this database was created "
+                    "with an older Milvus Lite release, it may not be compatible with Milvus Lite "
+                    "3.x. Move the existing .db file aside, then rebuild the index from your "
+                    "source markdown files with 'memsearch index'. Alternatively, use Milvus "
+                    "Server via Docker or Zilliz Cloud."
+                ) from exc
+            raise
         self._is_lite = is_local
         self._resolved_uri = resolved
         self._collection = collection
@@ -62,6 +73,7 @@ class MilvusStore:
     def _ensure_collection(self) -> None:
         if self._client.has_collection(self._collection):
             self._check_dimension()
+            self._load_collection()
             return
 
         if self._dimension is None:
@@ -100,6 +112,14 @@ class MilvusStore:
             schema=schema,
             index_params=index_params,
         )
+        self._load_collection()
+
+    def _load_collection(self) -> None:
+        """Load the collection before query/search operations."""
+        try:
+            self._client.load_collection(collection_name=self._collection)
+        except TypeError:
+            self._client.load_collection(self._collection)
 
     def _check_dimension(self) -> None:
         """Verify that the existing collection's embedding dimension matches."""

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -616,6 +616,8 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
 
     turn_db.close()
     conn.close()
+
+
 def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -140,6 +140,32 @@ def test_dimension_mismatch(tmp_path: Path):
         MilvusStore(uri=db, dimension=8)
 
 
+def test_reopened_collection_is_loaded_for_query(tmp_path: Path):
+    db = str(tmp_path / "reopen_test.db")
+    chunk = {
+        "embedding": [1.0, 0.0, 0.0, 0.0],
+        "content": "Reopened collection",
+        "source": "test.md",
+        "heading": "",
+        "chunk_hash": "reopen_hash",
+        "heading_level": 0,
+        "start_line": 1,
+        "end_line": 1,
+    }
+
+    s1 = MilvusStore(uri=db, dimension=4)
+    s1.upsert([chunk])
+    s1.close()
+
+    s2 = MilvusStore(uri=db, dimension=4)
+    try:
+        results = s2.query()
+    finally:
+        s2.close()
+
+    assert [r["chunk_hash"] for r in results] == ["reopen_hash"]
+
+
 def test_drop(store: MilvusStore):
     chunk = {
         "embedding": [1.0, 0.0, 0.0, 0.0],


### PR DESCRIPTION
## Summary
- load Milvus collections after create or when reopening an existing collection
- surface a clearer local Milvus Lite database compatibility error
- document Milvus Lite released-state recovery and 3.x storage-format migration notes

## Validation
- uv run ruff check src/memsearch/store.py tests/test_store.py
- uv run python -m pytest tests/test_store.py tests/test_cli_error_handling.py -q
- uv run --with pymilvus==3.0.0 --with milvus-lite==3.0 python -m pytest tests/test_store.py::test_reopened_collection_is_loaded_for_query -q
- uv run mkdocs build --strict