### PR TITLE
Honor OpenCode config resolution in runners

### DIFF
--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,6 +25,233 @@ DEFAULT_NATIVE_MODELS = {
     "opencode": "",
     "openclaw": "",
 }
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        return _read_jsonc_config_from_text(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
 
 
 def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
@@ -54,14 +282,19 @@ def extract_task_json_output(output: str) -> str:
     return output
 
 
-def ensure_opencode_isolated_config() -> Path:
+def ensure_opencode_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> Path:
     home = Path.home()
-    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated = root / "opencode"
     isolated.mkdir(parents=True, exist_ok=True)
-    src = home / ".config" / "opencode" / "opencode.json"
-    if src.is_file():
-        shutil.copy2(src, isolated / "opencode.json")
-    return isolated
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return root
 
 
 def ensure_memsearch_importable() -> None:
@@ -193,11 +426,15 @@ def run_native_provider(ctx, prompt: str) -> str:
         return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
 
     if ctx.platform == "opencode":
-        isolated = ensure_opencode_isolated_config()
+        isolated = ensure_opencode_isolated_config(ctx.project_dir)
         cmd = ["opencode", "run"]
         if model:
             cmd += ["-m", model]
         cmd.append(prompt)
+        env["OPENCODE_CONFIG"] = ""
+        env["OPENCODE_CONFIG_DIR"] = ""
+        env["OPENCODE_CONFIG_CONTENT"] = ""
+        env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
         env["XDG_CONFIG_HOME"] = str(isolated)
         env["XDG_DATA_HOME"] = str(isolated / "data")
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,6 +25,233 @@ DEFAULT_NATIVE_MODELS = {
     "opencode": "",
     "openclaw": "",
 }
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        return _read_jsonc_config_from_text(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
 
 
 def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
@@ -54,14 +282,19 @@ def extract_task_json_output(output: str) -> str:
     return output
 
 
-def ensure_opencode_isolated_config() -> Path:
+def ensure_opencode_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> Path:
     home = Path.home()
-    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated = root / "opencode"
     isolated.mkdir(parents=True, exist_ok=True)
-    src = home / ".config" / "opencode" / "opencode.json"
-    if src.is_file():
-        shutil.copy2(src, isolated / "opencode.json")
-    return isolated
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return root
 
 
 def ensure_memsearch_importable() -> None:
@@ -193,11 +426,15 @@ def run_native_provider(ctx, prompt: str) -> str:
         return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
 
     if ctx.platform == "opencode":
-        isolated = ensure_opencode_isolated_config()
+        isolated = ensure_opencode_isolated_config(ctx.project_dir)
         cmd = ["opencode", "run"]
         if model:
             cmd += ["-m", model]
         cmd.append(prompt)
+        env["OPENCODE_CONFIG"] = ""
+        env["OPENCODE_CONFIG_DIR"] = ""
+        env["OPENCODE_CONFIG_CONTENT"] = ""
+        env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
         env["XDG_CONFIG_HOME"] = str(isolated)
         env["XDG_DATA_HOME"] = str(isolated / "data")
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,6 +25,233 @@ DEFAULT_NATIVE_MODELS = {
     "opencode": "",
     "openclaw": "",
 }
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        return _read_jsonc_config_from_text(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
 
 
 def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
@@ -54,14 +282,19 @@ def extract_task_json_output(output: str) -> str:
     return output
 
 
-def ensure_opencode_isolated_config() -> Path:
+def ensure_opencode_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> Path:
     home = Path.home()
-    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated = root / "opencode"
     isolated.mkdir(parents=True, exist_ok=True)
-    src = home / ".config" / "opencode" / "opencode.json"
-    if src.is_file():
-        shutil.copy2(src, isolated / "opencode.json")
-    return isolated
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return root
 
 
 def ensure_memsearch_importable() -> None:
@@ -193,11 +426,15 @@ def run_native_provider(ctx, prompt: str) -> str:
         return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
 
     if ctx.platform == "opencode":
-        isolated = ensure_opencode_isolated_config()
+        isolated = ensure_opencode_isolated_config(ctx.project_dir)
         cmd = ["opencode", "run"]
         if model:
             cmd += ["-m", model]
         cmd.append(prompt)
+        env["OPENCODE_CONFIG"] = ""
+        env["OPENCODE_CONFIG_DIR"] = ""
+        env["OPENCODE_CONFIG_CONTENT"] = ""
+        env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
         env["XDG_CONFIG_HOME"] = str(isolated)
         env["XDG_DATA_HOME"] = str(isolated / "data")
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,6 +25,233 @@ DEFAULT_NATIVE_MODELS = {
     "opencode": "",
     "openclaw": "",
 }
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        return _read_jsonc_config_from_text(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
 
 
 def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
@@ -54,14 +282,19 @@ def extract_task_json_output(output: str) -> str:
     return output
 
 
-def ensure_opencode_isolated_config() -> Path:
+def ensure_opencode_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> Path:
     home = Path.home()
-    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated = root / "opencode"
     isolated.mkdir(parents=True, exist_ok=True)
-    src = home / ".config" / "opencode" / "opencode.json"
-    if src.is_file():
-        shutil.copy2(src, isolated / "opencode.json")
-    return isolated
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return root
 
 
 def ensure_memsearch_importable() -> None:
@@ -193,11 +426,15 @@ def run_native_provider(ctx, prompt: str) -> str:
         return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
 
     if ctx.platform == "opencode":
-        isolated = ensure_opencode_isolated_config()
+        isolated = ensure_opencode_isolated_config(ctx.project_dir)
         cmd = ["opencode", "run"]
         if model:
             cmd += ["-m", model]
         cmd.append(prompt)
+        env["OPENCODE_CONFIG"] = ""
+        env["OPENCODE_CONFIG_DIR"] = ""
+        env["OPENCODE_CONFIG_CONTENT"] = ""
+        env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
         env["XDG_CONFIG_HOME"] = str(isolated)
         env["XDG_DATA_HOME"] = str(isolated / "data")
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -21,7 +21,6 @@ import json
 import os
 import re
 import shlex
-import shutil
 import signal
 import sqlite3
 import subprocess
@@ -57,21 +56,238 @@ def split_memsearch_cmd(memsearch_cmd: str) -> list[str]:
     return shlex.split(memsearch_cmd)
 
 
-def get_small_model() -> str:
-    """Read small_model from opencode.json config (fallback to model, then empty)."""
-    config_paths = [
-        os.path.expanduser("~/.config/opencode/opencode.json"),
-        "opencode.json",
-    ]
-    for p in config_paths:
-        if os.path.exists(p):
-            try:
-                with open(p, encoding="utf-8") as f:
-                    cfg = json.load(f)
-                return cfg.get("small_model", cfg.get("model", ""))
-            except Exception:
-                pass
-    return ""
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(path.read_text(encoding="utf-8")))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
+
+
+def get_small_model(project_dir: str | os.PathLike[str] | None = None) -> str:
+    """Read small_model from OpenCode config, falling back to model."""
+    cfg = load_opencode_config(project_dir)
+    return str(cfg.get("small_model", cfg.get("model", "")) or "")
 
 
 def get_plugin_summarize_model(memsearch_cmd: str | None = None) -> str:
@@ -122,19 +338,19 @@ def get_plugin_summarize_enabled(memsearch_cmd: str | None = None) -> bool:
         return True
 
 
-def ensure_isolated_config() -> str:
+def ensure_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> str:
     """Create isolated config dir without plugins/ to prevent recursion."""
-    isolated = os.path.expanduser("~/.codex/tmp/opencode-memsearch-summarize/opencode")
-    os.makedirs(isolated, exist_ok=True)
-    # Copy opencode.json (provider config) but NOT plugins/
-    src = os.path.expanduser("~/.config/opencode/opencode.json")
-    dst = os.path.join(isolated, "opencode.json")
-    if os.path.islink(dst) or (os.path.lexists(dst) and not os.path.isfile(dst)):
-        with contextlib.suppress(OSError):
-            os.remove(dst)
-    if os.path.exists(src) and not os.path.exists(dst):
-        shutil.copy2(src, dst)
-    return os.path.dirname(isolated)
+    root = Path.home() / ".codex" / "tmp" / "opencode-memsearch-summarize"
+    isolated = root / "opencode"
+    isolated.mkdir(parents=True, exist_ok=True)
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return str(root)
 
 
 def _load_summarize_prompt(agent_name: str, memsearch_cmd: str | None = None) -> str:
@@ -171,7 +387,12 @@ def _load_summarize_prompt(agent_name: str, memsearch_cmd: str | None = None) ->
     )
 
 
-def summarize_with_llm(turn_text: str, small_model: str, memsearch_cmd: str | None = None) -> str | None:
+def summarize_with_llm(
+    turn_text: str,
+    small_model: str,
+    memsearch_cmd: str | None = None,
+    project_dir: str | os.PathLike[str] | None = None,
+) -> str | None:
     """Summarize using configured provider routing."""
     if not get_plugin_summarize_enabled(memsearch_cmd):
         return None
@@ -202,7 +423,7 @@ def summarize_with_llm(turn_text: str, small_model: str, memsearch_cmd: str | No
         return None
 
     # Native path: summarize using opencode run in isolated env (no plugins -> no recursion).
-    isolated_dir = ensure_isolated_config()
+    isolated_dir = ensure_isolated_config(project_dir)
 
     summarize_model = get_plugin_summarize_model(memsearch_cmd) or small_model
     cmd = ["opencode", "run"]
@@ -215,6 +436,10 @@ def summarize_with_llm(turn_text: str, small_model: str, memsearch_cmd: str | No
             cmd,
             env={
                 **os.environ,
+                "OPENCODE_CONFIG": "",
+                "OPENCODE_CONFIG_DIR": "",
+                "OPENCODE_CONFIG_CONTENT": "",
+                "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
                 "XDG_CONFIG_HOME": isolated_dir,
                 "XDG_DATA_HOME": os.path.join(isolated_dir, "data"),
                 "MEMSEARCH_NO_WATCH": "1",
@@ -491,7 +716,8 @@ def capture_session_turns(
         if not capture_exists(memory_dir, session_id, turn.turn_id):
             if not get_plugin_summarize_enabled(memsearch_cmd):
                 continue
-            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd)
+            project_dir = Path(memory_dir).resolve().parent.parent
+            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, project_dir)
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,
@@ -538,7 +764,7 @@ def main() -> None:
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)
 
-    small_model = get_small_model()
+    small_model = get_small_model(args.project_dir)
     turn_db = open_turn_db(args.project_dir)
     tail_turn_cache: dict[str, TailTurnObservation] = {}
 

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,6 +25,233 @@ DEFAULT_NATIVE_MODELS = {
     "opencode": "",
     "openclaw": "",
 }
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove JSONC comments and trailing commas while preserving string contents."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+
+    without_comments = "".join(out)
+    out = []
+    i = 0
+    in_string = False
+    string_quote = ""
+    escaped = False
+    while i < len(without_comments):
+        char = without_comments[i]
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            string_quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == ",":
+            j = i + 1
+            while j < len(without_comments) and without_comments[j].isspace():
+                j += 1
+            if j < len(without_comments) and without_comments[j] in "]}":
+                i += 1
+                continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _read_jsonc_config_from_text(text: str) -> dict:
+    try:
+        data = json.loads(_strip_jsonc(text))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_jsonc_config(path: Path) -> dict:
+    try:
+        return _read_jsonc_config_from_text(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _deep_merge_config(base: dict, override: dict) -> dict:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge_config(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _rewrite_relative_file_refs(value, config_dir: Path):
+    if isinstance(value, dict):
+        return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_relative_file_refs(item, config_dir) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        file_ref = match.group(1)
+        if file_ref.startswith("~/") or os.path.isabs(file_ref):
+            return match.group(0)
+        return "{file:" + str((config_dir / file_ref).resolve()) + "}"
+
+    return re.sub(r"\{file:([^}]+)\}", replace, value)
+
+
+def _load_opencode_config_file(path: Path) -> dict:
+    cfg = _read_jsonc_config(path)
+    if not cfg:
+        return {}
+    return _rewrite_relative_file_refs(cfg, path.parent)
+
+
+def _opencode_global_config_dir() -> Path:
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser() / "opencode"
+    return Path.home() / ".config" / "opencode"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    found: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        for filename in ("opencode.jsonc", "opencode.json"):
+            candidate = current / filename
+            if candidate.is_file():
+                found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(found))
+
+
+def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    dirs: list[Path] = []
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        current = project_dir.resolve()
+        while True:
+            local = current / ".opencode"
+            if local.is_dir() and local not in dirs:
+                dirs.append(local)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    home_local = Path.home() / ".opencode"
+    if home_local.is_dir() and home_local not in dirs:
+        dirs.append(home_local)
+
+    env_dir = os.environ.get("OPENCODE_CONFIG_DIR", "").strip()
+    if env_dir:
+        config_dir = Path(env_dir).expanduser()
+        if config_dir not in dirs:
+            dirs.append(config_dir)
+
+    files: list[Path] = []
+    for directory in dirs:
+        for filename in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / filename
+            if candidate.is_file():
+                files.append(candidate)
+    return files
+
+
+def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    project = Path(project_dir or os.getcwd()).expanduser().resolve()
+    files: list[Path] = []
+
+    global_dir = _opencode_global_config_dir()
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        candidate = global_dir / filename
+        if candidate.is_file():
+            files.append(candidate)
+
+    env_config = os.environ.get("OPENCODE_CONFIG", "").strip()
+    if env_config:
+        candidate = Path(env_config).expanduser()
+        if candidate.is_file():
+            files.append(candidate)
+
+    if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
+        files.extend(_opencode_project_config_files(project))
+
+    files.extend(_opencode_directory_config_files(project))
+    return files
+
+
+def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> dict:
+    """Load local OpenCode config sources in OpenCode-compatible precedence order."""
+    merged: dict = {}
+    for path in _iter_opencode_config_files(project_dir):
+        merged = _deep_merge_config(merged, _load_opencode_config_file(path))
+
+    content = os.environ.get("OPENCODE_CONFIG_CONTENT")
+    if content:
+        content_dir = Path(project_dir or os.getcwd()).expanduser().resolve()
+        cfg = _rewrite_relative_file_refs(_read_jsonc_config_from_text(content), content_dir)
+        merged = _deep_merge_config(merged, cfg)
+    return merged
+
+
+def _sanitize_opencode_config(cfg: dict) -> dict:
+    sanitized = dict(cfg)
+    for key in ("plugin", "plugins", "plugin_origins"):
+        sanitized.pop(key, None)
+    return sanitized
 
 
 def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> str:
@@ -54,14 +282,19 @@ def extract_task_json_output(output: str) -> str:
     return output
 
 
-def ensure_opencode_isolated_config() -> Path:
+def ensure_opencode_isolated_config(project_dir: str | os.PathLike[str] | None = None) -> Path:
     home = Path.home()
-    isolated = home / ".codex" / "tmp" / "opencode-memsearch-maintenance" / "opencode"
+    root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated = root / "opencode"
     isolated.mkdir(parents=True, exist_ok=True)
-    src = home / ".config" / "opencode" / "opencode.json"
-    if src.is_file():
-        shutil.copy2(src, isolated / "opencode.json")
-    return isolated
+    for filename in ("config.json", "opencode.json", "opencode.jsonc"):
+        stale = isolated / filename
+        if stale.is_symlink() or stale.is_file():
+            stale.unlink(missing_ok=True)
+    cfg = _sanitize_opencode_config(load_opencode_config(project_dir))
+    if cfg:
+        (isolated / "opencode.json").write_text(json.dumps(cfg, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return root
 
 
 def ensure_memsearch_importable() -> None:
@@ -193,11 +426,15 @@ def run_native_provider(ctx, prompt: str) -> str:
         return extract_task_json_output(run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120))
 
     if ctx.platform == "opencode":
-        isolated = ensure_opencode_isolated_config()
+        isolated = ensure_opencode_isolated_config(ctx.project_dir)
         cmd = ["opencode", "run"]
         if model:
             cmd += ["-m", model]
         cmd.append(prompt)
+        env["OPENCODE_CONFIG"] = ""
+        env["OPENCODE_CONFIG_DIR"] = ""
+        env["OPENCODE_CONFIG_CONTENT"] = ""
+        env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
         env["XDG_CONFIG_HOME"] = str(isolated)
         env["XDG_DATA_HOME"] = str(isolated / "data")
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -142,3 +142,63 @@ def test_openclaw_native_runner_extracts_json_from_noisy_output(tmp_path: Path, 
     result = runner.run_native_provider(ctx, "maintenance prompt")
 
     assert json.loads(result) == {"action": "none", "reason": "ok"}
+
+
+def test_opencode_native_runner_uses_sanitized_isolated_config(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+    home = tmp_path / "home"
+    project = tmp_path / "repo"
+    config_dir = tmp_path / "opencode-config-dir"
+    home.mkdir()
+    project.mkdir()
+    config_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", '{"username": "from-content", "plugin": ["content-plugin"]}')
+    monkeypatch.delenv("OPENCODE_CONFIG", raising=False)
+    monkeypatch.delenv("OPENCODE_DISABLE_PROJECT_CONFIG", raising=False)
+
+    (project / "opencode.jsonc").write_text(
+        '{"model": "project/model", "plugin": ["project-plugin"]}',
+        encoding="utf-8",
+    )
+    (config_dir / "opencode.jsonc").write_text(
+        '{"model": "dir/model", "provider": {"openai": {"apiKey": "{file:token.txt}"}}, "plugin": ["dir-plugin"]}',
+        encoding="utf-8",
+    )
+
+    captured = {}
+
+    def fake_run_command(cmd, *, env, cwd, timeout):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["cwd"] = cwd
+        return '{"action":"none","reason":"ok"}'
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    ctx = SimpleNamespace(
+        platform="opencode",
+        project_dir=project,
+        task_config=SimpleNamespace(model=""),
+    )
+
+    result = runner.run_native_provider(ctx, "maintenance prompt")
+
+    isolated_root = home / ".codex" / "tmp" / "opencode-memsearch-maintenance"
+    isolated_config = json.loads((isolated_root / "opencode" / "opencode.json").read_text(encoding="utf-8"))
+
+    assert json.loads(result) == {"action": "none", "reason": "ok"}
+    assert captured["cmd"] == ["opencode", "run", "maintenance prompt"]
+    assert captured["cwd"] == project
+    assert captured["env"]["XDG_CONFIG_HOME"] == str(isolated_root)
+    assert captured["env"]["XDG_DATA_HOME"] == str(isolated_root / "data")
+    assert captured["env"]["OPENCODE_CONFIG"] == ""
+    assert captured["env"]["OPENCODE_CONFIG_DIR"] == ""
+    assert captured["env"]["OPENCODE_CONFIG_CONTENT"] == ""
+    assert captured["env"]["OPENCODE_DISABLE_PROJECT_CONFIG"] == "true"
+    assert isolated_config["model"] == "dir/model"
+    assert isolated_config["username"] == "from-content"
+    assert isolated_config["provider"]["openai"]["apiKey"] == f"{{file:{config_dir / 'token.txt'}}}"
+    assert "plugin" not in isolated_config

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -34,6 +34,114 @@ from opencode_turns import (  # noqa: E402
 )
 
 
+def test_opencode_config_resolution_uses_jsonc_and_env_dir_precedence(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    xdg_config = tmp_path / "xdg-config"
+    project = tmp_path / "repo"
+    config_dir = tmp_path / "custom-opencode"
+    home.mkdir()
+    project.mkdir()
+    (xdg_config / "opencode").mkdir(parents=True)
+    config_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    monkeypatch.delenv("OPENCODE_CONFIG", raising=False)
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.delenv("OPENCODE_DISABLE_PROJECT_CONFIG", raising=False)
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(config_dir))
+
+    (xdg_config / "opencode" / "opencode.json").write_text(
+        '{"small_model": "global-json", "username": "global"}',
+        encoding="utf-8",
+    )
+    (xdg_config / "opencode" / "opencode.jsonc").write_text(
+        '{\n  // jsonc should override json in the same directory\n  "small_model": "global-jsonc",\n}\n',
+        encoding="utf-8",
+    )
+    (project / "opencode.json").write_text(
+        '{"small_model": "project-json", "username": "project-json"}',
+        encoding="utf-8",
+    )
+    (project / "opencode.jsonc").write_text(
+        '{\n  "small_model": "project-jsonc",\n  "provider": {"openai": {"apiKey": "{file:token.txt}"}},\n}\n',
+        encoding="utf-8",
+    )
+    (config_dir / "opencode.jsonc").write_text(
+        '{"small_model": "config-dir", "plugin": ["memsearch-opencode"]}',
+        encoding="utf-8",
+    )
+
+    cfg = capture_daemon.load_opencode_config(project)
+
+    assert capture_daemon.get_small_model(project) == "config-dir"
+    assert cfg["small_model"] == "config-dir"
+    assert cfg["username"] == "project-json"
+    assert cfg["provider"]["openai"]["apiKey"] == f"{{file:{project / 'token.txt'}}}"
+
+
+def test_opencode_config_resolution_uses_opencode_config_file(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    xdg_config = tmp_path / "xdg-config"
+    project = tmp_path / "repo"
+    custom_config = tmp_path / "custom-opencode.jsonc"
+    home.mkdir()
+    project.mkdir()
+    (xdg_config / "opencode").mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config))
+    monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.delenv("OPENCODE_DISABLE_PROJECT_CONFIG", raising=False)
+
+    (xdg_config / "opencode" / "opencode.jsonc").write_text(
+        '{"small_model": "global-jsonc"}',
+        encoding="utf-8",
+    )
+    custom_config.write_text(
+        '{\n  // exact env config overrides global config\n  "small_model": "env-config",\n}\n',
+        encoding="utf-8",
+    )
+
+    assert capture_daemon.get_small_model(project) == "env-config"
+
+
+def test_opencode_isolated_config_sanitizes_plugins(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "repo"
+    config_dir = tmp_path / "custom-opencode"
+    home.mkdir()
+    project.mkdir()
+    config_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("OPENCODE_CONFIG", raising=False)
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.delenv("OPENCODE_DISABLE_PROJECT_CONFIG", raising=False)
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(config_dir))
+
+    (project / "opencode.jsonc").write_text(
+        '{"model": "project/model", "plugin": ["project-plugin"]}',
+        encoding="utf-8",
+    )
+    (config_dir / "opencode.jsonc").write_text(
+        '{"small_model": "dir/model", "plugin": ["dir-plugin"]}',
+        encoding="utf-8",
+    )
+
+    isolated_root = Path(capture_daemon.ensure_isolated_config(project))
+    isolated_config = json.loads((isolated_root / "opencode" / "opencode.json").read_text(encoding="utf-8"))
+
+    assert isolated_root == home / ".codex" / "tmp" / "opencode-memsearch-summarize"
+    assert isolated_config["model"] == "project/model"
+    assert isolated_config["small_model"] == "dir/model"
+    assert "plugin" not in isolated_config
+    assert not (isolated_root / "opencode" / "opencode.jsonc").exists()
+
+
 def _make_opencode_db(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row


### PR DESCRIPTION
## Summary
- Load OpenCode config from global, environment, project, directory, and content sources with JSONC support.
- Preserve user model and provider settings for native runner calls while writing isolated configs without plugin entries.
- Add tests for config precedence, JSONC parsing, file reference rewriting, and isolated config sanitization.

## Testing
- uv run python -m pytest tests/test_opencode_turns.py tests/test_maintenance_runner.py
- uv run ruff check plugins/opencode/scripts/capture-daemon.py plugins/_shared/scripts/maintenance-runner.py plugins/claude-code/scripts/maintenance-runner.py plugins/codex/scripts/maintenance-runner.py plugins/openclaw/scripts/maintenance-runner.py plugins/opencode/scripts/maintenance-runner.py tests/test_opencode_turns.py tests/test_maintenance_runner.py
- git diff --check
- OpenCode TUI E2E with a JSONC OPENCODE_CONFIG_DIR, memory write, fresh recall, and memory_search tool call