### PR TITLE
chore: bump versions for patch release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.2"
+version = "0.4.3"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump memsearch package version to 0.4.3
- bump Claude Code plugin marketplace version to 0.4.3
- bump OpenCode plugin package version to 0.3.0

## Validation
- uv run python -m pytest tests/test_store.py tests/test_opencode_turns.py tests/test_opencode_parse_transcript.py -q
- uv run mkdocs build --strict
- npm pack --dry-run