### PR TITLE
Add plugin memory maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ htmlcov/
 .memsearch/
 CONTEXT.md
 CLAUDE.local.md
+AGENTS.local.md
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -236,12 +236,38 @@ Advanced users can route plugin summarization through a memsearch-managed API pr
 
 ```bash
 memsearch config set llm.providers.openai.type openai
-memsearch config set llm.providers.openai.model gpt-4o-mini
+memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.codex.summarize.provider openai
 ```
 
 Leave `plugins.<platform>.summarize.provider` empty or set it to `native` to preserve the default behavior. Plugin-specific summarize settings do not fall back to `llm.model`.
+
+You can also disable automatic capture for a project while keeping the plugin installed:
+
+```bash
+memsearch config set plugins.codex.summarize.enabled false --project
+```
+
+#### Advanced Memory Maintenance
+
+Plugins can optionally maintain higher-level project and user notes in the background. These tasks are disabled by default and run only when a plugin wakes them after a session/turn, the journal input changed, and `min_interval_hours` has elapsed.
+
+```bash
+memsearch config set plugins.codex.project_review.enabled true --project
+memsearch config set plugins.codex.project_review.provider native --project
+memsearch config set plugins.codex.project_review.min_interval_hours 24 --project
+memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md --project
+
+memsearch config set plugins.codex.user_profile.enabled true --project
+memsearch config set plugins.codex.user_profile.output_file .memsearch/USER.md --project
+```
+
+`project_review` summarizes durable project state such as active threads, decisions, risks, and next steps. `user_profile` captures reusable user preferences, working style, recurring goals, and background context. Both read `.memsearch/memory` by default; set `input_dir` if your journal files live somewhere else.
+
+Use `provider = "native"` to reuse the current agent's own non-interactive model path, or point the task at a named `[llm.providers.<name>]` API provider. Custom prompt files can be configured with `prompts.project_review` and `prompts.user_profile`.
+
+The `memory-config` skill, installed with the plugins, can inspect the current setup, explain these options, and make safe project-scoped changes from natural-language requests.
 
 ### What can you use it for?
 
@@ -428,7 +454,7 @@ async def agent_chat(user_input: str) -> str:
 
     # 2. Think — call LLM with memory context
     resp = llm.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": f"You have these memories:\n{context}"},
             {"role": "user", "content": user_input},
@@ -488,7 +514,7 @@ async def agent_chat(user_input: str) -> str:
 
     # 2. Think — call Claude with memory context
     resp = llm.messages.create(
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-6",
         max_tokens=1024,
         system=f"You have these memories:\n{context}",
         messages=[{"role": "user", "content": user_input}],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,7 +293,7 @@ model = ""
 
 [llm.providers.openai]                  # optional named providers for plugin summarization
 type = "openai"                         # openai/openai-compatible/anthropic/gemini
-model = "gpt-4o-mini"
+model = "gpt-5-mini"
 base_url = ""
 api_key = "env:OPENAI_API_KEY"
 
@@ -316,6 +316,8 @@ model = ""
 [prompts]
 compact = ""                           # custom compact prompt file
 summarize = ""                         # custom summarize prompt file
+project_review = ""                    # custom PROJECT.md maintenance prompt file
+user_profile = ""                      # custom USER.md maintenance prompt file
 
 [chunking]
 max_chunk_size = 1500

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,10 +86,26 @@ Writing to: /home/user/.memsearch/config.toml
 -- Watch --
   Debounce (ms) [1500]:
 
--- Compact --
-  LLM provider [openai]:
-  LLM model (empty for default) []:
-  Prompt file path (empty for built-in) []:
+-- LLM (for memsearch compact) --
+  Provider (empty/openai/anthropic/gemini) []:
+  Model []:
+
+-- Plugin summarize routing --
+  Leave provider empty/native to keep each plugin's current native summarizer.
+  Codex automatic summaries enabled [Y/n]:
+  Codex summarize provider []:
+  Codex summarize model []:
+
+-- Advanced maintenance --
+  Disabled by default. Configure provider/model if you enable these tasks.
+  Codex project review enabled [y/N]:
+  Codex user profile enabled [y/N]:
+
+-- Prompts --
+  Leave empty to use built-in defaults.
+  Summarize prompt file (for plugin session notes) []:
+  Project review prompt file []:
+  User profile prompt file []:
 
 Config saved to /home/user/.memsearch/config.toml
 ```
@@ -123,6 +139,23 @@ Set embedding.provider = google in .memsearch.toml
 $ memsearch config set chunking.max_chunk_size 2000
 Set chunking.max_chunk_size = 2000 in /home/user/.memsearch/config.toml
 ```
+
+Plugin config keys use `plugins.<platform>.<task>.<field>`:
+
+```bash
+$ memsearch config set plugins.codex.summarize.enabled false --project
+Set plugins.codex.summarize.enabled = false in .memsearch.toml
+
+$ memsearch config set plugins.codex.project_review.enabled true --project
+Set plugins.codex.project_review.enabled = true in .memsearch.toml
+
+$ memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md --project
+Set plugins.codex.project_review.output_file = .memsearch/PROJECT.md in .memsearch.toml
+```
+
+Supported plugin platforms are `claude-code`, `codex`, `opencode`, and
+`openclaw`. Supported plugin tasks are `summarize`, `project_review`, and
+`user_profile`.
 
 #### `memsearch config get`
 
@@ -180,7 +213,7 @@ model = ""
 
 [llm.providers.openai]
 type = "openai"
-model = "gpt-4o-mini"
+model = "gpt-5-mini"
 base_url = ""
 api_key = "env:OPENAI_API_KEY"
 
@@ -252,6 +285,8 @@ provider = "openai"
 | `plugins.openclaw.summarize.model` | string | `""` | OpenClaw native model override, or named provider model override |
 | `prompts.compact` | string | `""` | Custom prompt file for `memsearch compact` |
 | `prompts.summarize` | string | `""` | Custom prompt file for plugin session summarization |
+| `prompts.project_review` | string | `""` | Custom prompt file for plugin project maintenance |
+| `prompts.user_profile` | string | `""` | Custom prompt file for plugin user-profile maintenance |
 
 ---
 
@@ -471,9 +506,9 @@ Use an LLM to compress all indexed chunks (or a subset) into a condensed markdow
 
 | Provider | Default Model |
 |----------|--------------|
-| `openai` | `gpt-4o-mini` |
-| `anthropic` | `claude-sonnet-4-5-20250929` |
-| `gemini` | `gemini-2.0-flash` |
+| `openai` | `gpt-5-mini` |
+| `anthropic` | `claude-sonnet-4-6` |
+| `gemini` | `gemini-3-flash-preview` |
 
 ### Examples
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,7 +230,7 @@ async def agent_chat(user_input: str) -> str:
 
     # 2. Think — call LLM with memory context
     resp = llm.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -282,7 +282,7 @@ llm = Anthropic()
 
 # In agent_chat(), replace the OpenAI call with:
 resp = llm.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     system=f"You have these memories:\n{context}",
     messages=[{"role": "user", "content": user_input}],
@@ -571,7 +571,7 @@ model = ""
 
 [llm.providers.openai]        # optional named providers for plugin summarization
 type = "openai"               # openai/openai-compatible/anthropic/gemini
-model = "gpt-4o-mini"
+model = "gpt-5-mini"
 base_url = ""
 api_key = "env:OPENAI_API_KEY"
 
@@ -594,6 +594,8 @@ model = ""                    # empty = OpenClaw default agent model
 [prompts]                    # custom prompt template files
 compact = ""                 # for memsearch compact
 summarize = ""               # for plugin session summarization
+project_review = ""          # for plugin PROJECT.md maintenance
+user_profile = ""            # for plugin USER.md maintenance
 ```
 
 ### Environment variable references

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -91,13 +91,101 @@ named provider and point a plugin at it:
 
 ```bash
 memsearch config set llm.providers.openai.type openai
-memsearch config set llm.providers.openai.model gpt-4o-mini
+memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.codex.summarize.provider openai
 ```
 
 Set `plugins.<platform>.summarize.provider` to `native`, or leave it empty, to
 preserve the current plugin behavior.
+
+You can disable automatic capture for a single project while keeping the plugin
+installed:
+
+```bash
+memsearch config set plugins.codex.summarize.enabled false --project
+```
+
+## Advanced Plugin Maintenance
+
+Plugins can optionally maintain higher-level markdown files in the background.
+This is disabled by default.
+
+| Task | Default output | Purpose |
+|------|----------------|---------|
+| `project_review` | `.memsearch/PROJECT.md` | Durable project state: active threads, decisions, risks, next steps |
+| `user_profile` | `.memsearch/USER.md` | Reusable user preferences, working style, recurring goals, background context |
+
+Example project-level setup for Codex:
+
+```bash
+memsearch config set plugins.codex.project_review.enabled true --project
+memsearch config set plugins.codex.project_review.provider native --project
+memsearch config set plugins.codex.project_review.min_interval_hours 24 --project
+memsearch config set plugins.codex.project_review.input_dir .memsearch/memory --project
+memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md --project
+
+memsearch config set plugins.codex.user_profile.enabled true --project
+memsearch config set plugins.codex.user_profile.provider native --project
+memsearch config set plugins.codex.user_profile.output_file .memsearch/USER.md --project
+```
+
+Equivalent TOML:
+
+```toml
+[plugins.codex.summarize]
+enabled = true
+provider = ""  # empty/native keeps the plugin-native summarizer
+model = ""
+
+[plugins.codex.project_review]
+enabled = true
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/PROJECT.md"
+
+[plugins.codex.user_profile]
+enabled = true
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/USER.md"
+```
+
+`input_dir` and `output_file` can be relative or absolute. Relative paths are
+resolved from the current project directory. The default input is the daily
+memory journal directory.
+
+Maintenance tasks run when the plugin wakes them and all of these are true:
+
+- the task is enabled
+- the input markdown digest changed
+- `min_interval_hours` has elapsed since the last successful run
+
+Set `provider = "native"` to reuse the agent's own non-interactive model path.
+To use a memsearch-managed API provider instead, define a named provider and
+reference it from the task:
+
+```bash
+memsearch config set llm.providers.openai.type openai
+memsearch config set llm.providers.openai.model gpt-5-mini
+memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
+memsearch config set plugins.codex.project_review.provider openai --project
+```
+
+Custom maintenance prompts are configured globally or per project:
+
+```bash
+memsearch config set prompts.project_review .memsearch/prompts/project-review.txt --project
+memsearch config set prompts.user_profile .memsearch/prompts/user-profile.txt --project
+```
+
+The plugin-installed `memory-config` skill can inspect current config, memory
+files, and index health; explain these settings; and make safe project-scoped
+changes from natural-language requests.
 
 ## Platform-Specific Config
 

--- a/docs/home/embedding-evaluation.md
+++ b/docs/home/embedding-evaluation.md
@@ -21,7 +21,7 @@ We built the evaluation set from real memsearch memory logs (`.memsearch/memory/
 
 1. **Collect** — Scan markdown memory files, chunk by heading using memsearch's `chunk_markdown()`.
 2. **Clean** — Remove HTML comments, drop short chunks (<50 chars), sanitize sensitive data (paths, IPs, tokens).
-3. **Annotate** with `gpt-4o-mini`:
+3. **Annotate** with `gpt-5-mini`:
     - **Simple** (1 per chunk) — straightforward factual questions.
     - **Complex** (1 per substantial chunk) — reasoning-required questions.
     - **Multi-hop** (group related chunks by project + date) — questions needing 2+ chunks to answer.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -68,7 +68,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 
-llm = ChatOpenAI(model="gpt-4o-mini")
+llm = ChatOpenAI(model="gpt-5-mini")
 retriever = MemSearchRetriever(mem=mem, top_k=3)
 
 
@@ -129,7 +129,7 @@ def search_memory(query: str) -> str:
     )
 
 
