### PR TITLE
Bump versions for 0.4.5 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,8 +1,19 @@
 {
   "name": "memsearch",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
+  "files": [
+    "index.js",
+    "index.ts",
+    "install.sh",
+    "openclaw.plugin.json",
+    "scripts/*.py",
+    "scripts/*.sh",
+    "skills/",
+    "prompts/",
+    "README.md"
+  ],
   "scripts": {
     "build": "esbuild index.ts --platform=node --format=esm --outfile=index.js"
   },

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.4"
+version = "0.4.5"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump memsearch package version to 0.4.5
- bump plugin package versions for the maintenance release
- restrict the OpenClaw package contents to published runtime files

## Tests
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run ruff check src/ tests/
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run ruff format --check src/ tests/
- env -u OPENAI_API_KEY UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run python -m pytest
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv build
- npm pack --dry-run (plugins/opencode)
- npm pack --dry-run (plugins/openclaw)