### PR TITLE
Restrict native summarizer tool access

### DIFF
--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -143,7 +143,7 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = ["claude", "-p", "--strict-mcp-config", "--tools", "", "--no-session-persistence", "--no-chrome"]
         if model:
             cmd += ["--model", model]
         cmd += [

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -142,6 +142,7 @@ Transcript:
 ${PARSED}"
   SUMMARY=$(MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
     --strict-mcp-config \
+    --tools "" \
     --model "$SUMMARIZE_MODEL" \
     --no-session-persistence \
     --no-chrome \

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -143,7 +143,7 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = ["claude", "-p", "--strict-mcp-config", "--tools", "", "--no-session-persistence", "--no-chrome"]
         if model:
             cmd += ["--model", model]
         cmd += [

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -143,7 +143,7 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = ["claude", "-p", "--strict-mcp-config", "--tools", "", "--no-session-persistence", "--no-chrome"]
         if model:
             cmd += ["--model", model]
         cmd += [

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -143,7 +143,7 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = ["claude", "-p", "--strict-mcp-config", "--tools", "", "--no-session-persistence", "--no-chrome"]
         if model:
             cmd += ["--model", model]
         cmd += [

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -143,7 +143,7 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = ["claude", "-p", "--strict-mcp-config", "--tools", "", "--no-session-persistence", "--no-chrome"]
         if model:
             cmd += ["--model", model]
         cmd += [


### PR DESCRIPTION
## Summary
- disable built-in tool access for the native summarizer subprocess during capture
- apply the same invocation flag to the shared maintenance runner and packaged copies

Fixes #565

## Verification
- hook syntax check
- runner bytecode compilation
- packaged runner copy comparison