### PR TITLE
fix(codex): preserve UTF-8 in stop summaries

### DIFF
--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -48,6 +48,20 @@ _load_worker_field() {
   _json_val "$work_input" "$key" ""
 }
 
+_truncate_chars() {
+  local limit="$1"
+  python3 -c "
+import sys
+limit = int(sys.argv[1])
+text = sys.stdin.read()
+sys.stdout.write(text[:limit])
+" "$limit" 2>/dev/null || true
+}
+
+_valid_utf8() {
+  iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat
+}
+
 run_worker() {
   local work_file="${1:-}"
   if [ -z "$work_file" ] || [ ! -f "$work_file" ]; then
@@ -153,7 +167,7 @@ ${CONTENT}"
   if [ -z "$SUMMARY" ]; then
     if [ -n "$LAST_MSG" ] && [ -n "$USER_QUESTION" ]; then
       local TRUNCATED_MSG
-      TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | head -c 800)
+      TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | _truncate_chars 800)
       if [ ${#LAST_MSG} -gt 800 ]; then
         TRUNCATED_MSG="${TRUNCATED_MSG}..."
       fi
@@ -161,7 +175,7 @@ ${CONTENT}"
 - Codex: ${TRUNCATED_MSG}"
     elif [ -n "$LAST_MSG" ]; then
       local TRUNCATED_MSG
-      TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | head -c 800)
+      TRUNCATED_MSG=$(printf '%s' "$LAST_MSG" | _truncate_chars 800)
       if [ ${#LAST_MSG} -gt 800 ]; then
         TRUNCATED_MSG="${TRUNCATED_MSG}..."
       fi
@@ -176,7 +190,7 @@ ${CONTENT}"
     if [ -n "$SESSION_ID" ]; then
       echo "<!-- session:${SESSION_ID} rollout:${TRANSCRIPT_PATH} -->"
     fi
-    echo "$SUMMARY"
+    printf '%s\n' "$SUMMARY" | _valid_utf8
     echo ""
   } >> "$MEMORY_FILE"
 
@@ -249,7 +263,7 @@ LAST_MSG=$(_json_val "$INPUT" "last_assistant_message" "")
 # Unbounded transcripts risk ARG_MAX overflow on execve; the worker only
 # ever uses the first 800 chars of LAST_MSG as a fallback summary anyway.
 if [ ${#LAST_MSG} -gt 4000 ]; then
-  LAST_MSG="${LAST_MSG:0:4000}...(truncated)"
+  LAST_MSG="$(printf '%s' "$LAST_MSG" | _truncate_chars 4000)...(truncated)"
 fi
 USER_QUESTION=""
 PARSED=""
@@ -322,7 +336,7 @@ fi
 
 MAX_CONTENT_CHARS="${MEMSEARCH_SUMMARY_MAX_CHARS:-8000}"
 if [ ${#CONTENT} -gt "$MAX_CONTENT_CHARS" ]; then
-  CONTENT="${CONTENT:0:$MAX_CONTENT_CHARS}...(truncated)"
+  CONTENT="$(printf '%s' "$CONTENT" | _truncate_chars "$MAX_CONTENT_CHARS")...(truncated)"
 fi
 
 WORK_FILE="$(mktemp "${TMPDIR:-/tmp}/memsearch-stop.XXXXXX.json")"

--- a/tests/test_codex_stop_hook_utf8.py
+++ b/tests/test_codex_stop_hook_utf8.py
@@ -30,12 +30,23 @@ def test_codex_stop_worker_fallback_summary_preserves_utf8(tmp_path: Path) -> No
         encoding="utf-8",
     )
 
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_codex = fake_bin / "codex"
+    fake_codex.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_codex.chmod(0o755)
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_memsearch.chmod(0o755)
+
     env = {
         **os.environ,
+        "HOME": str(tmp_path / "home"),
         "MEMSEARCH_PROJECT_DIR": str(tmp_path),
         "MEMSEARCH_SKIP_HOOK_STDIN": "1",
-        # Keep codex/memsearch out of PATH so the worker uses fallback summary.
-        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        # Force the native summarizer path to return no summary so fallback
+        # formatting is exercised even on machines with codex installed.
+        "PATH": f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin",
     }
     subprocess.run(["bash", str(SCRIPT), "--worker", str(work_file)], check=True, env=env)
 

--- a/tests/test_codex_stop_hook_utf8.py
+++ b/tests/test_codex_stop_hook_utf8.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("plugins/codex/hooks/stop.sh")
+
+
+def test_codex_stop_worker_fallback_summary_preserves_utf8(tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+    memory_file = memory_dir / "2026-06-01.md"
+    work_file = tmp_path / "work.json"
+    long_cyrillic_message = "Привет мир, проверяем безопасную обрезку UTF-8. " * 120
+
+    work_file.write_text(
+        json.dumps(
+            {
+                "now": "15:10",
+                "memory_file": str(memory_file),
+                "session_id": "test-session",
+                "transcript_path": str(tmp_path / "rollout.jsonl"),
+                "content": "fallback content",
+                "user_question": "как поправить?",
+                "last_msg": long_cyrillic_message,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "MEMSEARCH_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_SKIP_HOOK_STDIN": "1",
+        # Keep codex/memsearch out of PATH so the worker uses fallback summary.
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+    }
+    subprocess.run(["bash", str(SCRIPT), "--worker", str(work_file)], check=True, env=env)
+
+    content = memory_file.read_text(encoding="utf-8")
+    assert "- User asked: как поправить?" in content
+    assert "- Codex: Привет мир" in content
+    assert "..." in content


### PR DESCRIPTION
## Summary
- replace byte-based truncation in the Codex stop hook with Unicode-safe character truncation
- sanitize fallback summary output before appending to memory markdown
- add a regression test that runs the stop worker with long Cyrillic text and reads the resulting memory file as UTF-8

## Verification
- bash -n plugins/codex/hooks/stop.sh
- uv run pytest tests/test_codex_stop_hook_utf8.py tests/test_codex_parse_rollout.py
- uv run ruff check tests/test_codex_stop_hook_utf8.py
- git diff --check