-llm = ChatOpenAI(model="gpt-4o-mini")
+llm = ChatOpenAI(model="gpt-5-mini")
 agent = create_react_agent(llm, [search_memory])
 
 result = agent.invoke(

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -176,9 +176,9 @@ Use an LLM to compress indexed chunks into a summary. The summary is appended to
 
 | Provider | Default Model |
 |----------|--------------|
-| `openai` | `gpt-4o-mini` |
-| `anthropic` | `claude-sonnet-4-5-20250929` |
-| `gemini` | `gemini-2.0-flash` |
+| `openai` | `gpt-5-mini` |
+| `anthropic` | `claude-sonnet-4-6` |
+| `gemini` | `gemini-3-flash-preview` |
 
 ```python
 # Compact all memories
@@ -266,7 +266,7 @@ A complete agent loop: seed knowledge, index it, then recall it during conversat
 
         # 2. Think — call LLM with memory context
         resp = llm.chat.completions.create(
-            model="gpt-4o-mini",
+            model="gpt-5-mini",
             messages=[
                 {"role": "system", "content": f"You have these memories:\n{context}"},
                 {"role": "user", "content": user_input},
@@ -314,7 +314,7 @@ A complete agent loop: seed knowledge, index it, then recall it during conversat
         context = "\n".join(f"- {m['content'][:200]}" for m in memories)
 
         resp = llm.messages.create(
-            model="claude-sonnet-4-5-20250929",
+            model="claude-sonnet-4-6",
             max_tokens=1024,
             system=f"You have these memories:\n{context}",
             messages=[{"role": "user", "content": user_input}],

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -12,7 +12,7 @@ The evaluation dataset was built from real-world memsearch memory logs (`.memsea
 
 1. **Collect** — Scan markdown memory files, chunk by heading using memsearch's `chunk_markdown()`
 2. **Clean** — Remove HTML comments, short chunks (<50 chars), sanitize sensitive data (paths, IPs, tokens)
-3. **Annotate** — Generate queries with `gpt-4o-mini`:
+3. **Annotate** — Generate queries with `gpt-5-mini`:
    - **Simple** (1 per chunk): straightforward factual questions
    - **Complex** (1 per substantial chunk): reasoning-required questions
    - **Multi-hop** (group related chunks by project+date): questions requiring information from 2+ chunks

--- a/plugins/_shared/prompts/project_review.txt
+++ b/plugins/_shared/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/plugins/_shared/prompts/user_profile.txt
+++ b/plugins/_shared/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Plugin-local runner for MemSearch maintenance tasks.
+
+This script belongs to the plugin layer. It handles host-native agent
+invocations, while the Python package provides shared config, due-state,
+prompt, and API-provider logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_NATIVE_MODELS = {
+    "claude-code": "sonnet",
+    "codex": "",
+    "opencode": "",
+    "openclaw": "",
+}
+
+
+def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=timeout,
+        check=False,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def extract_task_json_output(output: str) -> str:
+    """Extract the first maintenance JSON object from noisy host output."""
+    for line in output.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "action" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+    return output
+
+
+def ensure_opencode_isolated_config() -> Path:
+    home = Path.home()
+    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    src = home / ".config" / "opencode" / "opencode.json"
+    if src.is_file():
+        shutil.copy2(src, isolated / "opencode.json")
+    return isolated
+
+
+def ensure_memsearch_importable() -> None:
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = shutil.which("memsearch")
+    if memsearch_bin:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"},
+                    )
+
+    uv = shutil.which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def apply_plugin_prompt_defaults(cfg) -> None:
+    plugin_dir = Path(__file__).resolve().parent.parent
+    prompts_dir = plugin_dir / "prompts"
+    for task in ("project_review", "user_profile"):
+        if getattr(cfg.prompts, task, ""):
+            continue
+        prompt_file = prompts_dir / f"{task}.txt"
+        if prompt_file.is_file():
+            setattr(cfg.prompts, task, str(prompt_file))
+
+
+def run_native_provider(ctx, prompt: str) -> str:
+    model = ctx.task_config.model or DEFAULT_NATIVE_MODELS.get(ctx.platform, "")
+    env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
+
+    if ctx.platform == "claude-code":
+        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [
+            "--system-prompt",
+            "You are a maintenance task runner. Output only the requested JSON object.",
+            prompt,
+        ]
+        env["CLAUDECODE"] = ""
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    if ctx.platform == "codex":
+        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "-c",
+            "features.hooks=false",
+            "-c",
+            'model_reasoning_effort="medium"',
+            "-o",
+            str(output_path),
+        ]
+        profile = os.environ.get("MEMSEARCH_CODEX_PROFILE", "").strip()
+        if profile:
+            cmd += ["-p", profile]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["MEMSEARCH_IN_STOP_WORKER"] = "1"
+        try:
+            run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    if ctx.platform == "openclaw":
+        cmd = ["openclaw", "agent", "--local", "--session-id", "memsearch-maintenance"]
+        if model:
+            cmd += ["--model", model]
+        cmd += ["-m", prompt]
+        env["MEMSEARCH_DISABLE"] = "1"
+        return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
+
+    if ctx.platform == "opencode":
+        isolated = ensure_opencode_isolated_config()
+        cmd = ["opencode", "run"]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["XDG_CONFIG_HOME"] = str(isolated)
+        env["XDG_DATA_HOME"] = str(isolated / "data")
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    raise RuntimeError(f"Unsupported native maintenance platform {ctx.platform!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run plugin-local MemSearch maintenance tasks.")
+    parser.add_argument("--platform", required=True, choices=["claude-code", "codex", "opencode", "openclaw"])
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--memsearch-dir", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    args = parser.parse_args()
+
+    old_cwd = Path.cwd()
+    try:
+        ensure_memsearch_importable()
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+
+        project_dir = Path(args.project_dir or old_cwd).expanduser().resolve()
+        os.chdir(project_dir)
+        cfg = resolve_config()
+        apply_plugin_prompt_defaults(cfg)
+
+        def llm_runner(ctx, prompt: str) -> str:
+            provider_name = (ctx.task_config.provider or "native").strip()
+            if provider_name in {"", "native"}:
+                return run_native_provider(ctx, prompt)
+            return run_task_llm(ctx, prompt, cfg)
+
+        results = run_due_tasks(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
+    except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        sys.stderr.write(f"Maintenance error: {exc}\n")
+        return 1
+    finally:
+        with contextlib.suppress(OSError):
+            os.chdir(old_cwd)
+
+    payload = [result.__dict__ for result in results]
+    if args.json_output:
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    else:
+        for result in results:
+            detail = f": {result.reason}" if result.reason else ""
+            sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -124,6 +124,16 @@ run_memsearch() {
   fi
 }
 
+run_maintenance() {
+  if command -v python3 >/dev/null 2>&1; then
+    MEMSEARCH_NO_WATCH=1 python3 "$SCRIPT_DIR/../scripts/maintenance-runner.py" \
+      --platform claude-code \
+      --project-dir "$_PROJECT_DIR" \
+      --memsearch-dir "$MEMSEARCH_DIR" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
 # --- Index process cleanup ---
 
 INDEX_PIDFILE="$MEMSEARCH_DIR/.index.pid"

--- a/plugins/claude-code/hooks/session-end.sh
+++ b/plugins/claude-code/hooks/session-end.sh
@@ -4,6 +4,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+( run_maintenance ) </dev/null &>/dev/null &
+
 stop_watch
 kill_orphaned_index
 

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -54,6 +54,12 @@ fi
 
 ensure_memory_dir
 
+SUMMARIZE_ENABLED=$($MEMSEARCH_CMD config get plugins.claude-code.summarize.enabled 2>/dev/null || echo "true")
+if [ "$SUMMARIZE_ENABLED" = "false" ]; then
+  echo '{}'
+  exit 0
+fi
+
 # Parse transcript — extract the last turn only (one user question + all responses)
 PARSED=$("$SCRIPT_DIR/parse-transcript.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)
 

--- a/plugins/claude-code/prompts/project_review.txt
+++ b/plugins/claude-code/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/plugins/claude-code/prompts/user_profile.txt
+++ b/plugins/claude-code/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Plugin-local runner for MemSearch maintenance tasks.
+
+This script belongs to the plugin layer. It handles host-native agent
+invocations, while the Python package provides shared config, due-state,
+prompt, and API-provider logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_NATIVE_MODELS = {
+    "claude-code": "sonnet",
+    "codex": "",
+    "opencode": "",
+    "openclaw": "",
+}
+
+
+def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=timeout,
+        check=False,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def extract_task_json_output(output: str) -> str:
+    """Extract the first maintenance JSON object from noisy host output."""
+    for line in output.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "action" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+    return output
+
+
+def ensure_opencode_isolated_config() -> Path:
+    home = Path.home()
+    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    src = home / ".config" / "opencode" / "opencode.json"
+    if src.is_file():
+        shutil.copy2(src, isolated / "opencode.json")
+    return isolated
+
+
+def ensure_memsearch_importable() -> None:
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = shutil.which("memsearch")
+    if memsearch_bin:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"},
+                    )
+
+    uv = shutil.which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def apply_plugin_prompt_defaults(cfg) -> None:
+    plugin_dir = Path(__file__).resolve().parent.parent
+    prompts_dir = plugin_dir / "prompts"
+    for task in ("project_review", "user_profile"):
+        if getattr(cfg.prompts, task, ""):
+            continue
+        prompt_file = prompts_dir / f"{task}.txt"
+        if prompt_file.is_file():
+            setattr(cfg.prompts, task, str(prompt_file))
+
+
+def run_native_provider(ctx, prompt: str) -> str:
+    model = ctx.task_config.model or DEFAULT_NATIVE_MODELS.get(ctx.platform, "")
+    env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
+
+    if ctx.platform == "claude-code":
+        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [
+            "--system-prompt",
+            "You are a maintenance task runner. Output only the requested JSON object.",
+            prompt,
+        ]
+        env["CLAUDECODE"] = ""
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    if ctx.platform == "codex":
+        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "-c",
+            "features.hooks=false",
+            "-c",
+            'model_reasoning_effort="medium"',
+            "-o",
+            str(output_path),
+        ]
+        profile = os.environ.get("MEMSEARCH_CODEX_PROFILE", "").strip()
+        if profile:
+            cmd += ["-p", profile]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["MEMSEARCH_IN_STOP_WORKER"] = "1"
+        try:
+            run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    if ctx.platform == "openclaw":
+        cmd = ["openclaw", "agent", "--local", "--session-id", "memsearch-maintenance"]
+        if model:
+            cmd += ["--model", model]
+        cmd += ["-m", prompt]
+        env["MEMSEARCH_DISABLE"] = "1"
+        return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
+
+    if ctx.platform == "opencode":
+        isolated = ensure_opencode_isolated_config()
+        cmd = ["opencode", "run"]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["XDG_CONFIG_HOME"] = str(isolated)
+        env["XDG_DATA_HOME"] = str(isolated / "data")
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    raise RuntimeError(f"Unsupported native maintenance platform {ctx.platform!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run plugin-local MemSearch maintenance tasks.")
+    parser.add_argument("--platform", required=True, choices=["claude-code", "codex", "opencode", "openclaw"])
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--memsearch-dir", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    args = parser.parse_args()
+
+    old_cwd = Path.cwd()
+    try:
+        ensure_memsearch_importable()
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+
+        project_dir = Path(args.project_dir or old_cwd).expanduser().resolve()
+        os.chdir(project_dir)
+        cfg = resolve_config()
+        apply_plugin_prompt_defaults(cfg)
+
+        def llm_runner(ctx, prompt: str) -> str:
+            provider_name = (ctx.task_config.provider or "native").strip()
+            if provider_name in {"", "native"}:
+                return run_native_provider(ctx, prompt)
+            return run_task_llm(ctx, prompt, cfg)
+
+        results = run_due_tasks(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
+    except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        sys.stderr.write(f"Maintenance error: {exc}\n")
+        return 1
+    finally:
+        with contextlib.suppress(OSError):
+            os.chdir(old_cwd)
+
+    payload = [result.__dict__ for result in results]
+    if args.json_output:
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    else:
+        for result in results:
+            detail = f": {result.reason}" if result.reason else ""
+            sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/claude-code/skills/memory-config/SKILL.md
+++ b/plugins/claude-code/skills/memory-config/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: memory-config
+description: "Diagnose and configure MemSearch memory behavior for the Claude Code plugin. Use when the user asks about MemSearch configuration, plugin summarization, PROJECT.md/USER.md maintenance, memory directories, index health, provider routing, prompt files, or migration/compatibility questions."
+context: fork
+allowed-tools: Bash
+---
+
+You are a MemSearch configuration assistant for the Claude Code plugin. This skill manages MemSearch settings only. It is not Claude Code's built-in memory configuration.
+
+Start every user-facing answer with:
+
+> This is MemSearch memory config, not Claude Code's own memory config.
+
+When this skill is triggered, inspect the user's request text. If there is no concrete request, run a diagnostic. If they ask for a specific setting or change, route the request using the flows below.
+
+## Intent Routing
+
+- Empty request or "check": diagnose current MemSearch setup.
+- "Show/get setting": read the requested resolved/global/project value.
+- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
+- "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
+- "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "Prompt": explain or configure prompt overrides.
+
+Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
+
+## Diagnose First
+
+```bash
+memsearch config list --resolved
+memsearch config list --global
+memsearch config list --project
+```
+
+If `memsearch` is unavailable, try `uvx --from memsearch[onnx] memsearch --version`.
+
+Check memory files:
+
+```bash
+MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}/memory"
+ls -la "$MDIR"
+find "$MDIR" -maxdepth 1 -type f -name '*.md' | sort | tail -10
+tail -120 "$MDIR/$(date +%Y-%m-%d).md"
+```
+
+Check index health:
+
+```bash
+memsearch stats
+```
+
+## Background and Compatibility
+
+Some plugin config fields may be missing or empty. That is usually normal:
+
+- `summarize.enabled`, advanced maintenance, and task-specific provider/model fields are newer settings.
+- Existing users' TOML files are not rewritten automatically after package/plugin upgrades.
+- Empty strings usually mean "use the built-in or host-native default"; they do not necessarily mean "disabled" or "broken".
+- Missing fields should be interpreted through `memsearch config list --resolved`, not by reading raw TOML alone.
+- New users who run `memsearch config init` may see more fields than old users because the template includes newer options.
+- Advanced maintenance is intentionally disabled by default to avoid surprise background model calls.
+
+## Configuration Logic
+
+Config is resolved from built-in defaults, global config, project config, env refs like `env:OPENAI_API_KEY`, and runtime env such as `MEMSEARCH_DIR`.
+
+Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
+
+Default recommendation:
+
+- Put reusable defaults in global config so users do not repeat setup in every project.
+- Put only project-specific overrides in project config.
+- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
+- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+
+Claude Code plugin keys:
+
+```toml
+[plugins.claude-code.summarize]
+enabled = true
+provider = ""      # empty/native = Claude Code native summarizer
+model = ""
+
+[plugins.claude-code.project_review]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/PROJECT.md"
+
+[plugins.claude-code.user_profile]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/USER.md"
+```
+
+Provider rules:
+
+- `provider = ""` or `native` uses Claude Code's non-interactive native path.
+- Any other provider value is a name that must exist under `[llm.providers.<name>]`.
+- Model resolution order is task-level `plugins.claude-code.<task>.model`, then named provider model, then built-in default.
+- API keys should be configured as env refs, not pasted into chat.
+- If a raw TOML field is blank, check resolved config before calling it unset or broken.
+
+Common provider examples:
+
+```toml
+[llm.providers.openai]
+type = "openai"
+model = "gpt-5-mini"
+api_key = "env:OPENAI_API_KEY"
+
+[llm.providers.anthropic]
+type = "anthropic"
+model = "claude-sonnet-4-6"
+api_key = "env:ANTHROPIC_API_KEY"
+
+[llm.providers.gemini]
+type = "gemini"
+model = "gemini-3-flash-preview"
+api_key = "env:GEMINI_API_KEY"
+```
+
+Model guidance:
+
+- Normal turn summaries can use small/fast models. Claude Code native summarize defaults to `haiku`.
+- Advanced maintenance needs better judgment. Claude Code native maintenance defaults to `sonnet`.
+- For API providers, defaults are `openai -> gpt-5-mini`, `anthropic -> claude-sonnet-4-6`, and `gemini -> gemini-3-flash-preview`.
+- If quality matters more than cost for maintenance, set `plugins.claude-code.project_review.model` and `plugins.claude-code.user_profile.model` explicitly.
+
+Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+
+Prompt overrides:
+
+```toml
+[prompts]
+summarize = ""
+project_review = ""
+user_profile = ""
+```
+
+Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
+
+Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+
+MemSearch TOML changes are read lazily by the CLI, hooks, and maintenance runner, so values such as `plugins.claude-code.summarize.*`, `plugins.claude-code.project_review.*`, `plugins.claude-code.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. A fresh Claude Code session is recommended after plugin install/update or hook/skill file changes, because the current session may already have loaded the old plugin state. After any answer, make clear that this is MemSearch memory configuration, not Claude Code's own memory/config system.
+
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -97,7 +97,7 @@ To use a memsearch-managed API provider instead:
 
 ```bash
 memsearch config set llm.providers.openai.type openai
-memsearch config set llm.providers.openai.model gpt-4o-mini
+memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.codex.summarize.provider openai
 ```

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -146,6 +146,16 @@ run_memsearch() {
   fi
 }
 
+run_maintenance() {
+  if command -v python3 >/dev/null 2>&1; then
+    MEMSEARCH_NO_WATCH=1 python3 "$SCRIPT_DIR/../scripts/maintenance-runner.py" \
+      --platform codex \
+      --project-dir "$PROJECT_DIR" \
+      --memsearch-dir "$MEMSEARCH_DIR" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
 # --- Index process cleanup ---
 
 INDEX_PIDFILE="$MEMSEARCH_DIR/.index.pid"

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -79,6 +79,14 @@ run_worker() {
 
   ensure_memory_dir
 
+  local SUMMARIZE_ENABLED="true"
+  if memsearch_available; then
+    SUMMARIZE_ENABLED=$(_memsearch config get plugins.codex.summarize.enabled 2>/dev/null || echo "true")
+  fi
+  if [ "$SUMMARIZE_ENABLED" = "false" ]; then
+    return 0
+  fi
+
   # Load summarization prompt: user custom (via config) > plugin built-in template
   local AGENT_NAME="Codex"
   local PROMPT_FILE=""
@@ -178,6 +186,8 @@ ${CONTENT}"
     kill_orphaned_index
     run_memsearch index "$MEMORY_DIR" >/dev/null
   fi
+
+  run_maintenance
 }
 
 if [ "${1:-}" = "--worker" ]; then

--- a/plugins/codex/prompts/project_review.txt
+++ b/plugins/codex/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/plugins/codex/prompts/user_profile.txt
+++ b/plugins/codex/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -185,27 +185,32 @@ else
   uvx --from 'memsearch[onnx]' memsearch --version 2>/dev/null || true
 fi
 
-# --- 2. Install memory-recall skill ---
-echo "[2/6] Installing memory-recall skill..."
-SKILL_SRC="$INSTALL_DIR/skills/memory-recall"
-SKILL_DST="$HOME/.agents/skills/memory-recall"
+# --- 2. Install skills ---
+echo "[2/6] Installing memsearch skills..."
 mkdir -p "$HOME/.agents/skills"
 
-if [ -d "$SKILL_DST" ] || [ -L "$SKILL_DST" ]; then
-  echo "  ⚠ Existing memory-recall skill found — replacing"
-  rm -rf "$SKILL_DST"
-fi
+for skill_name in memory-recall memory-config; do
+  SKILL_SRC="$INSTALL_DIR/skills/$skill_name"
+  SKILL_DST="$HOME/.agents/skills/$skill_name"
+  if [ -d "$SKILL_DST" ] || [ -L "$SKILL_DST" ]; then
+    echo "  ⚠ Existing $skill_name skill found — replacing"
+    rm -rf "$SKILL_DST"
+  fi
 
-# Copy (not symlink) so we can substitute __INSTALL_DIR__ placeholder
-cp -r "$SKILL_SRC" "$SKILL_DST"
-echo "  ✓ Copied skill to $SKILL_DST"
+  # Copy (not symlink) so we can substitute __INSTALL_DIR__ placeholder
+  cp -r "$SKILL_SRC" "$SKILL_DST"
+  echo "  ✓ Copied $skill_name skill to $SKILL_DST"
+done
 
 # --- 3. Replace __INSTALL_DIR__ placeholder in SKILL.md ---
 echo "[3/6] Configuring skill paths..."
-if [ -f "$SKILL_DST/SKILL.md" ]; then
-  replace_text_in_file "$SKILL_DST/SKILL.md" "__INSTALL_DIR__" "$INSTALL_DIR"
-  echo "  ✓ Updated SKILL.md with install path: $INSTALL_DIR"
-fi
+for skill_name in memory-recall memory-config; do
+  SKILL_DST="$HOME/.agents/skills/$skill_name"
+  if [ -f "$SKILL_DST/SKILL.md" ]; then
+    replace_text_in_file "$SKILL_DST/SKILL.md" "__INSTALL_DIR__" "$INSTALL_DIR"
+    echo "  ✓ Updated $skill_name SKILL.md with install path: $INSTALL_DIR"
+  fi
+done
 
 # --- 4. Install or update hooks.json ---
 echo "[4/6] Configuring hooks..."
@@ -242,10 +247,11 @@ echo "  • SessionStart: indexes project memory, injects recent context"
 echo "  • Stop: summarizes each turn and saves to memory"
 echo "  • UserPromptSubmit: reminds Codex about memory-recall skill"
 echo "  • memory-recall skill: search past memories when relevant"
+echo "  • memory-config skill: diagnose and configure memsearch"
 echo ""
 echo "Memory files:   <project>/.memsearch/memory/*.md"
 echo "Hooks config:   $HOOKS_FILE"
-echo "Skill location: $SKILL_DST"
+echo "Skill location: $HOME/.agents/skills/{memory-recall,memory-config}"
 echo "Feature flag:   hooks = true in $CONFIG_FILE"
 echo ""
 echo "To verify: start a new codex session and check for [memsearch] status line."

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Plugin-local runner for MemSearch maintenance tasks.
+
+This script belongs to the plugin layer. It handles host-native agent
+invocations, while the Python package provides shared config, due-state,
+prompt, and API-provider logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_NATIVE_MODELS = {
+    "claude-code": "sonnet",
+    "codex": "",
+    "opencode": "",
+    "openclaw": "",
+}
+
+
+def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=timeout,
+        check=False,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def extract_task_json_output(output: str) -> str:
+    """Extract the first maintenance JSON object from noisy host output."""
+    for line in output.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "action" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+    return output
+
+
+def ensure_opencode_isolated_config() -> Path:
+    home = Path.home()
+    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    src = home / ".config" / "opencode" / "opencode.json"
+    if src.is_file():
+        shutil.copy2(src, isolated / "opencode.json")
+    return isolated
+
+
+def ensure_memsearch_importable() -> None:
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = shutil.which("memsearch")
+    if memsearch_bin:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"},
+                    )
+
+    uv = shutil.which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def apply_plugin_prompt_defaults(cfg) -> None:
+    plugin_dir = Path(__file__).resolve().parent.parent
+    prompts_dir = plugin_dir / "prompts"
+    for task in ("project_review", "user_profile"):
+        if getattr(cfg.prompts, task, ""):
+            continue
+        prompt_file = prompts_dir / f"{task}.txt"
+        if prompt_file.is_file():
+            setattr(cfg.prompts, task, str(prompt_file))
+
+
+def run_native_provider(ctx, prompt: str) -> str:
+    model = ctx.task_config.model or DEFAULT_NATIVE_MODELS.get(ctx.platform, "")
+    env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
+
+    if ctx.platform == "claude-code":
+        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [
+            "--system-prompt",
+            "You are a maintenance task runner. Output only the requested JSON object.",
+            prompt,
+        ]
+        env["CLAUDECODE"] = ""
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    if ctx.platform == "codex":
+        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "-c",
+            "features.hooks=false",
+            "-c",
+            'model_reasoning_effort="medium"',
+            "-o",
+            str(output_path),
+        ]
+        profile = os.environ.get("MEMSEARCH_CODEX_PROFILE", "").strip()
+        if profile:
+            cmd += ["-p", profile]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["MEMSEARCH_IN_STOP_WORKER"] = "1"
+        try:
+            run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    if ctx.platform == "openclaw":
+        cmd = ["openclaw", "agent", "--local", "--session-id", "memsearch-maintenance"]
+        if model:
+            cmd += ["--model", model]
+        cmd += ["-m", prompt]
+        env["MEMSEARCH_DISABLE"] = "1"
+        return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
+
+    if ctx.platform == "opencode":
+        isolated = ensure_opencode_isolated_config()
+        cmd = ["opencode", "run"]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["XDG_CONFIG_HOME"] = str(isolated)
+        env["XDG_DATA_HOME"] = str(isolated / "data")
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    raise RuntimeError(f"Unsupported native maintenance platform {ctx.platform!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run plugin-local MemSearch maintenance tasks.")
+    parser.add_argument("--platform", required=True, choices=["claude-code", "codex", "opencode", "openclaw"])
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--memsearch-dir", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    args = parser.parse_args()
+
+    old_cwd = Path.cwd()
+    try:
+        ensure_memsearch_importable()
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+
+        project_dir = Path(args.project_dir or old_cwd).expanduser().resolve()
+        os.chdir(project_dir)
+        cfg = resolve_config()
+        apply_plugin_prompt_defaults(cfg)
+
+        def llm_runner(ctx, prompt: str) -> str:
+            provider_name = (ctx.task_config.provider or "native").strip()
+            if provider_name in {"", "native"}:
+                return run_native_provider(ctx, prompt)
+            return run_task_llm(ctx, prompt, cfg)
+
+        results = run_due_tasks(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
+    except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        sys.stderr.write(f"Maintenance error: {exc}\n")
+        return 1
+    finally:
+        with contextlib.suppress(OSError):
+            os.chdir(old_cwd)
+
+    payload = [result.__dict__ for result in results]
+    if args.json_output:
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    else:
+        for result in results:
+            detail = f": {result.reason}" if result.reason else ""
+            sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/codex/skills/memory-config/SKILL.md
+++ b/plugins/codex/skills/memory-config/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: memory-config
+description: "Diagnose and configure MemSearch memory behavior for the Codex plugin. Use when the user asks about MemSearch configuration, plugin summarization, PROJECT.md/USER.md maintenance, memory directories, index health, provider routing, prompt files, or migration/compatibility questions."
+---
+
+You are a MemSearch configuration assistant for the Codex plugin. This skill manages MemSearch settings only. It is not Codex's built-in memory configuration.
+
+Start every user-facing answer with:
+
+> This is MemSearch memory config, not Codex's own memory config.
+
+When this skill is triggered, inspect the user's request text. If there is no concrete request, run a diagnostic. If they ask for a specific setting or change, route the request using the flows below.
+
+## Intent Routing
+
+- Empty request or "check": diagnose current MemSearch setup.
+- "Show/get setting": read the requested resolved/global/project value.
+- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
+- "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
+- "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "Prompt": explain or configure prompt overrides.
+
+Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
+
+## Diagnose First
+
+```bash
+memsearch config list --resolved
+memsearch config list --global
+memsearch config list --project
+```
+
+If `memsearch` is unavailable, try `uvx --from memsearch[onnx] memsearch --version`.
+
+Check memory files:
+
+```bash
+MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}/memory"
+ls -la "$MDIR"
+find "$MDIR" -maxdepth 1 -type f -name '*.md' | sort | tail -10
+tail -120 "$MDIR/$(date +%Y-%m-%d).md"
+```
+
+Check index health:
+
+```bash
+memsearch stats
+```
+
+## Background and Compatibility
+
+Some plugin config fields may be missing or empty. That is usually normal:
+
+- `summarize.enabled`, advanced maintenance, and task-specific provider/model fields are newer settings.
+- Existing users' TOML files are not rewritten automatically after package/plugin upgrades.
+- Empty strings usually mean "use the built-in or host-native default"; they do not necessarily mean "disabled" or "broken".
+- Missing fields should be interpreted through `memsearch config list --resolved`, not by reading raw TOML alone.
+- New users who run `memsearch config init` may see more fields than old users because the template includes newer options.
+- Advanced maintenance is intentionally disabled by default to avoid surprise background model calls.
+
+## Configuration Logic
+
+Config is resolved from built-in defaults, global config, project config, env refs like `env:OPENAI_API_KEY`, and runtime env such as `MEMSEARCH_DIR`.
+
+Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
+
+Default recommendation:
+
+- Put reusable defaults in global config so users do not repeat setup in every project.
+- Put only project-specific overrides in project config.
+- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
+- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+
+Codex plugin keys:
+
+```toml
+[plugins.codex.summarize]
+enabled = true
+provider = ""      # empty/native = Codex native summarizer
+model = ""
+
+[plugins.codex.project_review]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/PROJECT.md"
+
+[plugins.codex.user_profile]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/USER.md"
+```
+
+Provider rules:
+
+- `provider = ""` or `native` uses Codex's non-interactive native path.
+- Any other provider value is a name that must exist under `[llm.providers.<name>]`.
+- Model resolution order is task-level `plugins.codex.<task>.model`, then named provider model, then built-in default.
+- API keys should be configured as env refs, not pasted into chat.
+- If a raw TOML field is blank, check resolved config before calling it unset or broken.
+
+Common provider examples:
+
+```toml
+[llm.providers.openai]
+type = "openai"
+model = "gpt-5-mini"
+api_key = "env:OPENAI_API_KEY"
+
+[llm.providers.anthropic]
+type = "anthropic"
+model = "claude-sonnet-4-6"
+api_key = "env:ANTHROPIC_API_KEY"
+
+[llm.providers.gemini]
+type = "gemini"
+model = "gemini-3-flash-preview"
+api_key = "env:GEMINI_API_KEY"
+```
+
+Model guidance:
+
+- Normal turn summaries can use small/fast models. Codex native summarize defaults to `gpt-5.1-codex-mini`.
+- Advanced maintenance needs better judgment. Codex native maintenance uses the Codex default unless `plugins.codex.<task>.model` is set.
+- For API providers, defaults are `openai -> gpt-5-mini`, `anthropic -> claude-sonnet-4-6`, and `gemini -> gemini-3-flash-preview`.
+- If quality matters more than cost for maintenance, set `plugins.codex.project_review.model` and `plugins.codex.user_profile.model` explicitly.
+
+Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+
+Prompt overrides:
+
+```toml
+[prompts]
+summarize = ""
+project_review = ""
+user_profile = ""
+```
+
+Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
+
+Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+
+MemSearch TOML changes are read lazily by the CLI, hooks, and maintenance runner, so values such as `plugins.codex.summarize.*`, `plugins.codex.project_review.*`, `plugins.codex.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. A fresh Codex session is recommended after `hooks.json`, skill, plugin, or local agent-file changes, because the current session may already have loaded the old hook/skill state. After any answer, make clear that this is MemSearch memory configuration, not Codex's own memory/config system.
+
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -116,7 +116,7 @@ To use a memsearch-managed API provider instead:
 
 ```bash
 memsearch config set llm.providers.openai.type openai
-memsearch config set llm.providers.openai.model gpt-4o-mini
+memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.openclaw.summarize.provider openai
 ```

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -186,6 +186,24 @@ var index_default = {
       );
       return r.stdout?.trim() || "";
     }
