### PR TITLE
fix(codex): install skills into Codex skill root

### DIFF
--- a/docs/platforms/codex/installation.md
+++ b/docs/platforms/codex/installation.md
@@ -18,7 +18,7 @@ bash memsearch/plugins/codex/scripts/install.sh
 
 The installer:
 
-1. Copies the memory-recall skill to `~/.agents/skills/`
+1. Copies the memory-recall skill to `~/.codex/skills/`
 2. Installs or updates memsearch hooks in `~/.codex/hooks.json`
 3. Enables `hooks = true` in `~/.codex/config.toml`
 4. Makes all scripts executable
@@ -69,7 +69,7 @@ from pathlib import Path
 import json
 import shutil
 
-skill_dir = Path.home() / ".agents/skills/memory-recall"
+skill_dir = Path.home() / ".codex/skills/memory-recall"
 if skill_dir.is_symlink() or skill_dir.is_file():
     skill_dir.unlink()
 elif skill_dir.exists():

--- a/docs/platforms/codex/memory-recall.md
+++ b/docs/platforms/codex/memory-recall.md
@@ -111,7 +111,7 @@ In practice, this works well for targeted queries but is less efficient for broa
 
 **Use specific queries.** "Redis caching" will return better results than "the thing we did". The hybrid search combines semantic similarity with keyword matching, so including specific terms helps.
 
-**Check the skill install.** The `$memory-recall` skill must be installed at `~/.agents/skills/memory-recall/SKILL.md`. The installer substitutes `__INSTALL_DIR__` with the actual plugin path. If recall doesn't work, verify the skill file exists and paths are correct.
+**Check the skill install.** The `$memory-recall` skill must be installed at `~/.codex/skills/memory-recall/SKILL.md`. The installer substitutes `__INSTALL_DIR__` with the actual plugin path. If recall doesn't work, verify the skill file exists and paths are correct.
 
 **Derive collection manually.** If you need to debug collection issues:
 ```bash

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -20,7 +20,7 @@ bash plugins/codex/scripts/install.sh
 ```
 
 The installer sets up everything automatically:
-- Copies the **memory-recall** skill to `~/.agents/skills/`
+- Copies the **memory-recall** skill to `~/.codex/skills/`
 - Installs or updates memsearch hook entries in `~/.codex/hooks.json`
 - Enables the `hooks` feature flag
 

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -187,11 +187,12 @@ fi
 
 # --- 2. Install skills ---
 echo "[2/6] Installing memsearch skills..."
-mkdir -p "$HOME/.agents/skills"
+SKILLS_DIR="$HOME/.codex/skills"
+mkdir -p "$SKILLS_DIR"
 
 for skill_name in memory-recall memory-config; do
   SKILL_SRC="$INSTALL_DIR/skills/$skill_name"
-  SKILL_DST="$HOME/.agents/skills/$skill_name"
+  SKILL_DST="$SKILLS_DIR/$skill_name"
   if [ -d "$SKILL_DST" ] || [ -L "$SKILL_DST" ]; then
     echo "  ⚠ Existing $skill_name skill found — replacing"
     rm -rf "$SKILL_DST"
@@ -205,7 +206,7 @@ done
 # --- 3. Replace __INSTALL_DIR__ placeholder in SKILL.md ---
 echo "[3/6] Configuring skill paths..."
 for skill_name in memory-recall memory-config; do
-  SKILL_DST="$HOME/.agents/skills/$skill_name"
+  SKILL_DST="$SKILLS_DIR/$skill_name"
   if [ -f "$SKILL_DST/SKILL.md" ]; then
     replace_text_in_file "$SKILL_DST/SKILL.md" "__INSTALL_DIR__" "$INSTALL_DIR"
     echo "  ✓ Updated $skill_name SKILL.md with install path: $INSTALL_DIR"
@@ -251,7 +252,7 @@ echo "  • memory-config skill: diagnose and configure memsearch"
 echo ""
 echo "Memory files:   <project>/.memsearch/memory/*.md"
 echo "Hooks config:   $HOOKS_FILE"
-echo "Skill location: $HOME/.agents/skills/{memory-recall,memory-config}"
+echo "Skill location: $SKILLS_DIR/{memory-recall,memory-config}"
 echo "Feature flag:   hooks = true in $CONFIG_FILE"
 echo ""
 echo "To verify: start a new codex session and check for [memsearch] status line."

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -12,6 +12,10 @@ Determine the collection name by running:
 bash -c 'if [ -n "${MEMSEARCH_DIR:-}" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$MEMSEARCH_DIR"; else root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi; fi'
 ```
 
+## Hermes vs MemSearch impact
+
+When explaining Hermes/MemSearch impact, distinguish runtime behaviour from infrastructure health: Hermes affects Hermes-native runs; MemSearch hooks affect Claude/Codex recall. Answer what changes in live Claude/Codex sessions, not just whether Milvus is healthy.
+
 ## Steps
 
 1. **Search**: Run `memsearch search "<query>" --top-k 5 --json-output --collection <collection name from above>` to find relevant chunks.


### PR DESCRIPTION
## Summary
- install Codex plugin skills into `~/.codex/skills` instead of `~/.agents/skills`
- update Codex plugin docs and uninstall guidance to match the Codex skill root
- keep memory-recall guidance clear about Hermes vs MemSearch runtime impact

## Verification
- `git diff --check origin/main..HEAD`
- `bash -n plugins/codex/scripts/install.sh`
- scanned added lines for local/user-specific paths: no matches for `/Users`, `dominic`, `monkhouse`, `claude-config`, `mcp-setup`, or `.agents/skills`