### PR TITLE
Fix native summary hook prompt handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -82,8 +82,17 @@ with open(sys.argv[1]) as f:
     for line in f:
         try:
             obj = json.loads(line)
-            if obj.get('type') == 'user' and isinstance(obj.get('message', {}).get('content'), str):
+            if obj.get('type') != 'user' or obj.get('isMeta'):
+                continue
+            content = obj.get('message', {}).get('content')
+            if isinstance(content, str) and content.strip():
                 uuid = obj.get('uuid', '')
+                continue
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text' and block.get('text', '').strip():
+                        uuid = obj.get('uuid', '')
+                        break
         except: pass
 print(uuid)
 " "$TRANSCRIPT_PATH" 2>/dev/null || true)
@@ -125,12 +134,18 @@ elif command -v claude &>/dev/null; then
       SUMMARIZE_MODEL="$CONFIG_MODEL"
     fi
   fi
-  SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
+  # Keep the shared external-observer prompt, but pass it as the primary prompt.
+  # This avoids the stdin + --system-prompt path while preserving summary rules.
+  LLM_PROMPT="${SYSTEM_PROMPT}
+
+Transcript:
+${PARSED}"
+  SUMMARY=$(MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
     --strict-mcp-config \
     --model "$SUMMARIZE_MODEL" \
     --no-session-persistence \
     --no-chrome \
-    --system-prompt "$SYSTEM_PROMPT" \
+    "$LLM_PROMPT" \
     2>/dev/null || true)
 fi
 


### PR DESCRIPTION
## Summary
- Preserve the shared summary instructions in native capture by sending the instructions and parsed transcript as one prompt.
- Improve last user-turn anchor extraction for string content, text block content, and metadata-only entries.
- Sync marketplace metadata to version 0.4.6.

## Testing
- Shell syntax check for the updated hook
- Targeted parser and maintenance test suite
- Whitespace check
- Remote interactive plugin smoke: save marker, verify markdown summary, verify fresh-session recall