+    async function wakeMaintenance() {
+      try {
+        const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
+        runCmd(
+          [
+            "bash",
+            "-c",
+            `python3 '${shellEscape(runner)}' --platform openclaw --project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(memsearchDir)}'`
+          ],
+          {
+            timeoutMs: 12e4,
+            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" })
+          }
+        ).catch(() => {
+        });
+      } catch {
+      }
+    }
     let _collectionNameFor = "";
     let _collectionName = "ms_openclaw_default";
     async function getCollectionName() {
@@ -500,10 +518,22 @@ ${anchor}${cleanSummary}
       api.on("agent_end", async (event) => {
         const messages = event.messages || [];
         if (messages.length < 2) return;
+        let summarizeEnabled = "true";
+        try {
+          summarizeEnabled = await getMemsearchConfigValue("plugins.openclaw.summarize.enabled");
+        } catch {
+        }
+        if (summarizeEnabled === "false") {
+          wakeMaintenance().catch(() => {
+          });
+          return;
+        }
         const lastTurn = extractLastTurn(messages);
         if (!lastTurn || lastTurn.length < 50) return;
         const sessionId = event.sessionId || "";
-        writeTurnCapture(lastTurn, sessionId);
+        await writeTurnCapture(lastTurn, sessionId);
+        wakeMaintenance().catch(() => {
+        });
       });
     }
     api.on("session_start", async () => {

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -302,6 +302,26 @@ export default {
       return r.stdout?.trim() || "";
     }
 
+    async function wakeMaintenance(): Promise<void> {
+      try {
+        const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
+        runCmd(
+          [
+            "bash", "-c",
+            `python3 '${shellEscape(runner)}' --platform openclaw ` +
+              `--project-dir '${shellEscape(projectDir)}' ` +
+              `--memsearch-dir '${shellEscape(memsearchDir)}'`,
+          ],
+          {
+            timeoutMs: 120000,
+            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" }),
+          }
+        ).catch(() => { /* ignore */ });
+      } catch {
+        /* ignore */
+      }
+    }
+
     // --- Lazy-cached collection name derivation ---
     let _collectionNameFor = "";
     let _collectionName = "ms_openclaw_default";
@@ -703,11 +723,21 @@ export default {
         const messages = event.messages || [];
         if (messages.length < 2) return;
 
+        let summarizeEnabled = "true";
+        try {
+          summarizeEnabled = await getMemsearchConfigValue("plugins.openclaw.summarize.enabled");
+        } catch { /* ignore */ }
+        if (summarizeEnabled === "false") {
+          wakeMaintenance().catch(() => { /* ignore */ });
+          return;
+        }
+
         const lastTurn = extractLastTurn(messages);
         if (!lastTurn || lastTurn.length < 50) return;
 
         const sessionId = event.sessionId || "";
-        writeTurnCapture(lastTurn, sessionId);
+        await writeTurnCapture(lastTurn, sessionId);
+        wakeMaintenance().catch(() => { /* ignore */ });
       });
     }
 

