### PR TITLE
Update summarize provider routing docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,16 +291,26 @@ prompt_file = ""
 provider = ""                          # empty = compact defaults to openai
 model = ""
 
-[plugins.claude-code.summarize]        # optional plugin summarize model overrides
-model = ""                             # empty = plugin default/native model
+[llm.providers.openai]                  # optional named providers for plugin summarization
+type = "openai"                         # openai/openai-compatible/anthropic/gemini
+model = "gpt-4o-mini"
+base_url = ""
+api_key = "env:OPENAI_API_KEY"
+
+[plugins.claude-code.summarize]        # optional plugin summarize routing
+provider = ""                           # empty/native = plugin native summarizer
+model = ""                              # native model override, or API provider model override
 
 [plugins.codex.summarize]
+provider = ""
 model = ""
 
 [plugins.opencode.summarize]
+provider = ""
 model = ""
 
 [plugins.openclaw.summarize]
+provider = ""
 model = ""
 
 [prompts]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,16 +178,26 @@ prompt_file = ""
 provider = ""
 model = ""
 
+[llm.providers.openai]
+type = "openai"
+model = "gpt-4o-mini"
+base_url = ""
+api_key = "env:OPENAI_API_KEY"
+
 [plugins.claude-code.summarize]
+provider = ""
 model = ""
 
 [plugins.codex.summarize]
+provider = ""
 model = ""
 
 [plugins.opencode.summarize]
+provider = ""
 model = ""
 
 [plugins.openclaw.summarize]
+provider = ""
 model = ""
 
 [prompts]
@@ -228,10 +238,18 @@ provider = "openai"
 | `llm.model` | string | `""` | LLM model override for `memsearch compact` |
 | `llm.base_url` | string | `""` | OpenAI-compatible API base URL |
 | `llm.api_key` | string | `""` | API key (supports `env:VAR_NAME` syntax) |
