### PR TITLE
Fix update hints and transcript encoding

### DIFF
--- a/plugins/claude-code/hooks/parse-transcript.sh
+++ b/plugins/claude-code/hooks/parse-transcript.sh
@@ -28,6 +28,7 @@ fi
 
 python3 -c '
 import json, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 def find_last_turn_start(lines):
     """Find the index of the last real user message (string or array-format content)."""
@@ -93,7 +94,7 @@ def format_turn(lines):
 
 # --- Main ---
 transcript_path = sys.argv[1]
-with open(transcript_path) as f:
+with open(transcript_path, encoding="utf-8", errors="replace") as f:
     lines = f.readlines()
 
 if not lines:

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -72,10 +72,16 @@ if [ -n "$VERSION" ]; then
   _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
   LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
-    # Detect install method to suggest the right upgrade command
-    _MS_REAL=$(readlink -f "$(command -v memsearch 2>/dev/null)" 2>/dev/null || echo "")
+    # Detect install method to suggest the right upgrade command.
+    _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")
+    _MS_REAL=""
+    if [ -n "$_MS_BIN" ]; then
+      _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
+    fi
     if [[ "$MEMSEARCH_CMD" == *"uvx"* ]] || [[ "$_MS_REAL" == *"uv/tools"* ]]; then
       UPGRADE_CMD="uv tool install -U 'memsearch[onnx]'"
+    elif [[ "$_MS_REAL" == *"/pipx/venvs/memsearch/"* ]] || { command -v pipx &>/dev/null && pipx list 2>/dev/null | grep -Eq "package memsearch([ ,]|$)"; }; then
+      UPGRADE_CMD="pipx upgrade memsearch"
     else
       UPGRADE_CMD="pip install --upgrade 'memsearch[onnx]'"
     fi

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -78,7 +78,7 @@ SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl)
 LAST_USER_TURN_UUID=$(python3 -c "
 import json, sys
 uuid = ''
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], encoding='utf-8', errors='replace') as f:
     for line in f:
         try:
             obj = json.loads(line)

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -67,10 +67,16 @@ if [ -n "$VERSION" ]; then
   _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
   LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
-    # Detect install method to suggest the right upgrade command
-    _MS_REAL=$(readlink -f "$(command -v memsearch 2>/dev/null)" 2>/dev/null || echo "")
+    # Detect install method to suggest the right upgrade command.
+    _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")
+    _MS_REAL=""
+    if [ -n "$_MS_BIN" ]; then
+      _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
+    fi
     if [ "${MEMSEARCH_CMD[0]:-}" = "uvx" ] || [[ "$_MS_REAL" == *"uv/tools"* ]]; then
       UPGRADE_CMD="uv tool install -U 'memsearch[onnx]'"
+    elif [[ "$_MS_REAL" == *"/pipx/venvs/memsearch/"* ]] || { command -v pipx &>/dev/null && pipx list 2>/dev/null | grep -Eq "package memsearch([ ,]|$)"; }; then
+      UPGRADE_CMD="pipx upgrade memsearch"
     else
       UPGRADE_CMD="pip install --upgrade 'memsearch[onnx]'"
     fi


### PR DESCRIPTION
## Summary
- detect pipx installs when building update command hints
- keep existing uvx and uv tool hint behavior unchanged
- read and emit transcript text with UTF-8 replacement on locale-sensitive shells

Fixes #566
Fixes #546

## Verification
- hook syntax check
- git diff whitespace check