--- a/plugins/openclaw/prompts/project_review.txt
+++ b/plugins/openclaw/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/plugins/openclaw/prompts/user_profile.txt
+++ b/plugins/openclaw/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Plugin-local runner for MemSearch maintenance tasks.
+
+This script belongs to the plugin layer. It handles host-native agent
+invocations, while the Python package provides shared config, due-state,
+prompt, and API-provider logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_NATIVE_MODELS = {
+    "claude-code": "sonnet",
+    "codex": "",
+    "opencode": "",
+    "openclaw": "",
+}
+
+
+def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=timeout,
+        check=False,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def extract_task_json_output(output: str) -> str:
+    """Extract the first maintenance JSON object from noisy host output."""
+    for line in output.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "action" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+    return output
+
+
+def ensure_opencode_isolated_config() -> Path:
+    home = Path.home()
+    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    src = home / ".config" / "opencode" / "opencode.json"
+    if src.is_file():
+        shutil.copy2(src, isolated / "opencode.json")
+    return isolated
+
+
+def ensure_memsearch_importable() -> None:
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = shutil.which("memsearch")
+    if memsearch_bin:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"},
+                    )
+
+    uv = shutil.which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def apply_plugin_prompt_defaults(cfg) -> None:
+    plugin_dir = Path(__file__).resolve().parent.parent
+    prompts_dir = plugin_dir / "prompts"
+    for task in ("project_review", "user_profile"):
+        if getattr(cfg.prompts, task, ""):
+            continue
+        prompt_file = prompts_dir / f"{task}.txt"
+        if prompt_file.is_file():
+            setattr(cfg.prompts, task, str(prompt_file))
+
+
+def run_native_provider(ctx, prompt: str) -> str:
+    model = ctx.task_config.model or DEFAULT_NATIVE_MODELS.get(ctx.platform, "")
+    env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
+
+    if ctx.platform == "claude-code":
+        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [
+            "--system-prompt",
+            "You are a maintenance task runner. Output only the requested JSON object.",
+            prompt,
+        ]
+        env["CLAUDECODE"] = ""
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    if ctx.platform == "codex":
+        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "-c",
+            "features.hooks=false",
+            "-c",
+            'model_reasoning_effort="medium"',
+            "-o",
+            str(output_path),
+        ]
+        profile = os.environ.get("MEMSEARCH_CODEX_PROFILE", "").strip()
+        if profile:
+            cmd += ["-p", profile]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["MEMSEARCH_IN_STOP_WORKER"] = "1"
+        try:
+            run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    if ctx.platform == "openclaw":
+        cmd = ["openclaw", "agent", "--local", "--session-id", "memsearch-maintenance"]
+        if model:
+            cmd += ["--model", model]
+        cmd += ["-m", prompt]
+        env["MEMSEARCH_DISABLE"] = "1"
+        return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
+
+    if ctx.platform == "opencode":
+        isolated = ensure_opencode_isolated_config()
+        cmd = ["opencode", "run"]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["XDG_CONFIG_HOME"] = str(isolated)
+        env["XDG_DATA_HOME"] = str(isolated / "data")
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    raise RuntimeError(f"Unsupported native maintenance platform {ctx.platform!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run plugin-local MemSearch maintenance tasks.")
+    parser.add_argument("--platform", required=True, choices=["claude-code", "codex", "opencode", "openclaw"])
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--memsearch-dir", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    args = parser.parse_args()
+
+    old_cwd = Path.cwd()
+    try:
+        ensure_memsearch_importable()
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+
+        project_dir = Path(args.project_dir or old_cwd).expanduser().resolve()
+        os.chdir(project_dir)
+        cfg = resolve_config()
+        apply_plugin_prompt_defaults(cfg)
+
+        def llm_runner(ctx, prompt: str) -> str:
+            provider_name = (ctx.task_config.provider or "native").strip()
+            if provider_name in {"", "native"}:
+                return run_native_provider(ctx, prompt)
+            return run_task_llm(ctx, prompt, cfg)
+
+        results = run_due_tasks(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
+    except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        sys.stderr.write(f"Maintenance error: {exc}\n")
+        return 1
+    finally:
+        with contextlib.suppress(OSError):
+            os.chdir(old_cwd)
+
+    payload = [result.__dict__ for result in results]
+    if args.json_output:
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    else:
+        for result in results:
+            detail = f": {result.reason}" if result.reason else ""
+            sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/openclaw/skills/memory-config/SKILL.md
+++ b/plugins/openclaw/skills/memory-config/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: memory-config
+description: "Diagnose and configure MemSearch memory behavior for the OpenClaw plugin. Use when the user asks about MemSearch configuration, plugin summarization, PROJECT.md/USER.md maintenance, memory directories, index health, provider routing, prompt files, or migration/compatibility questions."
+---
+
+You are a MemSearch configuration assistant for the OpenClaw plugin. This skill manages MemSearch settings only. It is not OpenClaw's built-in memory configuration.
+
+Start every user-facing answer with:
+
+> This is MemSearch memory config, not OpenClaw's own memory config.
+
+When this skill is triggered, inspect the user's request text. If there is no concrete request, run a diagnostic. If they ask for a specific setting or change, route the request using the flows below.
+
+## Intent Routing
+
+- Empty request or "check": diagnose current MemSearch setup.
+- "Show/get setting": read the requested resolved/global/project value.
+- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
+- "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
+- "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "Prompt": explain or configure prompt overrides.
+
+Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
+
+## Diagnose First
+
+```bash
+memsearch config list --resolved
+memsearch config list --global
+memsearch config list --project
+```
+
+If `memsearch` is unavailable, try `uvx --from memsearch[onnx] memsearch --version`.
+
+Check memory files:
+
+```bash
+MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}/memory"
+ls -la "$MDIR"
+find "$MDIR" -maxdepth 1 -type f -name '*.md' | sort | tail -10
+tail -120 "$MDIR/$(date +%Y-%m-%d).md"
+```
+
+Check index health:
+
+```bash
+memsearch stats
+```
+
+## Background and Compatibility
+
+Some plugin config fields may be missing or empty. That is usually normal:
+
+- `summarize.enabled`, advanced maintenance, and task-specific provider/model fields are newer settings.
+- Existing users' TOML files are not rewritten automatically after package/plugin upgrades.
+- Empty strings usually mean "use the built-in or host-native default"; they do not necessarily mean "disabled" or "broken".
+- Missing fields should be interpreted through `memsearch config list --resolved`, not by reading raw TOML alone.
+- New users who run `memsearch config init` may see more fields than old users because the template includes newer options.
+- Advanced maintenance is intentionally disabled by default to avoid surprise background model calls.
+
+## Configuration Logic
+
+Config is resolved from built-in defaults, global config, project config, env refs like `env:OPENAI_API_KEY`, and runtime env such as `MEMSEARCH_DIR`.
+
+Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for workspace-specific overrides.
+
+Default recommendation:
+
+- Put reusable defaults in global config so users do not repeat setup in every project.
+- Put only project-specific overrides in project config.
+- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
+- Use project config for one workspace's enable/disable switches, unusual output files, special intervals, or workspace-specific providers.
+
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current workspace/project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+
+OpenClaw plugin keys:
+
+```toml
+[plugins.openclaw.summarize]
+enabled = true
+provider = ""      # empty/native = OpenClaw native summarizer
+model = ""
+
+[plugins.openclaw.project_review]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/PROJECT.md"
+
+[plugins.openclaw.user_profile]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/USER.md"
+```
+
+Provider rules:
+
+- `provider = ""` or `native` uses OpenClaw's non-interactive native path.
+- Any other provider value is a name that must exist under `[llm.providers.<name>]`.
+- Model resolution order is task-level `plugins.openclaw.<task>.model`, then named provider model, then built-in default.
+- API keys should be configured as env refs, not pasted into chat.
+- If a raw TOML field is blank, check resolved config before calling it unset or broken.
+
+Common provider examples:
+
+```toml
+[llm.providers.openai]
+type = "openai"
+model = "gpt-5-mini"
+api_key = "env:OPENAI_API_KEY"
+
+[llm.providers.anthropic]
+type = "anthropic"
+model = "claude-sonnet-4-6"
+api_key = "env:ANTHROPIC_API_KEY"
+
+[llm.providers.gemini]
+type = "gemini"
+model = "gemini-3-flash-preview"
+api_key = "env:GEMINI_API_KEY"
+```
+
+Model guidance:
+
+- Normal turn summaries can use small/fast models. OpenClaw native summarize uses the OpenClaw agent/default model unless overridden.
+- Advanced maintenance needs better judgment. OpenClaw native maintenance also uses the OpenClaw agent/default model unless `plugins.openclaw.<task>.model` is set.
+- For API providers, defaults are `openai -> gpt-5-mini`, `anthropic -> claude-sonnet-4-6`, and `gemini -> gemini-3-flash-preview`.
+- If quality matters more than cost for maintenance, set `plugins.openclaw.project_review.model` and `plugins.openclaw.user_profile.model` explicitly.
+
+Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+
+Prompt overrides:
+
+```toml
+[prompts]
+summarize = ""
+project_review = ""
+user_profile = ""
+```
+
+Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
+
+Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+
+MemSearch TOML changes are read lazily by the CLI, OpenClaw plugin hooks/tools, and maintenance runner, so values such as `plugins.openclaw.summarize.*`, `plugins.openclaw.project_review.*`, `plugins.openclaw.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. Run `openclaw gateway restart` after plugin install/update or hook permission changes, because the gateway may already have loaded the old plugin state. After any answer, make clear that this is MemSearch memory configuration, not OpenClaw's own memory/config system.
+
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -158,7 +158,7 @@ To use a memsearch-managed API provider instead:
 
 ```bash
 memsearch config set llm.providers.openai.type openai
-memsearch config set llm.providers.openai.model gpt-4o-mini
+memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.opencode.summarize.provider openai
 ```

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -19,11 +19,12 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  realpathSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_DIR = dirname(realpathSync(fileURLToPath(import.meta.url)));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -167,6 +168,19 @@ function stopCaptureDaemon(projectDir: string): void {
   }
 }
 
+function wakeMaintenance(projectDir: string, memsearchDir: string): void {
+  const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
+  exec(
+    `python3 '${shellEscape(runner)}' --platform opencode ` +
+      `--project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(memsearchDir)}' &`,
+    {
+      timeout: 5000,
+      env: { ...process.env, MEMSEARCH_NO_WATCH: "1" },
+    },
+    () => { /* ignore */ }
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Plugin entry
 // ---------------------------------------------------------------------------