-| `plugins.claude-code.summarize.model` | string | `""` | Claude Code plugin summarize model override (empty = plugin default) |
-| `plugins.codex.summarize.model` | string | `""` | Codex plugin summarize model override (empty = plugin default) |
-| `plugins.opencode.summarize.model` | string | `""` | OpenCode plugin summarize model override (empty = `small_model` / plugin default) |
-| `plugins.openclaw.summarize.model` | string | `""` | OpenClaw plugin summarize model override (empty = default agent model) |
+| `llm.providers.<name>.type` | string | `""` | Named provider type for plugin summarization (`openai`, `openai-compatible`, `anthropic`, `gemini`) |
+| `llm.providers.<name>.model` | string | `""` | Default model for a named plugin summarization provider |
+| `llm.providers.<name>.base_url` | string | `""` | OpenAI-compatible API base URL for a named provider |
+| `llm.providers.<name>.api_key` | string | `""` | API key for a named provider (supports `env:VAR_NAME` syntax) |
+| `plugins.claude-code.summarize.provider` | string | `""` | Claude Code summarize provider route (empty/`native` = native summarizer) |
+| `plugins.claude-code.summarize.model` | string | `""` | Claude Code native model override, or named provider model override |
+| `plugins.codex.summarize.provider` | string | `""` | Codex summarize provider route (empty/`native` = native summarizer) |
+| `plugins.codex.summarize.model` | string | `""` | Codex native model override, or named provider model override |
+| `plugins.opencode.summarize.provider` | string | `""` | OpenCode summarize provider route (empty/`native` = native summarizer) |
+| `plugins.opencode.summarize.model` | string | `""` | OpenCode native model override, or named provider model override |
+| `plugins.openclaw.summarize.provider` | string | `""` | OpenClaw summarize provider route (empty/`native` = native summarizer) |
+| `plugins.openclaw.summarize.model` | string | `""` | OpenClaw native model override, or named provider model override |
 | `prompts.compact` | string | `""` | Custom prompt file for `memsearch compact` |
 | `prompts.summarize` | string | `""` | Custom prompt file for plugin session summarization |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ The most mature plugin. Marketplace install, zero config.
 /plugin install memsearch
 ```
 
-Shell hooks + SKILL.md with `context: fork` subagent. Conversations are auto-summarized via Haiku and recalled via semantic search -- all without polluting your main context window.
+Shell hooks + SKILL.md with `context: fork` subagent. Conversations are auto-summarized by the native CLI by default, with optional API provider routing, and recalled via semantic search -- all without polluting your main context window.
 
 [:octicons-arrow-right-24: Claude Code Plugin docs](platforms/claude-code/index.md){ .md-button .md-button--primary }
 [:octicons-arrow-right-24: Troubleshooting](platforms/claude-code/troubleshooting.md){ .md-button }

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -45,7 +45,7 @@ The plugin defines 4 lifecycle hooks that map to Claude Code's session events:
 |------|------|-------|---------|-------------|
 | **SessionStart** | command | no | 10s | Start `memsearch watch`, write session heading, inject recent memories as cold-start context, display config status |
 | **UserPromptSubmit** | command | no | 15s | Return `systemMessage` hint "[memsearch] Memory available" (skips prompts < 10 chars) |
-| **Stop** | command | **yes** | 120s | Parse last turn from transcript, call `claude -p --model haiku` to summarize, append to daily `.md`, re-index |
+| **Stop** | command | **yes** | 120s | Parse last turn from transcript, summarize via native Haiku by default or configured API provider, append to daily `.md`, re-index |
 | **SessionEnd** | command | no | 10s | Stop the `memsearch watch` background process |
 
 All hooks output JSON to stdout -- `additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}` for no-op. The `common.sh` shared library is sourced by every hook, providing JSON parsing, memsearch binary detection, and watch process management.
@@ -253,7 +253,7 @@ plugins/claude-code/
 | `common.sh` | Shared shell library sourced by all hooks. Handles stdin JSON parsing, PATH setup, memsearch binary detection (prefers PATH, falls back to `uv run`), memory directory management, and the watch singleton (start/stop with PID file and orphan cleanup). Changes here affect all hooks. |
 | `session-start.sh` | Starts the watcher, writes session heading, reads recent memory files for cold-start injection, checks for updates. |
 | `user-prompt-submit.sh` | Returns lightweight `systemMessage` hint. No search -- retrieval is handled by the memory-recall skill. |
-| `stop.sh` | Extracts transcript, validates it, calls `parse-transcript.sh`, summarizes via Haiku, appends with anchors. Has recursion guard (`stop_hook_active`) and sets `CLAUDECODE=` / `MEMSEARCH_NO_WATCH=1` on child processes. |
+| `stop.sh` | Extracts transcript, validates it, calls `parse-transcript.sh`, summarizes via native Haiku by default or configured API provider, appends with anchors. Has recursion guard (`stop_hook_active`) and sets `CLAUDECODE=` / `MEMSEARCH_NO_WATCH=1` on child processes. |
 | `parse-transcript.sh` | Standalone last-turn extractor using Python 3. Outputs role-labeled text. No `jq` dependency. |
 | `session-end.sh` | Calls `stop_watch` to terminate background watcher and clean up. |
 | `derive-collection.sh` | Generates a deterministic per-project Milvus collection name from the project path (e.g., `ms_myproject_a1b2c3`). |

--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -30,7 +30,7 @@ If you experience issues with the Stop hook in strict sandbox mode, see [Trouble
 
 ## Key Features
 
-- **Automatic capture** -- conversations summarized via `codex exec` using `gpt-5.1-codex-mini` after each turn
+- **Automatic capture** -- conversations summarized via native `codex exec` by default, with optional API provider routing
 - **Best-effort rollout drill-down** -- search and expand always work, with original rollout parsing available when Codex includes rollout anchors ([details](memory-recall.md))
 - **Shell hook architecture** -- similar to [Claude Code plugin](../claude-code/index.md), easy to understand and modify
 - **Orphan cleanup** -- handles missing `SessionEnd` hook gracefully (Codex doesn't have one)

--- a/docs/platforms/openclaw/how-it-works.md
+++ b/docs/platforms/openclaw/how-it-works.md
@@ -5,7 +5,7 @@
 | Event | What memsearch does |
 |-------|-------------------|
 | **Agent starts** | Recent memories from the 2 most recent daily logs are injected as context (`before_agent_start`) |
-| **Each turn ends** | Conversation is summarized by the OpenClaw agent and appended to daily `.md` (`agent_end` hook) |
+| **Each turn ends** | Conversation is summarized by the native OpenClaw agent by default, or by a configured API provider, then appended to daily `.md` (`agent_end` hook) |
 | **LLM needs history** | Calls `memory_search`, `memory_get`, or `memory_transcript` tools progressively |
 
 ---

--- a/docs/platforms/opencode/index.md
+++ b/docs/platforms/opencode/index.md
@@ -28,7 +28,7 @@ If you use multiple AI coding agents (e.g., OpenCode for some projects, Claude C
 
 - **SQLite-based capture** -- background daemon polls OpenCode's database for new turns, no hook limitations
 - **Three-layer progressive recall** -- search, expand, and drill into original conversations ([details](memory-tools.md))
-- **Automatic summarization** -- each turn summarized via `opencode run` with isolated config
+- **Automatic summarization** -- each turn summarized via native `opencode run` with isolated config by default, with optional API provider routing
 - **Cold-start context** -- recent memories injected via `system.transform` hook
 - **ONNX embedding by default** -- no API key required, runs locally on CPU
 - **Daemon self-management** -- PID file singleton, automatic restart, persistent state across daemon restarts

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -147,7 +147,7 @@ stateDiagram-v2
 |------|------|-------|---------|-------------|
 | **SessionStart** | command | no | 10s | Start `memsearch watch` singleton, write session heading to today's `.md`, inject recent daily logs as cold-start context via `additionalContext`, display config status (provider/model/milvus) in `systemMessage` |
 | **UserPromptSubmit** | command | no | 15s | Lightweight hint: returns `systemMessage` "[memsearch] Memory available" (skip if < 10 chars). No search — recall is handled by the memory-recall skill |
-| **Stop** | command | **yes** | 120s | Extract last turn from transcript with `parse-transcript.sh`, call `claude -p --model haiku` to summarize (third-person notes), append summary with session/turn anchors to daily `.md` |
+| **Stop** | command | **yes** | 120s | Extract last turn from transcript with `parse-transcript.sh`, summarize via native Haiku by default or configured API provider, append summary with session/turn anchors to daily `.md` |
 | **SessionEnd** | command | no | 10s | Stop the `memsearch watch` background process (cleanup) |
 
 ### What Each Hook Does


### PR DESCRIPTION
## Summary
- update configuration examples with named provider routing
- document plugin summarize provider keys in CLI reference
- refresh platform summaries to mention optional API provider routing

## Validation
- uv run mkdocs build --strict