### PR TITLE
docs(memory): clarify Hermes versus MemSearch recall impact

### DIFF
--- a/plugins/claude-code/skills/memory-recall/SKILL.md
+++ b/plugins/claude-code/skills/memory-recall/SKILL.md
@@ -11,6 +11,10 @@ You are a memory retrieval agent for memsearch. Your job is to search past memor
 
 Collection: !`bash -c 'if [ -n "${MEMSEARCH_DIR:-}" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$MEMSEARCH_DIR"; else root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh" "$root"; else bash "${CLAUDE_PLUGIN_ROOT}/scripts/derive-collection.sh"; fi; fi'`
 
+## Hermes vs MemSearch impact
+
+When explaining Hermes/MemSearch impact, distinguish runtime behaviour from infrastructure health: Hermes affects Hermes-native runs; MemSearch hooks affect Claude/Codex recall. Answer what changes in live Claude/Codex sessions, not just whether Milvus is healthy.
+
 ## Your Task
 
 Search for memories relevant to: $ARGUMENTS

--- a/plugins/codex/skills/memory-recall/SKILL.md
+++ b/plugins/codex/skills/memory-recall/SKILL.md
@@ -12,6 +12,10 @@ Determine the collection name by running:
 bash -c 'if [ -n "${MEMSEARCH_DIR:-}" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$MEMSEARCH_DIR"; else root=$(git rev-parse --show-toplevel 2>/dev/null || true); if [ -n "$root" ]; then bash __INSTALL_DIR__/scripts/derive-collection.sh "$root"; else bash __INSTALL_DIR__/scripts/derive-collection.sh; fi; fi'
 ```
 
+## Hermes vs MemSearch impact
+
+When explaining Hermes/MemSearch impact, distinguish runtime behaviour from infrastructure health: Hermes affects Hermes-native runs; MemSearch hooks affect Claude/Codex recall. Answer what changes in live Claude/Codex sessions, not just whether Milvus is healthy.
+
 ## Steps
 
 1. **Search**: Run `memsearch search "<query>" --top-k 5 --json-output --collection <collection name from above>` to find relevant chunks.


### PR DESCRIPTION
## Summary
- add guidance to memory-recall skills for explaining Hermes versus MemSearch impact
- distinguish runtime behaviour from infrastructure health

## Verification
- git diff --check origin/main..HEAD
- scanned diff additions for user-specific local paths