@@ -212,6 +226,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
   // Start capture daemon for auto-capture
   if (autoCapture) {
     startCaptureDaemon(projectDir, collectionName, memsearchCmd);
+    wakeMaintenance(projectDir, memsearchDir);
   }
 
   return {

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -41,16 +41,18 @@ else
 fi
 echo ""
 
-# 3. Symlink skill to ~/.agents/skills/ (OpenCode-compatible)
+# 3. Symlink skills to ~/.agents/skills/ (OpenCode-compatible)
 mkdir -p "${AGENTS_SKILLS_DIR}"
-SKILL_LINK="${AGENTS_SKILLS_DIR}/memory-recall"
-if [ -L "${SKILL_LINK}" ] || [ -d "${SKILL_LINK}" ]; then
-  echo "[SKIP] Skill already exists at ${SKILL_LINK}"
-  echo "       Remove it first if you want to reinstall: rm -rf ${SKILL_LINK}"
-else
-  ln -sf "${SCRIPT_DIR}/skills/memory-recall" "${SKILL_LINK}"
-  echo "[OK] Skill symlinked: ${SKILL_LINK} -> ${SCRIPT_DIR}/skills/memory-recall"
-fi
+for skill_name in memory-recall memory-config; do
+  SKILL_LINK="${AGENTS_SKILLS_DIR}/${skill_name}"
+  if [ -L "${SKILL_LINK}" ] || [ -d "${SKILL_LINK}" ]; then
+    echo "[SKIP] Skill already exists at ${SKILL_LINK}"
+    echo "       Remove it first if you want to reinstall: rm -rf ${SKILL_LINK}"
+  else
+    ln -sf "${SCRIPT_DIR}/skills/${skill_name}" "${SKILL_LINK}"
+    echo "[OK] Skill symlinked: ${SKILL_LINK} -> ${SCRIPT_DIR}/skills/${skill_name}"
+  fi
+done
 echo ""
 
 # 4. Install plugin dependencies

--- a/plugins/opencode/prompts/project_review.txt
+++ b/plugins/opencode/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/plugins/opencode/prompts/user_profile.txt
+++ b/plugins/opencode/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -40,7 +40,7 @@ from opencode_turns import (
 )
 
 _ANCHOR_RE = re.compile(r"<!-- session:([^ ]+) turn:([^ ]+) db:")
-_TAIL_TURN_QUIET_PERIOD_MS = 300_000
+_TAIL_TURN_QUIET_PERIOD_MS = int(os.environ.get("MEMSEARCH_OPENCODE_TAIL_QUIET_MS", "300000"))
 
 
 class TailTurnObservation:
@@ -106,6 +106,22 @@ def get_plugin_summarize_provider(memsearch_cmd: str | None = None) -> str:
         return ""
 
 
+def get_plugin_summarize_enabled(memsearch_cmd: str | None = None) -> bool:
+    """Read whether the memsearch OpenCode summarizer is enabled."""
+    if not memsearch_cmd:
+        return True
+    try:
+        result = subprocess.run(
+            [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.enabled"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip().lower() != "false"
+    except Exception:
+        return True
+
+
 def ensure_isolated_config() -> str:
     """Create isolated config dir without plugins/ to prevent recursion."""
     isolated = os.path.expanduser("~/.codex/tmp/opencode-memsearch-summarize/opencode")
@@ -154,6 +170,9 @@ def _load_summarize_prompt(agent_name: str, memsearch_cmd: str | None = None) ->
 
 def summarize_with_llm(turn_text: str, small_model: str, memsearch_cmd: str | None = None) -> str | None:
     """Summarize using configured provider routing."""
+    if not get_plugin_summarize_enabled(memsearch_cmd):
+        return None
+
     system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
     full_prompt = f"{system_prompt}\n\nTranscript:\n{turn_text}"
 
@@ -467,6 +486,8 @@ def capture_session_turns(
         # Check anchor first so that sidecar rebuilds repair state without
         # calling the summarizer again for already-captured turns.
         if not capture_exists(memory_dir, session_id, turn.turn_id):
+            if not get_plugin_summarize_enabled(memsearch_cmd):
+                continue
             summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
             write_capture(
                 memory_dir,
@@ -543,6 +564,12 @@ def main() -> None:
                 os.system(
                     f"{args.memsearch_cmd} index '{memory_dir}' "
                     f"--collection {args.collection_name} &"
+                )
+                os.system(
+                    f"python3 {shlex.quote(str(Path(__file__).resolve().parent / 'maintenance-runner.py'))} "
+                    f"--platform opencode "
+                    f"--project-dir {shlex.quote(args.project_dir)} "
+                    f"--memsearch-dir {shlex.quote(os.path.join(args.project_dir, '.memsearch'))} &"
                 )
         except Exception:
             pass

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Plugin-local runner for MemSearch maintenance tasks.
+
+This script belongs to the plugin layer. It handles host-native agent
+invocations, while the Python package provides shared config, due-state,
+prompt, and API-provider logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_NATIVE_MODELS = {
+    "claude-code": "sonnet",
+    "codex": "",
+    "opencode": "",
+    "openclaw": "",
+}
+
+
+def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=timeout,
+        check=False,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def extract_task_json_output(output: str) -> str:
+    """Extract the first maintenance JSON object from noisy host output."""
+    for line in output.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "action" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+    return output
+
+
+def ensure_opencode_isolated_config() -> Path:
+    home = Path.home()
+    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    src = home / ".config" / "opencode" / "opencode.json"
+    if src.is_file():
+        shutil.copy2(src, isolated / "opencode.json")
+    return isolated
+
+
+def ensure_memsearch_importable() -> None:
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = shutil.which("memsearch")
+    if memsearch_bin:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"},
+                    )
+
+    uv = shutil.which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_MAINTENANCE_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def apply_plugin_prompt_defaults(cfg) -> None:
+    plugin_dir = Path(__file__).resolve().parent.parent
+    prompts_dir = plugin_dir / "prompts"
+    for task in ("project_review", "user_profile"):
+        if getattr(cfg.prompts, task, ""):
+            continue
+        prompt_file = prompts_dir / f"{task}.txt"
+        if prompt_file.is_file():
+            setattr(cfg.prompts, task, str(prompt_file))
+
+
+def run_native_provider(ctx, prompt: str) -> str:
+    model = ctx.task_config.model or DEFAULT_NATIVE_MODELS.get(ctx.platform, "")
+    env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
+
+    if ctx.platform == "claude-code":
+        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [
+            "--system-prompt",
+            "You are a maintenance task runner. Output only the requested JSON object.",
+            prompt,
+        ]
+        env["CLAUDECODE"] = ""
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    if ctx.platform == "codex":
+        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        cmd = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "-c",
+            "features.hooks=false",
+            "-c",
+            'model_reasoning_effort="medium"',
+            "-o",
+            str(output_path),
+        ]
+        profile = os.environ.get("MEMSEARCH_CODEX_PROFILE", "").strip()
+        if profile:
+            cmd += ["-p", profile]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["MEMSEARCH_IN_STOP_WORKER"] = "1"
+        try:
+            run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    if ctx.platform == "openclaw":
+        cmd = ["openclaw", "agent", "--local", "--session-id", "memsearch-maintenance"]
+        if model:
+            cmd += ["--model", model]
+        cmd += ["-m", prompt]
+        env["MEMSEARCH_DISABLE"] = "1"
+        return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
+
+    if ctx.platform == "opencode":
+        isolated = ensure_opencode_isolated_config()
+        cmd = ["opencode", "run"]
+        if model:
+            cmd += ["-m", model]
+        cmd.append(prompt)
+        env["XDG_CONFIG_HOME"] = str(isolated)
+        env["XDG_DATA_HOME"] = str(isolated / "data")
+        return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
+
+    raise RuntimeError(f"Unsupported native maintenance platform {ctx.platform!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run plugin-local MemSearch maintenance tasks.")
+    parser.add_argument("--platform", required=True, choices=["claude-code", "codex", "opencode", "openclaw"])
+    parser.add_argument("--project-dir", default=None)
+    parser.add_argument("--memsearch-dir", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    args = parser.parse_args()
+
+    old_cwd = Path.cwd()
+    try:
+        ensure_memsearch_importable()
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+
+        project_dir = Path(args.project_dir or old_cwd).expanduser().resolve()
+        os.chdir(project_dir)
+        cfg = resolve_config()
+        apply_plugin_prompt_defaults(cfg)
+
+        def llm_runner(ctx, prompt: str) -> str:
+            provider_name = (ctx.task_config.provider or "native").strip()
+            if provider_name in {"", "native"}:
+                return run_native_provider(ctx, prompt)
+            return run_task_llm(ctx, prompt, cfg)
+
+        results = run_due_tasks(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
+    except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        sys.stderr.write(f"Maintenance error: {exc}\n")
+        return 1
+    finally:
+        with contextlib.suppress(OSError):
+            os.chdir(old_cwd)
+
+    payload = [result.__dict__ for result in results]
+    if args.json_output:
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    else:
+        for result in results:
+            detail = f": {result.reason}" if result.reason else ""
+            sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
-@dataclass(slots=True)
+@dataclass
 class OpenCodeMessage:
     """A single meaningful OpenCode message with rendered text."""
 
@@ -29,7 +29,7 @@ class OpenCodeMessage:
     text: str
 
 
-@dataclass(slots=True)
+@dataclass
 class OpenCodeTurn:
     """A user turn plus its assistant follow-up messages."""
 
@@ -60,7 +60,7 @@ class OpenCodeTurn:
         return "\n".join(lines).strip()
 
 
-@dataclass(slots=True)
+@dataclass
 class TurnState:
     """Persistent capture progress for a session."""
 

--- a/plugins/opencode/skills/memory-config/SKILL.md
+++ b/plugins/opencode/skills/memory-config/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: memory-config
+description: "Diagnose and configure MemSearch memory behavior for the OpenCode plugin. Use when the user asks about MemSearch configuration, plugin summarization, PROJECT.md/USER.md maintenance, memory directories, index health, provider routing, prompt files, or migration/compatibility questions."
+---
+
+You are a MemSearch configuration assistant for the OpenCode plugin. This skill manages MemSearch settings only. It is not OpenCode's built-in memory configuration.
+
+Start every user-facing answer with:
+
+> This is MemSearch memory config, not OpenCode's own memory config.
+
+When this skill is triggered, inspect the user's request text. If there is no concrete request, run a diagnostic. If they ask for a specific setting or change, route the request using the flows below.
+
+## Intent Routing
+
+- Empty request or "check": diagnose current MemSearch setup.
+- "Show/get setting": read the requested resolved/global/project value.
+- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
+- "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
+- "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "Prompt": explain or configure prompt overrides.
+
+Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
+
+## Diagnose First
+
+```bash
+memsearch config list --resolved
+memsearch config list --global
+memsearch config list --project
+```
+
+If `memsearch` is unavailable, try `uvx --from memsearch[onnx] memsearch --version`.
+
+Check memory files:
+
+```bash
+MDIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}/memory"
+ls -la "$MDIR"
+find "$MDIR" -maxdepth 1 -type f -name '*.md' | sort | tail -10
+tail -120 "$MDIR/$(date +%Y-%m-%d).md"
+```
+
+Check index health:
+
+```bash
+memsearch stats
+```
+
+OpenCode transcript recall reads from OpenCode's SQLite database, while captured MemSearch memory lives as markdown under `.memsearch/memory/`.
+
+## Background and Compatibility
+
+Some plugin config fields may be missing or empty. That is usually normal:
+
+- `summarize.enabled`, advanced maintenance, and task-specific provider/model fields are newer settings.
+- Existing users' TOML files are not rewritten automatically after package/plugin upgrades.
+- Empty strings usually mean "use the built-in or host-native default"; they do not necessarily mean "disabled" or "broken".
+- Missing fields should be interpreted through `memsearch config list --resolved`, not by reading raw TOML alone.
+- New users who run `memsearch config init` may see more fields than old users because the template includes newer options.
+- Advanced maintenance is intentionally disabled by default to avoid surprise background model calls.
+
+## Configuration Logic
+
+Config is resolved from built-in defaults, global config, project config, env refs like `env:OPENAI_API_KEY`, and runtime env such as `MEMSEARCH_DIR`.
+
+Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
+
+Default recommendation:
+
+- Put reusable defaults in global config so users do not repeat setup in every project.
+- Put only project-specific overrides in project config.
+- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
+- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+
+OpenCode plugin keys:
+
+```toml
+[plugins.opencode.summarize]
+enabled = true
+provider = ""      # empty/native = OpenCode native summarizer
+model = ""
+
+[plugins.opencode.project_review]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/PROJECT.md"
+
+[plugins.opencode.user_profile]
+enabled = false
+provider = "native"
+model = ""
+min_interval_hours = 24
+input_dir = ".memsearch/memory"
+output_file = ".memsearch/USER.md"
+```
+
+Provider rules:
+
+- `provider = ""` or `native` uses OpenCode's non-interactive native path.
+- Any other provider value is a name that must exist under `[llm.providers.<name>]`.
+- Model resolution order is task-level `plugins.opencode.<task>.model`, then named provider model, then built-in default.
+- API keys should be configured as env refs, not pasted into chat.
+- If a raw TOML field is blank, check resolved config before calling it unset or broken.
+
+Common provider examples:
+
+```toml
+[llm.providers.openai]
+type = "openai"
+model = "gpt-5-mini"
+api_key = "env:OPENAI_API_KEY"
+
+[llm.providers.anthropic]
+type = "anthropic"
+model = "claude-sonnet-4-6"
+api_key = "env:ANTHROPIC_API_KEY"
+
+[llm.providers.gemini]
+type = "gemini"
+model = "gemini-3-flash-preview"
+api_key = "env:GEMINI_API_KEY"
+```
+
+Model guidance:
+
+- Normal turn summaries can use small/fast models. OpenCode native summarize uses OpenCode `small_model`, then its configured model/default behavior.
+- Advanced maintenance needs better judgment. OpenCode native maintenance uses OpenCode's default unless `plugins.opencode.<task>.model` is set.
+- For API providers, defaults are `openai -> gpt-5-mini`, `anthropic -> claude-sonnet-4-6`, and `gemini -> gemini-3-flash-preview`.
+- If quality matters more than cost for maintenance, set `plugins.opencode.project_review.model` and `plugins.opencode.user_profile.model` explicitly.
+
+Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+
+Prompt overrides:
+
+```toml
+[prompts]
+summarize = ""
+project_review = ""
+user_profile = ""
+```
+
+Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
+
+Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+
+MemSearch TOML changes are read lazily by the CLI, capture daemon, and maintenance runner, so values such as `plugins.opencode.summarize.*`, `plugins.opencode.project_review.*`, `plugins.opencode.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. Restart OpenCode after `opencode.json` or plugin package changes; if capture behavior still looks stale after TOML edits, restart OpenCode or the capture daemon. After any answer, make clear that this is MemSearch memory configuration, not OpenCode's own memory/config system.
+
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -848,9 +848,9 @@ def config_init(project: bool) -> None:
     click.echo("\n── LLM (for memsearch compact) ──")
     click.echo("  Plugin summarization uses plugins.<platform>.summarize.model.")
     _llm_defaults = {
-        "openai": "gpt-4o-mini",
-        "anthropic": "claude-haiku-4-5-20251001",
-        "gemini": "gemini-2.0-flash",
+        "openai": "gpt-5-mini",
+        "anthropic": "claude-sonnet-4-6",
+        "gemini": "gemini-3-flash-preview",
     }
     result["llm"] = {}
     result["llm"]["provider"] = click.prompt(
@@ -876,11 +876,15 @@ def config_init(project: bool) -> None:
     click.echo("\n── Plugin summarize routing ──")
     click.echo("  Leave provider empty/native to keep each plugin's current native summarizer.")
     result["plugins"] = {
-        "claude-code": {"summarize": {}},
-        "codex": {"summarize": {}},
-        "opencode": {"summarize": {}},
-        "openclaw": {"summarize": {}},
+        "claude-code": {"summarize": {}, "project_review": {}, "user_profile": {}},
+        "codex": {"summarize": {}, "project_review": {}, "user_profile": {}},
+        "opencode": {"summarize": {}, "project_review": {}, "user_profile": {}},
+        "openclaw": {"summarize": {}, "project_review": {}, "user_profile": {}},
     }
+    result["plugins"]["claude-code"]["summarize"]["enabled"] = click.confirm(
+        "  Claude Code automatic summaries enabled",
+        default=current.plugins.claude_code.summarize.enabled,
+    )
     result["plugins"]["claude-code"]["summarize"]["provider"] = click.prompt(
         "  Claude Code summarize provider",
         default=current.plugins.claude_code.summarize.provider,
@@ -888,6 +892,10 @@ def config_init(project: bool) -> None:
     result["plugins"]["claude-code"]["summarize"]["model"] = click.prompt(
         "  Claude Code summarize model",
         default=current.plugins.claude_code.summarize.model,
+    )
+    result["plugins"]["codex"]["summarize"]["enabled"] = click.confirm(
+        "  Codex automatic summaries enabled",
+        default=current.plugins.codex.summarize.enabled,
     )
     result["plugins"]["codex"]["summarize"]["provider"] = click.prompt(
         "  Codex summarize provider",
@@ -897,6 +905,10 @@ def config_init(project: bool) -> None:
         "  Codex summarize model",
         default=current.plugins.codex.summarize.model,
     )
+    result["plugins"]["opencode"]["summarize"]["enabled"] = click.confirm(
+        "  OpenCode automatic summaries enabled",
+        default=current.plugins.opencode.summarize.enabled,
+    )
     result["plugins"]["opencode"]["summarize"]["provider"] = click.prompt(
         "  OpenCode summarize provider",
         default=current.plugins.opencode.summarize.provider,
@@ -904,6 +916,10 @@ def config_init(project: bool) -> None:
     result["plugins"]["opencode"]["summarize"]["model"] = click.prompt(
         "  OpenCode summarize model",
         default=current.plugins.opencode.summarize.model,
+    )
+    result["plugins"]["openclaw"]["summarize"]["enabled"] = click.confirm(
+        "  OpenClaw automatic summaries enabled",
+        default=current.plugins.openclaw.summarize.enabled,
     )
     result["plugins"]["openclaw"]["summarize"]["provider"] = click.prompt(
         "  OpenClaw summarize provider",
@@ -913,6 +929,28 @@ def config_init(project: bool) -> None:
         "  OpenClaw summarize model",
         default=current.plugins.openclaw.summarize.model,
     )
+
+    click.echo("\n── Advanced maintenance ──")
+    click.echo("  Disabled by default. Configure provider/model if you enable these tasks.")
+    for key, label, current_platform in [
+        ("claude-code", "Claude Code", current.plugins.claude_code),
+        ("codex", "Codex", current.plugins.codex),
+        ("opencode", "OpenCode", current.plugins.opencode),
+        ("openclaw", "OpenClaw", current.plugins.openclaw),
+    ]:
+        for task_name, task_label in [("project_review", "project review"), ("user_profile", "user profile")]:
+            task = getattr(current_platform, task_name)
+            section = result["plugins"][key][task_name]
+            section["enabled"] = click.confirm(f"  {label} {task_label} enabled", default=task.enabled)
+            section["provider"] = click.prompt(f"  {label} {task_label} provider", default=task.provider)
+            section["model"] = click.prompt(f"  {label} {task_label} model", default=task.model)
+            section["min_interval_hours"] = click.prompt(
+                f"  {label} {task_label} min interval hours",
+                default=task.min_interval_hours,
+                type=int,
+            )
+            section["input_dir"] = click.prompt(f"  {label} {task_label} input dir", default=task.input_dir)
+            section["output_file"] = click.prompt(f"  {label} {task_label} output file", default=task.output_file)
 
     # Prompts
     click.echo("\n── Prompts ──")
@@ -925,6 +963,14 @@ def config_init(project: bool) -> None:
     result["prompts"]["summarize"] = click.prompt(
         "  Summarize prompt file (for plugin session notes)",
         default=current.prompts.summarize,
+    )
+    result["prompts"]["project_review"] = click.prompt(
+        "  Project review prompt file",
+        default=current.prompts.project_review,
+    )
+    result["prompts"]["user_profile"] = click.prompt(
+        "  User profile prompt file",
+        default=current.prompts.user_profile,
     )
 
     save_config(result, target)

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -69,11 +69,11 @@ async def compact_chunks(
     prompt = template.format(chunks=combined)
 
     if llm_provider == "openai":
-        return await _compact_openai(prompt, model or "gpt-4o-mini", base_url=base_url, api_key=api_key)
+        return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
     elif llm_provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-5-20250929")
+        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
     elif llm_provider == "gemini":
-        return await _compact_gemini(prompt, model or "gemini-2.0-flash")
+        return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
     else:
         raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
 
@@ -89,11 +89,11 @@ async def summarize_text(
     """Summarize preformatted text with a memsearch-managed LLM provider."""
     provider = "openai" if llm_provider == "openai-compatible" else llm_provider
     if provider == "openai":
-        return await _compact_openai(prompt, model or "gpt-4o-mini", base_url=base_url, api_key=api_key)
+        return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
     if provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-5-20250929")
+        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
     if provider == "gemini":
-        return await _compact_gemini(prompt, model or "gemini-2.0-flash")
+        return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
     raise ValueError(
         f"Unknown LLM provider type {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini"
     )

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -26,7 +26,8 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size"}
+_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours"}
+_BOOL_FIELDS = {"enabled"}
 
 
 @dataclass
@@ -104,14 +105,29 @@ class PromptsConfig:
 
     compact: str = ""  # custom prompt file for memsearch compact
     summarize: str = ""  # custom prompt file for plugin session summarization
+    project_review: str = ""  # custom prompt file for project maintenance
+    user_profile: str = ""  # custom prompt file for user profile maintenance
 
 
 @dataclass
 class PluginSummarizeConfig:
     """Plugin summarization settings."""
 
+    enabled: bool = True
     provider: str = ""  # empty/native = keep plugin-native summarization path
     model: str = ""  # empty = keep plugin default/native model selection
+
+
+@dataclass
+class PluginMaintenanceTaskConfig:
+    """Advanced plugin maintenance task settings."""
+
+    enabled: bool = False
+    provider: str = "native"
+    model: str = ""
+    min_interval_hours: int = 24
+    input_dir: str = ".memsearch/memory"
+    output_file: str = ""
 
 
 @dataclass
@@ -119,6 +135,12 @@ class PluginPlatformConfig:
     """Settings for one platform plugin."""
 
     summarize: PluginSummarizeConfig = field(default_factory=PluginSummarizeConfig)
+    project_review: PluginMaintenanceTaskConfig = field(
+        default_factory=lambda: PluginMaintenanceTaskConfig(output_file=".memsearch/PROJECT.md")
+    )
+    user_profile: PluginMaintenanceTaskConfig = field(
+        default_factory=lambda: PluginMaintenanceTaskConfig(output_file=".memsearch/USER.md")
+    )
 
 
 @dataclass
@@ -239,7 +261,11 @@ def _dict_to_plugins_config(section_data: dict[str, Any]) -> PluginsConfig:
     """Convert a TOML plugins table to PluginsConfig."""
     kwargs: dict[str, Any] = {}
     valid_platform_fields = {f.name for f in fields(PluginPlatformConfig)}
-    valid_summarize_fields = {f.name for f in fields(PluginSummarizeConfig)}
+    task_classes = {
+        "summarize": PluginSummarizeConfig,
+        "project_review": PluginMaintenanceTaskConfig,
+        "user_profile": PluginMaintenanceTaskConfig,
+    }
 
     for raw_platform, raw_platform_data in section_data.items():
         platform = _PLUGIN_KEY_TO_FIELD.get(raw_platform)
@@ -247,12 +273,14 @@ def _dict_to_plugins_config(section_data: dict[str, Any]) -> PluginsConfig:
             continue
 
         platform_kwargs: dict[str, Any] = {}
-        summarize_data = raw_platform_data.get("summarize", {})
-        if isinstance(summarize_data, dict):
-            summarize_filtered = {k: v for k, v in summarize_data.items() if k in valid_summarize_fields}
-            platform_kwargs["summarize"] = PluginSummarizeConfig(**summarize_filtered)
+        for task_name, task_cls in task_classes.items():
+            task_data = raw_platform_data.get(task_name, {})
+            if isinstance(task_data, dict):
+                valid_task_fields = {f.name for f in fields(task_cls)}
+                task_filtered = {k: v for k, v in task_data.items() if k in valid_task_fields}
+                platform_kwargs[task_name] = task_cls(**task_filtered)
 
-        filtered = {k: v for k, v in raw_platform_data.items() if k in valid_platform_fields and k != "summarize"}
+        filtered = {k: v for k, v in raw_platform_data.items() if k in valid_platform_fields and k not in task_classes}
         platform_kwargs.update(filtered)
         kwargs[platform] = PluginPlatformConfig(**platform_kwargs)
 
@@ -389,17 +417,21 @@ def _validate_dotted_key(parts: list[str]) -> str:
 
     if section == "plugins":
         if len(parts) != 4:
-            raise ValueError(
-                f"Plugin config keys must be plugins.<platform>.summarize.<field> (got {'.'.join(parts)!r})"
-            )
+            raise ValueError(f"Plugin config keys must be plugins.<platform>.<task>.<field> (got {'.'.join(parts)!r})")
         platform, subsection, field_name = parts[1:]
         if platform not in _PLUGIN_KEY_TO_FIELD:
             raise KeyError(f"Unknown plugin platform: {platform}")
-        if subsection != "summarize":
+        task_classes = {
+            "summarize": PluginSummarizeConfig,
+            "project_review": PluginMaintenanceTaskConfig,
+            "user_profile": PluginMaintenanceTaskConfig,
+        }
+        task_cls = task_classes.get(subsection)
+        if task_cls is None:
             raise KeyError(f"Unknown plugin config section: {subsection} in platform {platform}")
-        valid = {f.name for f in fields(PluginSummarizeConfig)}
+        valid = {f.name for f in fields(task_cls)}
         if field_name not in valid:
-            raise KeyError(f"Unknown plugin summarize field: {field_name} in platform {platform}")
+            raise KeyError(f"Unknown plugin {subsection} field: {field_name} in platform {platform}")
         return field_name
 
     if section == "llm" and len(parts) == 4 and parts[1] == "providers":
@@ -461,6 +493,14 @@ def set_config_value(key: str, value: Any, *, project: bool = False) -> None:
     # Auto-convert int fields
     if field_name in _INT_FIELDS and isinstance(value, str):
         value = int(value)
+    if field_name in _BOOL_FIELDS and isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            value = True
+        elif normalized in {"0", "false", "no", "off"}:
+            value = False
+        else:
+            raise ValueError(f"Boolean field {field_name!r} must be true or false")
 
     current: dict[str, Any] = existing
     for part in parts[:-1]:

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -1,0 +1,576 @@
+"""Background maintenance tasks for plugin-managed memories."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from .compact import summarize_text
+from .config import (
+    LLMProviderConfig,
+    MemSearchConfig,
+    PluginMaintenanceTaskConfig,
+    config_to_dict,
+    resolve_env_ref,
+)
+
+TASKS = ("project_review", "user_profile")
+MAX_PROMPT_CHARS = 80_000
+MAX_COMMAND_OUTPUT = 12_000
+MAX_TOOL_CALLS = 3
+
+
+@dataclass
+class MaintenanceResult:
+    task: str
+    action: str
+    reason: str = ""
+    output_file: str = ""
+    skipped: bool = False
+
+
+@dataclass
+class TaskContext:
+    platform: str
+    task: str
+    task_config: PluginMaintenanceTaskConfig
+    project_dir: Path
+    memsearch_dir: Path
+    input_dir: Path
+    output_file: Path
+    input_digest: str
+
+
+def run_due_tasks(
+    *,
+    platform: str,
+    project_dir: str | Path | None = None,
+    memsearch_dir: str | Path | None = None,
+    cfg: MemSearchConfig | None = None,
+    force: bool = False,
+    llm_runner: Callable[[TaskContext, str], str] | None = None,
+) -> list[MaintenanceResult]:
+    """Run enabled maintenance tasks that are due."""
+    if cfg is None:
+        from .config import resolve_config
+
+        cfg = resolve_config()
+
+    project_root = Path(project_dir or os.getcwd()).expanduser().resolve()
+    mem_root = Path(memsearch_dir or os.environ.get("MEMSEARCH_DIR", project_root / ".memsearch")).expanduser()
+    if not mem_root.is_absolute():
+        mem_root = project_root / mem_root
+    mem_root = mem_root.resolve()
+    mem_root.mkdir(parents=True, exist_ok=True)
+
+    state_path = mem_root / ".maintenance-state.json"
+    state = _load_state(state_path)
+
+    results: list[MaintenanceResult] = []
+    for task_name in TASKS:
+        task_cfg = _get_task_config(cfg, platform, task_name)
+        if task_cfg is None or not task_cfg.enabled:
+            results.append(MaintenanceResult(task=task_name, action="disabled", skipped=True))
+            continue
+
+        input_dir = _resolve_task_path(task_cfg.input_dir or str(mem_root / "memory"), project_root, mem_root)
+        output_file = _resolve_task_path(task_cfg.output_file, project_root, mem_root)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        digest = _input_digest(input_dir)
+        state_key = f"{platform}.{task_name}"
+        task_state = state.get(state_key, {})
+        due, reason = _is_due(task_cfg, task_state, digest, force)
+        if not due:
+            results.append(MaintenanceResult(task=task_name, action="skip", reason=reason, skipped=True))
+            continue
+
+        lock_path = mem_root / f".maintenance-{platform}-{task_name}.lock"
+        with _file_lock(lock_path) as locked:
+            if not locked:
+                results.append(MaintenanceResult(task=task_name, action="locked", skipped=True))
+                continue
+
+            ctx = TaskContext(
+                platform=platform,
+                task=task_name,
+                task_config=task_cfg,
+                project_dir=project_root,
+                memsearch_dir=mem_root,
+                input_dir=input_dir,
+                output_file=output_file,
+                input_digest=digest,
+            )
+            prompt = _build_prompt(ctx, cfg)
+            raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
+            parsed = _parse_task_response(raw)
+            now = _now()
+
+            if parsed["action"] == "replace":
+                content = str(parsed.get("content") or "").strip()
+                if not content:
+                    raise RuntimeError(f"{task_name} returned replace without content")
+                output_file.write_text(content.rstrip() + "\n", encoding="utf-8")
+                action = "replace"
+            else:
+                action = "none"
+
+            state[state_key] = {
+                "last_checked_at": now,
+                "last_success_at": now,
+                "last_input_digest": digest,
+                "last_action": action,
+                "output_file": str(output_file),
+            }
+            _save_state(state_path, state)
+            results.append(
+                MaintenanceResult(
+                    task=task_name,
+                    action=action,
+                    reason=str(parsed.get("reason") or ""),
+                    output_file=str(output_file),
+                )
+            )
+
+    return results
+
+
+def _get_task_config(cfg: MemSearchConfig, platform: str, task_name: str) -> PluginMaintenanceTaskConfig | None:
+    plugins = config_to_dict(cfg).get("plugins", {})
+    platform_cfg = plugins.get(platform)
+    if not isinstance(platform_cfg, dict):
+        return None
+    task_data = platform_cfg.get(task_name)
+    if not isinstance(task_data, dict):
+        return None
+    return PluginMaintenanceTaskConfig(
+        **{k: v for k, v in task_data.items() if k in PluginMaintenanceTaskConfig.__dataclass_fields__}
+    )
+
+
+def _resolve_task_path(raw_path: str, project_dir: Path, memsearch_dir: Path) -> Path:
+    path_text = raw_path or ""
+    if path_text == ".memsearch/memory":
+        return (memsearch_dir / "memory").resolve()
+    path = Path(path_text).expanduser()
+    if not path.is_absolute():
+        path = project_dir / path
+    return path.resolve()
+
+
+def _input_digest(input_dir: Path) -> str:
+    h = hashlib.sha256()
+    if not input_dir.is_dir():
+        return "sha256:empty"
+    for path in sorted(input_dir.rglob("*.md")):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(input_dir))
+        h.update(rel.encode())
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return f"sha256:{h.hexdigest()}"
+
+
+def _is_due(task_cfg: PluginMaintenanceTaskConfig, state: dict[str, Any], digest: str, force: bool) -> tuple[bool, str]:
+    if force:
+        return True, "force"
+    if state.get("last_input_digest") == digest:
+        return False, "input unchanged"
+    last_success = state.get("last_success_at")
+    if not last_success:
+        return True, "never run"
+    try:
+        last_dt = datetime.fromisoformat(str(last_success).replace("Z", "+00:00"))
+    except ValueError:
+        return True, "invalid state timestamp"
+    age_hours = (datetime.now(timezone.utc) - last_dt).total_seconds() / 3600
+    if age_hours < max(0, task_cfg.min_interval_hours):
+        return False, f"not due for {task_cfg.min_interval_hours}h"
+    return True, "due"
+
+
+def _build_prompt(ctx: TaskContext, cfg: MemSearchConfig) -> str:
+    template = _load_prompt_template(ctx.task, cfg)
+    replacements = {
+        "{{AGENT_NAME}}": ctx.platform,
+        "{{TASK_NAME}}": ctx.task,
+        "{{PROJECT_DIR}}": str(ctx.project_dir),
+        "{{INPUT_DIR}}": str(ctx.input_dir),
+        "{{OUTPUT_FILE}}": str(ctx.output_file),
+    }
+    for marker, value in replacements.items():
+        template = template.replace(marker, value)
+
+    existing = ctx.output_file.read_text(encoding="utf-8") if ctx.output_file.is_file() else ""
+    journals = _read_recent_journals(ctx.input_dir)
+    prompt = f"""{template}
+
+## Existing output file
+
+```markdown
+{existing.strip()}
+```
+
+## Recent memory journal entries
+
+```markdown
+{journals.strip()}
+```
+
+## Changed input digest
+
+{ctx.input_digest}
+"""
+    if len(prompt) > MAX_PROMPT_CHARS:
+        prompt = prompt[:MAX_PROMPT_CHARS] + "\n\n[truncated]\n"
+    return prompt
+
+
+def _load_prompt_template(task: str, cfg: MemSearchConfig) -> str:
+    configured = getattr(cfg.prompts, task, "")
+    if configured:
+        path = Path(configured).expanduser()
+        if path.is_file():
+            return path.read_text(encoding="utf-8")
+    with resources.files("memsearch.prompts").joinpath(f"{task}.txt").open("r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _read_recent_journals(input_dir: Path, max_files: int = 12) -> str:
+    if not input_dir.is_dir():
+        return ""
+    chunks: list[str] = []
+    files = sorted((p for p in input_dir.rglob("*.md") if p.is_file()), key=lambda p: p.stat().st_mtime)[-max_files:]
+    for path in files:
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            chunks.append(f"\n<!-- source:{path} -->\n{path.read_text(encoding='utf-8')}")
+    return "\n".join(chunks)
+
+
+def run_task_llm(ctx: TaskContext, prompt: str, cfg: MemSearchConfig) -> str:
+    """Run a memsearch-managed API provider for a maintenance task.
+
+    Host-native providers are handled by plugin-local runners because the
+    invocation details belong to each plugin host, not the Python core.
+    """
+    provider_name = (ctx.task_config.provider or "native").strip()
+    if provider_name == "native":
+        raise RuntimeError("Native maintenance providers must be handled by the plugin runner")
+
+    provider_cfg = cfg.llm.providers.get(provider_name)
+    if provider_cfg is None:
+        raise RuntimeError(f"Unknown LLM provider {provider_name!r}")
+    provider_type = provider_cfg.type or provider_name
+    model = ctx.task_config.model or provider_cfg.model or None
+
+    if provider_type in {"openai", "openai-compatible"}:
+        return _run_openai_with_tools(ctx, prompt, provider_type, model, provider_cfg)
+    if provider_type == "anthropic":
+        return _run_anthropic_with_tools(ctx, prompt, model, provider_cfg)
+    if provider_type == "gemini":
+        return _run_gemini_with_tools(ctx, prompt, model, provider_cfg)
+
+    return _run_async_summarize_text(prompt, provider_type, model, provider_cfg)
+
+
+def _run_async_summarize_text(
+    prompt: str, provider_type: str, model: str | None, provider_cfg: LLMProviderConfig
+) -> str:
+    import asyncio
+
+    return asyncio.run(
+        summarize_text(
+            prompt,
+            llm_provider=provider_type,
+            model=model,
+            base_url=provider_cfg.base_url or None,
+            api_key=provider_cfg.api_key or None,
+        )
+    )
+
+
+def _run_openai_with_tools(
+    ctx: TaskContext, prompt: str, provider_type: str, model: str | None, provider_cfg: LLMProviderConfig
+) -> str:
+    import openai
+
+    kwargs: dict[str, str] = {}
+    base_url = resolve_env_ref(provider_cfg.base_url) if provider_cfg.base_url else os.environ.get("OPENAI_BASE_URL")
+    if base_url:
+        kwargs["base_url"] = base_url
+    if provider_cfg.api_key:
+        kwargs["api_key"] = resolve_env_ref(provider_cfg.api_key)
+    client = openai.OpenAI(**kwargs)
+    messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
+    tools = [_openai_memory_tool_schema()]
+    chosen_model = model or "gpt-5-mini"
+    tool_call_count = 0
+    for _ in range(MAX_TOOL_CALLS):
+        resp = client.chat.completions.create(
+            model=chosen_model,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+            temperature=0.2,
+        )
+        msg = resp.choices[0].message
+        tool_calls = msg.tool_calls or []
+        if not tool_calls:
+            return msg.content or ""
+        messages.append(msg.model_dump(exclude_none=True))
+        for call in tool_calls:
+            if tool_call_count < MAX_TOOL_CALLS:
+                args = json.loads(call.function.arguments or "{}")
+                output = run_memory_command(str(args.get("command", "")), ctx)
+                tool_call_count += 1
+            else:
+                output = "Error: memory tool call limit reached"
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": output,
+                }
+            )
+    resp = client.chat.completions.create(
+        model=chosen_model,
+        messages=messages,
+        tools=tools,
+        tool_choice="none",
+        temperature=0.2,
+    )
+    return resp.choices[0].message.content or ""
+
+
+def _openai_memory_tool_schema() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "run_memory_command",
+            "description": "Run a restricted read-only memsearch memory drill-down command.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "A read-only command such as memsearch expand, memsearch transcript, find, or grep under the memory input directory.",
+                    }
+                },
+                "required": ["command"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _run_anthropic_with_tools(ctx: TaskContext, prompt: str, model: str | None, provider_cfg: LLMProviderConfig) -> str:
+    import anthropic
+
+    api_key = resolve_env_ref(provider_cfg.api_key) if provider_cfg.api_key else None
+    client = anthropic.Anthropic(api_key=api_key) if api_key else anthropic.Anthropic()
+    messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
+    chosen_model = model or "claude-sonnet-4-6"
+    for _ in range(MAX_TOOL_CALLS):
+        resp = client.messages.create(
+            model=chosen_model,
+            max_tokens=4096,
+            tools=[_anthropic_memory_tool_schema()],
+            messages=messages,
+        )
+        text_parts: list[str] = []
+        tool_results: list[dict[str, Any]] = []
+        assistant_content: list[Any] = []
+        for block in resp.content:
+            assistant_content.append(block)
+            if getattr(block, "type", "") == "text":
+                text_parts.append(block.text)
+            elif getattr(block, "type", "") == "tool_use":
+                command = str((block.input or {}).get("command", ""))
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": run_memory_command(command, ctx),
+                    }
+                )
+        if not tool_results:
+            return "\n".join(text_parts).strip()
+        messages.append({"role": "assistant", "content": assistant_content})
+        messages.append({"role": "user", "content": tool_results})
+    resp = client.messages.create(
+        model=chosen_model,
+        max_tokens=4096,
+        messages=messages,
+    )
+    return "\n".join(block.text for block in resp.content if getattr(block, "type", "") == "text").strip()
+
+
+def _anthropic_memory_tool_schema() -> dict[str, Any]:
+    return {
+        "name": "run_memory_command",
+        "description": "Run a restricted read-only memsearch memory drill-down command.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    }
+
+
+def _run_gemini_with_tools(ctx: TaskContext, prompt: str, model: str | None, provider_cfg: LLMProviderConfig) -> str:
+    from google import genai
+    from google.genai import types
+
+    api_key = resolve_env_ref(provider_cfg.api_key) if provider_cfg.api_key else None
+    client = genai.Client(api_key=api_key) if api_key else genai.Client()
+    chosen_model = model or "gemini-3-flash-preview"
+
+    def run_memory_command_tool(command: str) -> str:
+        """Run a restricted read-only memsearch memory drill-down command."""
+        return run_memory_command(command, ctx)
+
+    resp = client.models.generate_content(
+        model=chosen_model,
+        contents=prompt,
+        config=types.GenerateContentConfig(tools=[run_memory_command_tool], temperature=0.2),
+    )
+    return resp.text or ""
+
+
+def run_memory_command(command: str, ctx: TaskContext) -> str:
+    """Run a restricted read-only memory command."""
+    if not command.strip():
+        return "Error: empty command"
+    if re.search(r"[|;&<>`$(){}]", command):
+        return "Error: shell metacharacters are not allowed"
+    try:
+        argv = shlex.split(command)
+    except ValueError as e:
+        return f"Error: {e}"
+    if not argv:
+        return "Error: empty command"
+
+    allowed_roots = [ctx.project_dir, ctx.input_dir, ctx.memsearch_dir]
+    executable = argv[0]
+    if executable == "memsearch":
+        if len(argv) < 2 or argv[1] not in {"expand", "transcript"}:
+            return "Error: only memsearch expand/transcript are allowed"
+        checked = _validate_paths_in_args(argv[2:], allowed_roots, cwd=ctx.project_dir, allow_hash=True)
+        if checked:
+            return checked
+        return _run_restricted(argv, ctx.project_dir)
+    if executable in {"find", "grep"}:
+        checked = _validate_paths_in_args(argv[1:], allowed_roots, cwd=ctx.project_dir, allow_hash=False)
+        if checked:
+            return checked
+        return _run_restricted(argv, ctx.project_dir)
+    if executable == "python3" and len(argv) >= 2 and argv[1].endswith("parse-transcript.py"):
+        checked = _validate_paths_in_args(argv[1:], allowed_roots, cwd=ctx.project_dir, allow_hash=False)
+        if checked:
+            return checked
+        return _run_restricted(argv, ctx.project_dir)
+    return f"Error: command {executable!r} is not allowed"
+
+
+def _validate_paths_in_args(args: list[str], allowed_roots: list[Path], *, cwd: Path, allow_hash: bool) -> str:
+    for arg in args:
+        if arg.startswith("-") or arg in {"*.md", "'*.md'", '"*.md"'}:
+            continue
+        if allow_hash and re.fullmatch(r"[a-fA-F0-9]{8,64}", arg):
+            continue
+        if "/" not in arg and not arg.startswith("."):
+            continue
+        path = Path(arg).expanduser()
+        if not path.is_absolute():
+            path = cwd / path
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if not any(_is_relative_to(resolved, root) for root in allowed_roots):
+            return f"Error: path {arg!r} is outside allowed memory roots"
+    return ""
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    with contextlib.suppress(ValueError):
+        path.relative_to(root)
+        return True
+    return False
+
+
+def _run_restricted(argv: list[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            env={**os.environ, "MEMSEARCH_NO_WATCH": "1"},
+            timeout=15,
+            check=False,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+    output = (result.stdout or result.stderr or "").strip()
+    return output[:MAX_COMMAND_OUTPUT]
+
+
+def _parse_task_response(raw: str) -> dict[str, str]:
+    text = raw.strip()
+    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if match:
+        text = match.group(1)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Maintenance LLM did not return valid JSON: {e}") from e
+    action = data.get("action")
+    if action not in {"none", "replace"}:
+        raise RuntimeError("Maintenance LLM action must be 'none' or 'replace'")
+    return data
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    with contextlib.suppress(json.JSONDecodeError, OSError):
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+@contextlib.contextmanager
+def _file_lock(path: Path):
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        yield False
+        return
+    try:
+        os.write(fd, str(os.getpid()).encode())
+        yield True
+    finally:
+        os.close(fd)
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/memsearch/prompts/__init__.py
+++ b/src/memsearch/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in prompt templates for memsearch maintenance tasks."""

--- a/src/memsearch/prompts/project_review.txt
+++ b/src/memsearch/prompts/project_review.txt
@@ -1,0 +1,42 @@
+You are maintaining a durable project memory file for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is durable project information worth preserving.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add durable project state.
+- Use action "replace" when recent journals contain a durable project decision, risk, constraint, active thread, or next step that is not already represented in the existing output file.
+- Treat journal lines explicitly labeled as project decision, project progress, project risk, project constraint, active thread, open question, or next step as project state unless they are clearly temporary noise.
+- Recent progress should be recorded when it changes implementation status, validation status, release status, or an important debugging/testing behavior.
+- If the existing output file is empty and recent journals contain any durable project state, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Keep this file about the project, not the user. Put stable user preferences, communication style, and personal workflow notes in USER.md instead.
+- Include user constraints only when they directly affect this project's execution.
+- Do not include general user preferences such as preferred language, dependency manager, PR wording style, verification style, or communication style unless the project has explicitly decided to encode them as project requirements.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # Project Memory
+- ## Current Direction
+- ## Active Threads
+- ## Recent Progress
+- ## Decisions
+- ## Open Questions
+- ## Risks and Constraints
+- ## Next Steps
+- ## Cold Items
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not change durable project state."}
+
+{"action":"replace","reason":"Recent journals add a new active thread.","content":"# Project Memory\n\n## Current Direction\n..."}

--- a/src/memsearch/prompts/user_profile.txt
+++ b/src/memsearch/prompts/user_profile.txt
@@ -1,0 +1,42 @@
+You are maintaining a conservative user/workflow profile for {{AGENT_NAME}}.
+
+Task: {{TASK_NAME}}
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+Output file: {{OUTPUT_FILE}}
+
+You will receive the current output file and recent memory journal entries. Update the output only when there is stable evidence about the user's durable preferences, priorities, constraints, or repeated workflows.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use action "none" when the recent journals do not add stable user/workflow information.
+- Use action "replace" when recent journals contain a stable user preference, priority, constraint, communication style, or repeated workflow that is not already represented in the existing output file.
+- If the existing output file is empty and recent journals contain stable user/workflow information, use action "replace".
+- Use action "replace" only when the output file should be replaced.
+- The "content" field, when present, must be the full replacement Markdown file.
+- Preserve useful existing content. Do not rewrite for style.
+- Do not infer broad personality traits from one-off messages.
+- Keep this file about the user and reusable workflow patterns, not transient project status. Put active project threads and implementation state in PROJECT.md instead.
+- Do not include project technical constraints, implementation decisions, file paths, bug fixes, or architecture decisions unless they are evidence of a repeated user preference across projects.
+- Lines labeled as project decision, project progress, project risk, implementation note, or project constraint belong in PROJECT.md, not USER.md.
+- Do not rewrite project decisions as "User prefers ...". Only include a preference when the journal explicitly describes a user preference, communication preference, workflow preference, or repeated behavior.
+- Treat raw transcript excerpts, when provided, as stronger evidence for wording, style, and decision context.
+- Do not copy raw journals or raw transcript excerpts wholesale.
+- Suggested sections are optional. Include only sections that are useful.
+- Keep the file concise and reviewable.
+- Prefer small targeted additions over broad rewrites when the existing output is already useful.
+
+Suggested Markdown shape:
+- # User Memory
+- ## Priorities
+- ## Preferences
+- ## Working Style
+- ## Technical Defaults
+- ## Communication Notes
+- ## Repeated Workflows
+- ## Constraints
+
+JSON examples:
+{"action":"none","reason":"Recent journals do not provide stable new user-profile evidence."}
+
+{"action":"replace","reason":"Recent journals confirm a recurring workflow preference.","content":"# User Memory\n\n## Priorities\n..."}

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -15,7 +15,7 @@ def test_build_cli_overrides_maps_only_non_none_values() -> None:
         milvus_uri="http://localhost:19530",
         milvus_token=None,
         llm_provider="gemini",
-        llm_model="gemini-2.0-flash",
+        llm_model="gemini-3-flash-preview",
         prompt_file="prompts/compact.txt",
         llm_base_url="https://llm.example.com",
         llm_api_key="env:LLM_KEY",
@@ -38,7 +38,7 @@ def test_build_cli_overrides_maps_only_non_none_values() -> None:
         },
         "compact": {
             "llm_provider": "gemini",
-            "llm_model": "gemini-2.0-flash",
+            "llm_model": "gemini-3-flash-preview",
             "prompt_file": "prompts/compact.txt",
             "base_url": "https://llm.example.com",
             "api_key": "env:LLM_KEY",

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -57,7 +57,7 @@ async def test_compact_chunks_dispatches_to_anthropic(monkeypatch) -> None:
     )
 
     assert result == "anthropic-summary"
-    assert captured["model"] == "claude-sonnet-4-5-20250929"
+    assert captured["model"] == "claude-sonnet-4-6"
     assert "memory chunk" in captured["prompt"]
 
 
@@ -81,7 +81,7 @@ async def test_compact_chunks_dispatches_to_gemini(monkeypatch) -> None:
     assert result == "gemini-summary"
     assert captured == {
         "prompt": "Summarize:\nmemory chunk",
-        "model": "gemini-2.0-flash",
+        "model": "gemini-3-flash-preview",
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,8 +34,14 @@ def test_default_config():
     assert cfg.compact.llm_provider == "openai"
     assert cfg.llm.providers == {}
     assert cfg.plugins.claude_code.summarize.provider == ""
+    assert cfg.plugins.claude_code.summarize.enabled is True
     assert cfg.plugins.claude_code.summarize.model == ""
     assert cfg.plugins.codex.summarize.model == ""
+    assert cfg.plugins.codex.project_review.enabled is False
+    assert cfg.plugins.codex.project_review.min_interval_hours == 24
+    assert cfg.plugins.codex.project_review.input_dir == ".memsearch/memory"
+    assert cfg.plugins.codex.project_review.output_file == ".memsearch/PROJECT.md"
+    assert cfg.plugins.codex.user_profile.output_file == ".memsearch/USER.md"
 
 
 def test_load_toml_file(tmp_path: Path):
@@ -170,6 +176,32 @@ def test_plugin_summarize_provider_config_roundtrip(tmp_path: Path, monkeypatch:
 
     saved = load_config_file(cfg_path)
     assert saved["plugins"]["codex"]["summarize"]["provider"] == "openai"
+
+
+def test_plugin_maintenance_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Plugin maintenance tasks should be addressable by dotted keys."""
+    cfg_path = tmp_path / "config.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    set_config_value("plugins.codex.project_review.enabled", "true")
+    set_config_value("plugins.codex.project_review.provider", "openai")
+    set_config_value("plugins.codex.project_review.min_interval_hours", "12")
+    set_config_value("plugins.codex.project_review.input_dir", "memory-journals")
+    set_config_value("plugins.codex.project_review.output_file", ".memsearch/AGENTS.md")
+    set_config_value("plugins.codex.user_profile.enabled", "false")
+
+    cfg = resolve_config()
+    assert cfg.plugins.codex.project_review.enabled is True
+    assert cfg.plugins.codex.project_review.provider == "openai"
+    assert cfg.plugins.codex.project_review.min_interval_hours == 12
+    assert cfg.plugins.codex.project_review.input_dir == "memory-journals"
+    assert cfg.plugins.codex.project_review.output_file == ".memsearch/AGENTS.md"
+    assert cfg.plugins.codex.user_profile.enabled is False
+
+    saved = load_config_file(cfg_path)
+    assert saved["plugins"]["codex"]["project_review"]["enabled"] is True
+    assert saved["plugins"]["codex"]["project_review"]["min_interval_hours"] == 12
 
 
 def test_named_llm_provider_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from memsearch.config import LLMProviderConfig, MemSearchConfig
+from memsearch.maintenance import run_due_tasks, run_memory_command, run_task_llm
+
+
+def test_maintenance_routes_gemini_provider_to_tool_runner(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("- User discussed Gemini maintenance.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.llm.providers["gemini"] = LLMProviderConfig(type="gemini", model="gemini-test")
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "gemini"
+
+    captured = {}
+
+    def fake_gemini(ctx, prompt: str, model: str | None, provider_cfg) -> str:
+        captured["model"] = model
+        captured["provider_type"] = provider_cfg.type
+        return json.dumps({"action": "none", "reason": "ok"})
+
+    monkeypatch.setattr("memsearch.maintenance._run_gemini_with_tools", fake_gemini)
+
+    results = run_due_tasks(platform="codex", project_dir=project, cfg=cfg)
+
+    assert results[0].action == "none"
+    assert captured == {"model": "gemini-test", "provider_type": "gemini"}
+
+
+def test_maintenance_replace_writes_output_and_state(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("### 10:00\n- User discussed maintenance runner.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "openai"
+
+    def fake_runner(ctx, prompt: str) -> str:
+        assert "Recent memory journal entries" in prompt
+        return json.dumps(
+            {
+                "action": "replace",
+                "reason": "new project state",
+                "content": "# Project Memory\n\n## Active Threads\n- Maintenance runner.",
+            }
+        )
+
+    results = run_due_tasks(platform="codex", project_dir=project, cfg=cfg, llm_runner=fake_runner)
+
+    assert [r.action for r in results] == ["replace", "disabled"]
+    assert (project / ".memsearch" / "PROJECT.md").read_text(encoding="utf-8").startswith("# Project Memory")
+    state = json.loads((project / ".memsearch" / ".maintenance-state.json").read_text(encoding="utf-8"))
+    assert state["codex.project_review"]["last_action"] == "replace"
+    assert state["codex.project_review"]["last_input_digest"].startswith("sha256:")
+
+
+def test_maintenance_skips_unchanged_input(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("### 10:00\n- Stable note.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+
+    calls = 0
+
+    def fake_runner(ctx, prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return json.dumps({"action": "none", "reason": "no durable change"})
+
+    first = run_due_tasks(platform="codex", project_dir=project, cfg=cfg, llm_runner=fake_runner)
+    second = run_due_tasks(platform="codex", project_dir=project, cfg=cfg, llm_runner=fake_runner)
+
+    assert first[0].action == "none"
+    assert second[0].action == "skip"
+    assert calls == 1
+
+
+def test_run_memory_command_rejects_shell_metacharacters(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    input_dir = project / ".memsearch" / "memory"
+    input_dir.mkdir(parents=True)
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+
+    captured = {}
+
+    def fake_runner(ctx, prompt: str) -> str:
+        captured["ctx"] = ctx
+        return json.dumps({"action": "none", "reason": "test"})
+
+    run_due_tasks(platform="codex", project_dir=project, cfg=cfg, force=True, llm_runner=fake_runner)
+    output = run_memory_command("cat /etc/passwd", captured["ctx"])
+
+    assert "not allowed" in output
+
+
+def test_native_provider_requires_plugin_runner(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    input_dir = project / ".memsearch" / "memory"
+    input_dir.mkdir(parents=True)
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "native"
+
+    captured = {}
+
+    def fake_runner(ctx, prompt: str) -> str:
+        captured["ctx"] = ctx
+        return json.dumps({"action": "none", "reason": "test"})
+
+    run_due_tasks(platform="codex", project_dir=project, cfg=cfg, force=True, llm_runner=fake_runner)
+
+    try:
+        run_task_llm(captured["ctx"], "{}", cfg)
+    except RuntimeError as e:
+        assert "plugin runner" in str(e)
+    else:
+        raise AssertionError("native maintenance provider should require plugin runner")

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_runner():
+    path = Path(__file__).resolve().parents[1] / "plugins" / "_shared" / "scripts" / "maintenance-runner.py"
+    spec = importlib.util.spec_from_file_location("memsearch_plugin_maintenance_runner", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plugin_maintenance_runner_copies_match_shared() -> None:
+    root = Path(__file__).resolve().parents[1]
+    shared = (root / "plugins" / "_shared" / "scripts" / "maintenance-runner.py").read_text(encoding="utf-8")
+    for platform in ["claude-code", "codex", "openclaw", "opencode"]:
+        copied = (root / "plugins" / platform / "scripts" / "maintenance-runner.py").read_text(encoding="utf-8")
+        assert copied == shared
+
+
+def test_plugin_maintenance_runner_uses_project_config(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-28.md").write_text("- Project decision: test shared runner.\n", encoding="utf-8")
+    (project / ".memsearch.toml").write_text(
+        '[plugins.codex.project_review]\nenabled = true\nprovider = "native"\n',
+        encoding="utf-8",
+    )
+
+    def fake_native(ctx, prompt: str) -> str:
+        assert ctx.project_dir == project
+        assert "test shared runner" in prompt
+        return json.dumps(
+            {
+                "action": "replace",
+                "reason": "test",
+                "content": "# Project Memory\n\n## Decisions\n- Test shared runner.",
+            }
+        )
+
+    monkeypatch.setattr(runner, "run_native_provider", fake_native)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "maintenance-runner.py",
+            "--platform",
+            "codex",
+            "--project-dir",
+            str(project),
+            "--json-output",
+        ],
+    )
+
+    assert runner.main() == 0
+    assert (project / ".memsearch" / "PROJECT.md").read_text(encoding="utf-8").startswith("# Project Memory")
+
+
+def test_codex_native_runner_uses_profile_and_last_message(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+    captured = {}
+
+    def fake_run_command(cmd, *, env, cwd, timeout):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["cwd"] = cwd
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text('{"action":"none","reason":"ok"}', encoding="utf-8")
+        return "diagnostic output that is not JSON"
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setenv("MEMSEARCH_CODEX_PROFILE", "zilliz")
+
+    ctx = SimpleNamespace(
+        platform="codex",
+        project_dir=tmp_path,
+        task_config=SimpleNamespace(model=""),
+    )
+
+    result = runner.run_native_provider(ctx, "prompt")
+
+    assert json.loads(result) == {"action": "none", "reason": "ok"}
+    assert captured["cmd"][0:2] == ["codex", "exec"]
+    assert captured["cmd"][captured["cmd"].index("-p") + 1] == "zilliz"
+    assert "-o" in captured["cmd"]
+    assert captured["env"]["MEMSEARCH_IN_STOP_WORKER"] == "1"
+
+
+def test_claude_native_runner_passes_prompt_as_user_input(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+    captured = {}
+
+    def fake_run_command(cmd, *, env, cwd, timeout):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["cwd"] = cwd
+        return '{"action":"none","reason":"ok"}'
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    ctx = SimpleNamespace(
+        platform="claude-code",
+        project_dir=tmp_path,
+        task_config=SimpleNamespace(model="sonnet"),
+    )
+
+    result = runner.run_native_provider(ctx, "maintenance prompt")
+
+    assert json.loads(result) == {"action": "none", "reason": "ok"}
+    assert captured["cmd"][0:2] == ["claude", "-p"]
+    assert captured["cmd"][-1] == "maintenance prompt"
+    assert captured["cmd"][captured["cmd"].index("--system-prompt") + 1] != "maintenance prompt"
+    assert captured["env"]["CLAUDECODE"] == ""
+
+
+def test_openclaw_native_runner_extracts_json_from_noisy_output(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+
+    def fake_run_command(cmd, *, env, cwd, timeout):
+        return "\n".join(
+            [
+                "[plugins] [memsearch] Plugin loaded.",
+                '{"action":"none","reason":"ok"}',
+                "[plugins] [memsearch] Captured turn summary.",
+            ]
+        )
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    ctx = SimpleNamespace(
+        platform="openclaw",
+        project_dir=tmp_path,
+        task_config=SimpleNamespace(model=""),
+    )
+
+    result = runner.run_native_provider(ctx, "maintenance prompt")
+
+    assert json.loads(result) == {"action": "none", "reason": "ok"}


### PR DESCRIPTION
## Summary
- add optional project and user maintenance tasks for all plugins
- add shared maintenance prompts and plugin-local runners
- update provider defaults and configuration docs

## Tests
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run python -m pytest tests/test_config.py tests/test_compact.py tests/test_compact_cli.py tests/test_cli_config_helpers.py tests/test_maintenance.py tests/test_maintenance_runner.py