### PR TITLE
Bump versions for 0.4.6 release

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.5"
+version = "0.4.6"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump memsearch package version to 0.4.6
- bump Claude Code plugin metadata to 0.4.6
- bump OpenClaw plugin to 0.3.6 and OpenCode plugin to 0.3.3

## Validation
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run --python 3.13 python -m pytest tests/test_config.py tests/test_compact_cli.py tests/test_compact.py tests/test_opencode_turns.py -q
- UV_CACHE_DIR=/tmp/uv-cache-memsearch uv run --python 3.13 mkdocs build --strict
- npm publish --dry-run