### PR TITLE
feat: distill reusable skills from memory (memory-to-skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@
   <img src="https://github.com/user-attachments/assets/427b7152-bc16-408c-a8b0-59a2b05fd1e0" alt="memsearch demo" width="800">
 </p>
 
+## 📰 What's New
+
+- **Skills from memory** — MemSearch now distills the workflows you repeat into reusable, installable agent skills (a third "procedural memory" layer) and keeps them up to date in the background. See [Skills from Memory](#skills-from-memory).
+- **Advanced memory maintenance** — optional background tasks keep durable `PROJECT.md` and `USER.md` notes current across sessions. See [Advanced Memory Maintenance](#advanced-memory-maintenance).
+
+---
+
 ### Why memsearch?
 
 - 🌐 **All Platforms, One Memory** — memories flow across [Claude Code](plugins/claude-code/README.md), [OpenClaw](plugins/openclaw/README.md), [OpenCode](plugins/opencode/README.md), and [Codex CLI](plugins/codex/README.md). A conversation in one agent becomes searchable context in all others — no extra setup
@@ -268,6 +275,23 @@ memsearch config set plugins.codex.user_profile.output_file .memsearch/USER.md -
 Use `provider = "native"` to reuse the current agent's own non-interactive model path, or point the task at a named `[llm.providers.<name>]` API provider. Custom prompt files can be configured with `prompts.project_review` and `prompts.user_profile`.
 
 The `memory-config` skill, installed with the plugins, can inspect the current setup, explain these options, and make safe project-scoped changes from natural-language requests.
+
+#### Skills from Memory
+
+Beyond episodic journals and the semantic `PROJECT.md` / `USER.md` notes, MemSearch can grow a third memory layer — **procedural memory**: reusable skills distilled from the workflows you repeat. When enabled, a background pass mines recent journals for recurring multi-step procedures and writes them as *candidate* skills under `.memsearch/skill-candidates/` (a git-tracked store that keeps evolving). Candidates are inert; turning one into an agent-visible skill is a deliberate, human step.
+
+```bash
+# Enable distillation (disabled by default, like the maintenance tasks above)
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+# How many times a workflow must recur before it is distilled (default 3; lower = more eager)
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project
+
+# Review candidates, then install one into an agent's skill directory
+memsearch skills list
+memsearch skills install <name> --path .claude/skills
+```
+
+The `/memory-to-skill` skill (installed with the plugins) drives the review-and-install flow: it lists candidates, asks where to install, and copies the chosen skill into `.claude/skills` (Claude Code), `.codex/skills` (Codex), `.agents/skills` (OpenCode/Cursor/…), or any path you configure. Because the store keeps evolving, re-installing simply takes a fresh snapshot. The distilled `SKILL.md` follows the [Agent Skills](https://agentskills.io) open standard, so a skill distilled once is portable across agents.
 
 ### What can you use it for?
 

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -187,6 +187,30 @@ The plugin-installed `memory-config` skill can inspect current config, memory
 files, and index health; explain these settings; and make safe project-scoped
 changes from natural-language requests.
 
+## Skills from Memory (procedural memory)
+
+A third maintenance task, `memory_to_skill`, distills recurring workflows into
+reusable agent skills. It is **disabled by default** and shares the maintenance
+tasks' provider/model routing, prompt-override mechanism
+(`prompts.memory_to_skill`), and `min_interval_hours` cadence.
+
+```bash
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
+memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project   # optional; empty = asked at install
+```
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Turn background distillation on |
+| `min_occurrences` | `3` | How many times a workflow must recur before it is distilled |
+| `min_interval_hours` | `24` | Minimum gap between background runs |
+| `provider` / `model` | `native` | Same routing as the maintenance tasks |
+| `paths` | _(empty)_ | Where installed skills are copied; empty = asked at install time |
+
+See **[Skills from Memory](skills-from-memory.md)** for the full guide: how
+distillation and the candidate store work, and how to review and install skills.
+
 ## Platform-Specific Config
 
 Each plugin may have additional configuration. See:

--- a/docs/home/skills-from-memory.md
+++ b/docs/home/skills-from-memory.md
@@ -1,0 +1,95 @@
+# Skills from Memory
+
+MemSearch can grow a third memory layer on top of your journals: **procedural
+memory** — reusable *skills* distilled from the workflows you repeat.
+
+| Layer | Where | What it holds |
+| --- | --- | --- |
+| Episodic | `.memsearch/memory/*.md` | What happened (raw conversation journals) |
+| Semantic | `.memsearch/PROJECT.md`, `.memsearch/USER.md` | What is true (durable project state, user profile) |
+| **Procedural** | `.memsearch/skill-candidates/` | **How you do recurring tasks** (candidate skills) |
+
+A skill is an [Agent Skills](https://agentskills.io)-standard `SKILL.md`: a short,
+reusable procedure (how to run the app, deploy, debug a class of error) that an
+agent can load and follow. Because it follows the open standard, a skill distilled
+once is portable across Claude Code, Codex, OpenCode, and other agents.
+
+## How it works
+
+There are two stages. Only the second one involves you.
+
+**1. Distill (automatic, background).** Like the
+[advanced maintenance](configuration.md#advanced-plugin-maintenance) tasks, a
+`memory_to_skill` task runs in the background on the session-end /
+`min_interval_hours` cadence. It mines recent journals for recurring multi-step
+procedures and writes them as **candidate** skills under
+`.memsearch/skill-candidates/`.
+
+That store is a self-contained **git repository**, so every automatic edit is a
+commit you can `git log`, `git diff`, or `git revert`. Candidates keep evolving
+there over time — including ones you have already installed; the store is the
+perpetually-updated source. Candidates are inert: they are **never** written into
+an agent's skill directory on their own.
+
+It is deliberately conservative — most runs distil nothing. A workflow becomes a
+candidate only when it is a genuine multi-step procedure, recurs at least
+`min_occurrences` times, generalizes into a reusable capability, and was not
+immediately corrected or abandoned.
+
+**2. Install (manual, human-driven).** You review a candidate — optionally inspect
+its history and edit it — then copy its current version into an agent's skill
+directory. Installing is the only thing that makes a skill agent-visible.
+Re-installing later simply takes a fresh snapshot of the evolved source.
+
+## Enable and tune
+
+Disabled by default, like the maintenance tasks. Configure per platform:
+
+```bash
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
+memsearch config set plugins.codex.memory_to_skill.provider native --project
+# Optional: pre-set install targets (otherwise the skill asks you)
+memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project
+# Optional: custom distillation prompt
+memsearch config set prompts.memory_to_skill .memsearch/prompts/memory-to-skill.txt --project
+```
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Turn background distillation on |
+| `min_occurrences` | `3` | How many times a workflow must recur before it is distilled |
+| `min_interval_hours` | `24` | Minimum gap between background runs |
+| `provider` / `model` | `native` | Same routing as the maintenance tasks |
+| `paths` | _(empty)_ | Where installed skills are copied; empty = you are asked at install time |
+
+See [Configuration](configuration.md) for how provider/model routing and prompt
+overrides work — they are shared with the maintenance tasks.
+
+## Review and install
+
+```bash
+memsearch skills list                                   # review candidates (-j for detail)
+memsearch skills install <name> --path .claude/skills   # snapshot into a skills directory
+```
+
+Different agents read skills from different directories:
+
+| Agent | Project dir | Global dir |
+| --- | --- | --- |
+| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
+| Codex | `.codex/skills/` | `~/.codex/skills/` |
+| OpenClaw | `.openclaw/skills/` | `~/.openclaw/skills/` |
+| OpenCode / Cursor / … | `.agents/skills/` | `~/.agents/skills/` |
+
+`.agents/skills/` is the shared standard read by OpenCode, Cursor, and others —
+but **not** by Claude Code. `--path` is repeatable, so you can install one skill
+to several agents at once.
+
+## The `/memory-to-skill` skill
+
+The plugins install a `/memory-to-skill` skill that drives this whole flow from
+natural language: it checks whether distillation is enabled (and offers to enable
+it), lists candidates, asks where to install, and copies the chosen skill out. It
+never enables the feature, changes install paths, or installs a candidate without
+your go-ahead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
     - For Agent Users: home/for-users.md
     - For Agent Developers: home/for-developers.md
     - Configuration: home/configuration.md
+    - Skills from Memory: home/skills-from-memory.md
     - Architecture: architecture.md
     - Design Philosophy: design-philosophy.md
     - Comparison with Alternatives: home/comparison.md

--- a/plugins/_shared/prompts/memory_to_skill.txt
+++ b/plugins/_shared/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -363,7 +363,7 @@ def ensure_memsearch_importable() -> None:
 def apply_plugin_prompt_defaults(cfg) -> None:
     plugin_dir = Path(__file__).resolve().parent.parent
     prompts_dir = plugin_dir / "prompts"
-    for task in ("project_review", "user_profile"):
+    for task in ("project_review", "user_profile", "memory_to_skill"):
         if getattr(cfg.prompts, task, ""):
             continue
         prompt_file = prompts_dir / f"{task}.txt"
@@ -388,7 +388,9 @@ def run_native_provider(ctx, prompt: str) -> str:
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":
-        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+        with tempfile.NamedTemporaryFile(
+            prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False
+        ) as output_file:
             output_path = Path(output_file.name)
         cmd = [
             "codex",
@@ -476,6 +478,20 @@ def main() -> int:
             force=args.force,
             llm_runner=llm_runner,
         )
+
+        # Distill recurring workflows into candidate skills (procedural memory).
+        # Same session-end trigger, due-state, and llm_runner as the tasks above;
+        # this only ever touches the candidate store, never an agent's skills dir.
+        from memsearch.skills import distill as distill_skills
+
+        skill_result = distill_skills(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
     except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
         sys.stderr.write(f"Maintenance error: {exc}\n")
         return 1
@@ -484,12 +500,15 @@ def main() -> int:
             os.chdir(old_cwd)
 
     payload = [result.__dict__ for result in results]
+    payload.append({"task": "memory_to_skill", **skill_result.__dict__})
     if args.json_output:
         sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     else:
         for result in results:
             detail = f": {result.reason}" if result.reason else ""
             sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+        skill_detail = f": {skill_result.reason}" if skill_result.reason else ""
+        sys.stdout.write(f"memory_to_skill: {skill_result.action}{skill_detail}\n")
     return 0
 
 

--- a/plugins/claude-code/prompts/memory_to_skill.txt
+++ b/plugins/claude-code/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -363,7 +363,7 @@ def ensure_memsearch_importable() -> None:
 def apply_plugin_prompt_defaults(cfg) -> None:
     plugin_dir = Path(__file__).resolve().parent.parent
     prompts_dir = plugin_dir / "prompts"
-    for task in ("project_review", "user_profile"):
+    for task in ("project_review", "user_profile", "memory_to_skill"):
         if getattr(cfg.prompts, task, ""):
             continue
         prompt_file = prompts_dir / f"{task}.txt"
@@ -388,7 +388,9 @@ def run_native_provider(ctx, prompt: str) -> str:
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":
-        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+        with tempfile.NamedTemporaryFile(
+            prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False
+        ) as output_file:
             output_path = Path(output_file.name)
         cmd = [
             "codex",
@@ -476,6 +478,20 @@ def main() -> int:
             force=args.force,
             llm_runner=llm_runner,
         )
+
+        # Distill recurring workflows into candidate skills (procedural memory).
+        # Same session-end trigger, due-state, and llm_runner as the tasks above;
+        # this only ever touches the candidate store, never an agent's skills dir.
+        from memsearch.skills import distill as distill_skills
+
+        skill_result = distill_skills(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
     except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
         sys.stderr.write(f"Maintenance error: {exc}\n")
         return 1
@@ -484,12 +500,15 @@ def main() -> int:
             os.chdir(old_cwd)
 
     payload = [result.__dict__ for result in results]
+    payload.append({"task": "memory_to_skill", **skill_result.__dict__})
     if args.json_output:
         sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     else:
         for result in results:
             detail = f": {result.reason}" if result.reason else ""
             sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+        skill_detail = f": {skill_result.reason}" if skill_result.reason else ""
+        sys.stdout.write(f"memory_to_skill: {skill_result.action}{skill_detail}\n")
     return 0
 
 

--- a/plugins/claude-code/skills/memory-config/SKILL.md
+++ b/plugins/claude-code/skills/memory-config/SKILL.md
@@ -21,6 +21,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "skill/distill/extract a skill/memory-to-skill": procedural-memory distillation — enable or tune it here, or use the dedicated `/memory-to-skill` skill to review and install candidates.
 - "Prompt": explain or configure prompt overrides.
 
 Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
@@ -145,6 +146,11 @@ model = ""
 min_interval_hours = 24
 input_dir = ".memsearch/memory"
 output_file = ".memsearch/USER.md"
+
+[plugins.claude-code.memory_to_skill]
+enabled = false
+min_occurrences = 3   # how many times a workflow must recur before it is distilled
+paths = []            # where installed skills are copied; empty = ask the user
 ```
 
 Provider rules:
@@ -192,6 +198,7 @@ Prompt overrides:
 summarize = ""
 project_review = ""
 user_profile = ""
+memory_to_skill = ""
 ```
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: memory-to-skill
+description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Claude Code own skills system."
+context: fork
+allowed-tools: Bash
+---
+
+You manage MemSearch's **procedural memory**: candidate skills distilled from the
+project's memory journals. This is the third memory layer, alongside the daily
+journals (episodic) and PROJECT.md / USER.md (semantic).
+
+State once in your summary that this is MemSearch skill distillation, not Claude Code's
+built-in skills system. Do not repeat that on every line.
+
+Two stages, and you only ever drive the second one:
+- **Distill (automatic, background):** MemSearch watches recent journals and writes
+  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
+  evolving them there over time. Every entry — even ones already installed — stays
+  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
+- **Install (this skill, human-driven):** the user reviews a candidate and you copy
+  its current version into agent skill directories. Installing is the only path that
+  makes a skill agent-visible, and re-installing is how an installed skill gets
+  updated — the store keeps evolving; install takes a fresh snapshot.
+
+## Intent routing
+
+Inspect the user's request:
+- No specific request, "what skills / review candidates" -> **List candidates**.
+- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
+- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+
+## 1. Check the feature is enabled
+
+```bash
+memsearch config get plugins.claude-code.memory_to_skill.enabled 2>/dev/null || echo "false"
+```
+
+If this is not `true`, background distillation is **off**. Tell the user, and offer
+to turn it on (do not enable it silently). On their confirmation:
+
+```bash
+memsearch config set plugins.claude-code.memory_to_skill.enabled true --project
+```
+
+Mention they can tune how eagerly skills are extracted with
+`plugins.claude-code.memory_to_skill.min_occurrences` (default 3 — how many times a
+workflow must recur before it becomes a candidate). Lower = more eager.
+
+## 2. List candidates
+
+```bash
+memsearch skills list
+```
+
+Show candidate names, status (candidate / installed), how often each recurred, and
+the one-line description. Use `memsearch skills list -j` for structured detail
+(sources, installed paths).
+
+## 3. Distill on demand (optional)
+
+If the user wants to extract right now rather than wait for the background pass:
+
+```bash
+memsearch skills distill --plugin claude-code --force
+```
+
+Then list again. Most runs add nothing — that is expected; the bar for a reusable
+skill is intentionally high.
+
+## 4. Install a candidate
+
+Installing copies a candidate's current `SKILL.md` into one or more skill
+directories. Before installing you may review the candidate, inspect its history
+(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
+guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
+are committed and then snapshotted out.
+
+First resolve **where** to install:
+
+```bash
+memsearch config get plugins.claude-code.memory_to_skill.paths 2>/dev/null || echo "[]"
+```
+
+If this is empty (`[]`), **do not guess** — ask the user where to install, then
+persist their choice. Offer these options and explain the trade-off:
+- `.claude/skills` — **project-local (recommended)**: scoped to this repo; a skill
+  distilled from this project's memory is usually most relevant here.
+- `~/.claude/skills` — global: available across all your projects.
+- a custom path, or several paths (one skill can be installed to multiple dirs).
+
+Note for cross-agent users, each agent reads skills from its own directory:
+Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
+and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
+**not** by Claude Code. To cover several agents, install to multiple paths.
+
+Persist the chosen paths (example for project-local), then install:
+
+```bash
+memsearch config set plugins.claude-code.memory_to_skill.paths '[".claude/skills"]' --project
+memsearch skills install <name> --path .claude/skills
+```
+
+`--path` is repeatable for multiple destinations. After installing, tell the user the
+installed location(s) and that the skill is now agent-visible.
+
+## Guardrails
+
+- Never enable the feature, change install paths, or install a candidate without the
+  user's go-ahead.
+- Edit candidates only under the user's guidance, and only via the git-tracked store
+  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.

--- a/plugins/codex/prompts/memory_to_skill.txt
+++ b/plugins/codex/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -363,7 +363,7 @@ def ensure_memsearch_importable() -> None:
 def apply_plugin_prompt_defaults(cfg) -> None:
     plugin_dir = Path(__file__).resolve().parent.parent
     prompts_dir = plugin_dir / "prompts"
-    for task in ("project_review", "user_profile"):
+    for task in ("project_review", "user_profile", "memory_to_skill"):
         if getattr(cfg.prompts, task, ""):
             continue
         prompt_file = prompts_dir / f"{task}.txt"
@@ -388,7 +388,9 @@ def run_native_provider(ctx, prompt: str) -> str:
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":
-        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+        with tempfile.NamedTemporaryFile(
+            prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False
+        ) as output_file:
             output_path = Path(output_file.name)
         cmd = [
             "codex",
@@ -476,6 +478,20 @@ def main() -> int:
             force=args.force,
             llm_runner=llm_runner,
         )
+
+        # Distill recurring workflows into candidate skills (procedural memory).
+        # Same session-end trigger, due-state, and llm_runner as the tasks above;
+        # this only ever touches the candidate store, never an agent's skills dir.
+        from memsearch.skills import distill as distill_skills
+
+        skill_result = distill_skills(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
     except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
         sys.stderr.write(f"Maintenance error: {exc}\n")
         return 1
@@ -484,12 +500,15 @@ def main() -> int:
             os.chdir(old_cwd)
 
     payload = [result.__dict__ for result in results]
+    payload.append({"task": "memory_to_skill", **skill_result.__dict__})
     if args.json_output:
         sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     else:
         for result in results:
             detail = f": {result.reason}" if result.reason else ""
             sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+        skill_detail = f": {skill_result.reason}" if skill_result.reason else ""
+        sys.stdout.write(f"memory_to_skill: {skill_result.action}{skill_detail}\n")
     return 0
 
 

--- a/plugins/codex/skills/memory-config/SKILL.md
+++ b/plugins/codex/skills/memory-config/SKILL.md
@@ -19,6 +19,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "skill/distill/extract a skill/memory-to-skill": procedural-memory distillation — enable or tune it here, or use the dedicated `/memory-to-skill` skill to review and install candidates.
 - "Prompt": explain or configure prompt overrides.
 
 Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
@@ -143,6 +144,11 @@ model = ""
 min_interval_hours = 24
 input_dir = ".memsearch/memory"
 output_file = ".memsearch/USER.md"
+
+[plugins.codex.memory_to_skill]
+enabled = false
+min_occurrences = 3   # how many times a workflow must recur before it is distilled
+paths = []            # where installed skills are copied; empty = ask the user
 ```
 
 Provider rules:
@@ -190,6 +196,7 @@ Prompt overrides:
 summarize = ""
 project_review = ""
 user_profile = ""
+memory_to_skill = ""
 ```
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: memory-to-skill
+description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Codex own skills system."
+---
+
+You manage MemSearch's **procedural memory**: candidate skills distilled from the
+project's memory journals. This is the third memory layer, alongside the daily
+journals (episodic) and PROJECT.md / USER.md (semantic).
+
+State once in your summary that this is MemSearch skill distillation, not Codex's
+built-in skills system. Do not repeat that on every line.
+
+Two stages, and you only ever drive the second one:
+- **Distill (automatic, background):** MemSearch watches recent journals and writes
+  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
+  evolving them there over time. Every entry — even ones already installed — stays
+  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
+- **Install (this skill, human-driven):** the user reviews a candidate and you copy
+  its current version into agent skill directories. Installing is the only path that
+  makes a skill agent-visible, and re-installing is how an installed skill gets
+  updated — the store keeps evolving; install takes a fresh snapshot.
+
+## Intent routing
+
+Inspect the user's request:
+- No specific request, "what skills / review candidates" -> **List candidates**.
+- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
+- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+
+## 1. Check the feature is enabled
+
+```bash
+memsearch config get plugins.codex.memory_to_skill.enabled 2>/dev/null || echo "false"
+```
+
+If this is not `true`, background distillation is **off**. Tell the user, and offer
+to turn it on (do not enable it silently). On their confirmation:
+
+```bash
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+```
+
+Mention they can tune how eagerly skills are extracted with
+`plugins.codex.memory_to_skill.min_occurrences` (default 3 — how many times a
+workflow must recur before it becomes a candidate). Lower = more eager.
+
+## 2. List candidates
+
+```bash
+memsearch skills list
+```
+
+Show candidate names, status (candidate / installed), how often each recurred, and
+the one-line description. Use `memsearch skills list -j` for structured detail
+(sources, installed paths).
+
+## 3. Distill on demand (optional)
+
+If the user wants to extract right now rather than wait for the background pass:
+
+```bash
+memsearch skills distill --plugin codex --force
+```
+
+Then list again. Most runs add nothing — that is expected; the bar for a reusable
+skill is intentionally high.
+
+## 4. Install a candidate
+
+Installing copies a candidate's current `SKILL.md` into one or more skill
+directories. Before installing you may review the candidate, inspect its history
+(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
+guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
+are committed and then snapshotted out.
+
+First resolve **where** to install:
+
+```bash
+memsearch config get plugins.codex.memory_to_skill.paths 2>/dev/null || echo "[]"
+```
+
+If this is empty (`[]`), **do not guess** — ask the user where to install, then
+persist their choice. Offer these options and explain the trade-off:
+- `.codex/skills` — **project-local (recommended)**: scoped to this repo; a skill
+  distilled from this project's memory is usually most relevant here.
+- `~/.codex/skills` — global: available across all your projects.
+- a custom path, or several paths (one skill can be installed to multiple dirs).
+
+Note for cross-agent users, each agent reads skills from its own directory:
+Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
+and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
+**not** by Claude Code. To cover several agents, install to multiple paths.
+
+Persist the chosen paths (example for project-local), then install:
+
+```bash
+memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project
+memsearch skills install <name> --path .codex/skills
+```
+
+`--path` is repeatable for multiple destinations. After installing, tell the user the
+installed location(s) and that the skill is now agent-visible.
+
+## Guardrails
+
+- Never enable the feature, change install paths, or install a candidate without the
+  user's go-ahead.
+- Edit candidates only under the user's guidance, and only via the git-tracked store
+  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.

--- a/plugins/openclaw/prompts/memory_to_skill.txt
+++ b/plugins/openclaw/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -363,7 +363,7 @@ def ensure_memsearch_importable() -> None:
 def apply_plugin_prompt_defaults(cfg) -> None:
     plugin_dir = Path(__file__).resolve().parent.parent
     prompts_dir = plugin_dir / "prompts"
-    for task in ("project_review", "user_profile"):
+    for task in ("project_review", "user_profile", "memory_to_skill"):
         if getattr(cfg.prompts, task, ""):
             continue
         prompt_file = prompts_dir / f"{task}.txt"
@@ -388,7 +388,9 @@ def run_native_provider(ctx, prompt: str) -> str:
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":
-        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+        with tempfile.NamedTemporaryFile(
+            prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False
+        ) as output_file:
             output_path = Path(output_file.name)
         cmd = [
             "codex",
@@ -476,6 +478,20 @@ def main() -> int:
             force=args.force,
             llm_runner=llm_runner,
         )
+
+        # Distill recurring workflows into candidate skills (procedural memory).
+        # Same session-end trigger, due-state, and llm_runner as the tasks above;
+        # this only ever touches the candidate store, never an agent's skills dir.
+        from memsearch.skills import distill as distill_skills
+
+        skill_result = distill_skills(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
     except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
         sys.stderr.write(f"Maintenance error: {exc}\n")
         return 1
@@ -484,12 +500,15 @@ def main() -> int:
             os.chdir(old_cwd)
 
     payload = [result.__dict__ for result in results]
+    payload.append({"task": "memory_to_skill", **skill_result.__dict__})
     if args.json_output:
         sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     else:
         for result in results:
             detail = f": {result.reason}" if result.reason else ""
             sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+        skill_detail = f": {skill_result.reason}" if skill_result.reason else ""
+        sys.stdout.write(f"memory_to_skill: {skill_result.action}{skill_detail}\n")
     return 0
 
 

--- a/plugins/openclaw/skills/memory-config/SKILL.md
+++ b/plugins/openclaw/skills/memory-config/SKILL.md
@@ -19,6 +19,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "skill/distill/extract a skill/memory-to-skill": procedural-memory distillation — enable or tune it here, or use the dedicated `/memory-to-skill` skill to review and install candidates.
 - "Prompt": explain or configure prompt overrides.
 
 Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
@@ -143,6 +144,11 @@ model = ""
 min_interval_hours = 24
 input_dir = ".memsearch/memory"
 output_file = ".memsearch/USER.md"
+
+[plugins.openclaw.memory_to_skill]
+enabled = false
+min_occurrences = 3   # how many times a workflow must recur before it is distilled
+paths = []            # where installed skills are copied; empty = ask the user
 ```
 
 Provider rules:
@@ -190,6 +196,7 @@ Prompt overrides:
 summarize = ""
 project_review = ""
 user_profile = ""
+memory_to_skill = ""
 ```
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: memory-to-skill
+description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenClaw own skills system."
+---
+
+You manage MemSearch's **procedural memory**: candidate skills distilled from the
+project's memory journals. This is the third memory layer, alongside the daily
+journals (episodic) and PROJECT.md / USER.md (semantic).
+
+State once in your summary that this is MemSearch skill distillation, not OpenClaw's
+built-in skills system. Do not repeat that on every line.
+
+Two stages, and you only ever drive the second one:
+- **Distill (automatic, background):** MemSearch watches recent journals and writes
+  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
+  evolving them there over time. Every entry — even ones already installed — stays
+  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
+- **Install (this skill, human-driven):** the user reviews a candidate and you copy
+  its current version into agent skill directories. Installing is the only path that
+  makes a skill agent-visible, and re-installing is how an installed skill gets
+  updated — the store keeps evolving; install takes a fresh snapshot.
+
+## Intent routing
+
+Inspect the user's request:
+- No specific request, "what skills / review candidates" -> **List candidates**.
+- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
+- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+
+## 1. Check the feature is enabled
+
+```bash
+memsearch config get plugins.openclaw.memory_to_skill.enabled 2>/dev/null || echo "false"
+```
+
+If this is not `true`, background distillation is **off**. Tell the user, and offer
+to turn it on (do not enable it silently). On their confirmation:
+
+```bash
+memsearch config set plugins.openclaw.memory_to_skill.enabled true --project
+```
+
+Mention they can tune how eagerly skills are extracted with
+`plugins.openclaw.memory_to_skill.min_occurrences` (default 3 — how many times a
+workflow must recur before it becomes a candidate). Lower = more eager.
+
+## 2. List candidates
+
+```bash
+memsearch skills list
+```
+
+Show candidate names, status (candidate / installed), how often each recurred, and
+the one-line description. Use `memsearch skills list -j` for structured detail
+(sources, installed paths).
+
+## 3. Distill on demand (optional)
+
+If the user wants to extract right now rather than wait for the background pass:
+
+```bash
+memsearch skills distill --plugin openclaw --force
+```
+
+Then list again. Most runs add nothing — that is expected; the bar for a reusable
+skill is intentionally high.
+
+## 4. Install a candidate
+
+Installing copies a candidate's current `SKILL.md` into one or more skill
+directories. Before installing you may review the candidate, inspect its history
+(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
+guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
+are committed and then snapshotted out.
+
+First resolve **where** to install:
+
+```bash
+memsearch config get plugins.openclaw.memory_to_skill.paths 2>/dev/null || echo "[]"
+```
+
+If this is empty (`[]`), **do not guess** — ask the user where to install, then
+persist their choice. Offer these options and explain the trade-off:
+- `.openclaw/skills` — **project-local (recommended)**: scoped to this repo; a skill
+  distilled from this project's memory is usually most relevant here.
+- `~/.openclaw/skills` — global: available across all your projects.
+- a custom path, or several paths (one skill can be installed to multiple dirs).
+
+Note for cross-agent users, each agent reads skills from its own directory:
+Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
+and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
+**not** by Claude Code. To cover several agents, install to multiple paths.
+
+Persist the chosen paths (example for project-local), then install:
+
+```bash
+memsearch config set plugins.openclaw.memory_to_skill.paths '[".openclaw/skills"]' --project
+memsearch skills install <name> --path .openclaw/skills
+```
+
+`--path` is repeatable for multiple destinations. After installing, tell the user the
+installed location(s) and that the skill is now agent-visible.
+
+## Guardrails
+
+- Never enable the feature, change install paths, or install a candidate without the
+  user's go-ahead.
+- Edit candidates only under the user's guidance, and only via the git-tracked store
+  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.

--- a/plugins/opencode/prompts/memory_to_skill.txt
+++ b/plugins/opencode/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -363,7 +363,7 @@ def ensure_memsearch_importable() -> None:
 def apply_plugin_prompt_defaults(cfg) -> None:
     plugin_dir = Path(__file__).resolve().parent.parent
     prompts_dir = plugin_dir / "prompts"
-    for task in ("project_review", "user_profile"):
+    for task in ("project_review", "user_profile", "memory_to_skill"):
         if getattr(cfg.prompts, task, ""):
             continue
         prompt_file = prompts_dir / f"{task}.txt"
@@ -388,7 +388,9 @@ def run_native_provider(ctx, prompt: str) -> str:
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":
-        with tempfile.NamedTemporaryFile(prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False) as output_file:
+        with tempfile.NamedTemporaryFile(
+            prefix="memsearch-codex-maintenance-", suffix=".txt", delete=False
+        ) as output_file:
             output_path = Path(output_file.name)
         cmd = [
             "codex",
@@ -476,6 +478,20 @@ def main() -> int:
             force=args.force,
             llm_runner=llm_runner,
         )
+
+        # Distill recurring workflows into candidate skills (procedural memory).
+        # Same session-end trigger, due-state, and llm_runner as the tasks above;
+        # this only ever touches the candidate store, never an agent's skills dir.
+        from memsearch.skills import distill as distill_skills
+
+        skill_result = distill_skills(
+            platform=args.platform,
+            project_dir=project_dir,
+            memsearch_dir=args.memsearch_dir,
+            cfg=cfg,
+            force=args.force,
+            llm_runner=llm_runner,
+        )
     except (KeyError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
         sys.stderr.write(f"Maintenance error: {exc}\n")
         return 1
@@ -484,12 +500,15 @@ def main() -> int:
             os.chdir(old_cwd)
 
     payload = [result.__dict__ for result in results]
+    payload.append({"task": "memory_to_skill", **skill_result.__dict__})
     if args.json_output:
         sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     else:
         for result in results:
             detail = f": {result.reason}" if result.reason else ""
             sys.stdout.write(f"{result.task}: {result.action}{detail}\n")
+        skill_detail = f": {skill_result.reason}" if skill_result.reason else ""
+        sys.stdout.write(f"memory_to_skill: {skill_result.action}{skill_detail}\n")
     return 0
 
 

--- a/plugins/opencode/skills/memory-config/SKILL.md
+++ b/plugins/opencode/skills/memory-config/SKILL.md
@@ -19,6 +19,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
+- "skill/distill/extract a skill/memory-to-skill": procedural-memory distillation — enable or tune it here, or use the dedicated `/memory-to-skill` skill to review and install candidates.
 - "Prompt": explain or configure prompt overrides.
 
 Ask the user before enabling external or paid providers, changing output paths, re-indexing, deleting state, or broadening what gets indexed.
@@ -145,6 +146,11 @@ model = ""
 min_interval_hours = 24
 input_dir = ".memsearch/memory"
 output_file = ".memsearch/USER.md"
+
+[plugins.opencode.memory_to_skill]
+enabled = false
+min_occurrences = 3   # how many times a workflow must recur before it is distilled
+paths = []            # where installed skills are copied; empty = ask the user
 ```
 
 Provider rules:
@@ -192,6 +198,7 @@ Prompt overrides:
 summarize = ""
 project_review = ""
 user_profile = ""
+memory_to_skill = ""
 ```
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: memory-to-skill
+description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenCode own skills system."
+---
+
+You manage MemSearch's **procedural memory**: candidate skills distilled from the
+project's memory journals. This is the third memory layer, alongside the daily
+journals (episodic) and PROJECT.md / USER.md (semantic).
+
+State once in your summary that this is MemSearch skill distillation, not OpenCode's
+built-in skills system. Do not repeat that on every line.
+
+Two stages, and you only ever drive the second one:
+- **Distill (automatic, background):** MemSearch watches recent journals and writes
+  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
+  evolving them there over time. Every entry — even ones already installed — stays
+  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
+- **Install (this skill, human-driven):** the user reviews a candidate and you copy
+  its current version into agent skill directories. Installing is the only path that
+  makes a skill agent-visible, and re-installing is how an installed skill gets
+  updated — the store keeps evolving; install takes a fresh snapshot.
+
+## Intent routing
+
+Inspect the user's request:
+- No specific request, "what skills / review candidates" -> **List candidates**.
+- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
+- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+
+## 1. Check the feature is enabled
+
+```bash
+memsearch config get plugins.opencode.memory_to_skill.enabled 2>/dev/null || echo "false"
+```
+
+If this is not `true`, background distillation is **off**. Tell the user, and offer
+to turn it on (do not enable it silently). On their confirmation:
+
+```bash
+memsearch config set plugins.opencode.memory_to_skill.enabled true --project
+```
+
+Mention they can tune how eagerly skills are extracted with
+`plugins.opencode.memory_to_skill.min_occurrences` (default 3 — how many times a
+workflow must recur before it becomes a candidate). Lower = more eager.
+
+## 2. List candidates
+
+```bash
+memsearch skills list
+```
+
+Show candidate names, status (candidate / installed), how often each recurred, and
+the one-line description. Use `memsearch skills list -j` for structured detail
+(sources, installed paths).
+
+## 3. Distill on demand (optional)
+
+If the user wants to extract right now rather than wait for the background pass:
+
+```bash
+memsearch skills distill --plugin opencode --force
+```
+
+Then list again. Most runs add nothing — that is expected; the bar for a reusable
+skill is intentionally high.
+
+## 4. Install a candidate
+
+Installing copies a candidate's current `SKILL.md` into one or more skill
+directories. Before installing you may review the candidate, inspect its history
+(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
+guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
+are committed and then snapshotted out.
+
+First resolve **where** to install:
+
+```bash
+memsearch config get plugins.opencode.memory_to_skill.paths 2>/dev/null || echo "[]"
+```
+
+If this is empty (`[]`), **do not guess** — ask the user where to install, then
+persist their choice. Offer these options and explain the trade-off:
+- `.agents/skills` — **project-local (recommended)**: scoped to this repo; a skill
+  distilled from this project's memory is usually most relevant here.
+- `~/.agents/skills` — global: available across all your projects.
+- a custom path, or several paths (one skill can be installed to multiple dirs).
+
+Note for cross-agent users, each agent reads skills from its own directory:
+Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
+and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
+**not** by Claude Code. To cover several agents, install to multiple paths.
+
+Persist the chosen paths (example for project-local), then install:
+
+```bash
+memsearch config set plugins.opencode.memory_to_skill.paths '[".agents/skills"]' --project
+memsearch skills install <name> --path .agents/skills
+```
+
+`--path` is repeatable for multiple destinations. After installing, tell the user the
+installed location(s) and that the skill is now agent-visible.
+
+## Guardrails
+
+- Never enable the feature, change install paths, or install a candidate without the
+  user's go-ahead.
+- Edit candidates only under the user's guidance, and only via the git-tracked store
+  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1038,3 +1038,73 @@ def config_list(mode: str) -> None:
         click.echo(tomli_w.dumps(data))
     else:
         click.echo("(empty)")
+
+
+@cli.group("skills")
+def skills_group() -> None:
+    """Distill, list, and install candidate skills from memory (procedural memory)."""
+
+
+@skills_group.command("distill")
+@click.option("--plugin", required=True, help="Plugin platform name (claude-code, codex, opencode, openclaw).")
+@click.option("--force", is_flag=True, help="Run even if input is unchanged or not yet due.")
+def skills_distill(plugin: str, force: bool) -> None:
+    """Distill candidate skills from recent memory journals."""
+    from . import skills as skills_mod
+
+    cfg = _safe_resolve_config()
+    result = skills_mod.distill(platform=plugin, cfg=cfg, force=force)
+    if result.action == "disabled":
+        click.echo(
+            f"memory_to_skill is disabled for {plugin!r}. "
+            f"Enable with: memsearch config set plugins.{plugin}.memory_to_skill.enabled true --project"
+        )
+        return
+    if result.skipped:
+        click.echo(f"Skipped: {result.reason or result.action}")
+        return
+    if result.created:
+        click.echo(f"Distilled {len(result.created)} candidate skill(s): {', '.join(result.created)}")
+    else:
+        click.echo("No new candidate skills.")
+
+
+@skills_group.command("list")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+def skills_list(json_output: bool) -> None:
+    """List candidate and installed skills in the store."""
+    from . import skills as skills_mod
+
+    _project_root, mem_root = skills_mod.resolve_roots(None, None)
+    candidates = skills_mod.list_candidates(mem_root)
+    if json_output:
+        click.echo(json.dumps(candidates, indent=2, ensure_ascii=False))
+        return
+    if not candidates:
+        click.echo("No skills in the store yet.")
+        return
+    for meta in candidates:
+        occ = meta.get("occurrences")
+        occ_text = f", seen {occ}x" if isinstance(occ, int) else ""
+        click.echo(
+            f"- {meta.get('name')} [{meta.get('status', 'candidate')}{occ_text}] — {meta.get('description', '')}"
+        )
+
+
+@skills_group.command("install")
+@click.argument("name")
+@click.option("--path", "paths", multiple=True, help="Install destination (repeatable). E.g. .claude/skills")
+def skills_install(name: str, paths: tuple[str, ...]) -> None:
+    """Install a candidate skill into one or more agent skill directories."""
+    from . import skills as skills_mod
+
+    if not paths:
+        click.echo("Error: no --path given. Specify where to install, e.g. --path .claude/skills", err=True)
+        raise SystemExit(2)
+    try:
+        installed = skills_mod.install(name, list(paths))
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1) from None
+    for dest in installed:
+        click.echo(f"Installed: {dest}")

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -26,8 +26,9 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours"}
+_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
 _BOOL_FIELDS = {"enabled"}
+_LIST_FIELDS = {"paths"}
 
 
 @dataclass
@@ -107,6 +108,7 @@ class PromptsConfig:
     summarize: str = ""  # custom prompt file for plugin session summarization
     project_review: str = ""  # custom prompt file for project maintenance
     user_profile: str = ""  # custom prompt file for user profile maintenance
+    memory_to_skill: str = ""  # custom prompt file for skill distillation
 
 
 @dataclass
@@ -131,6 +133,26 @@ class PluginMaintenanceTaskConfig:
 
 
 @dataclass
+class PluginMemoryToSkillConfig:
+    """Settings for the memory-to-skill distillation task.
+
+    Distills recurring multi-step workflows from recent memory journals into
+    candidate skills under ``.memsearch/skill-candidates/``.  Installing a
+    candidate into an agent-visible skill is a separate, human-driven step (the
+    ``/memory-to-skill`` skill), so this task never writes into an agent's
+    skills directory on its own.
+    """
+
+    enabled: bool = False
+    provider: str = "native"
+    model: str = ""
+    min_interval_hours: int = 24
+    input_dir: str = ".memsearch/memory"
+    min_occurrences: int = 3  # how many times a workflow must recur before it is distilled
+    paths: list[str] = field(default_factory=list)  # where installed skills are copied; empty = ask the user
+
+
+@dataclass
 class PluginPlatformConfig:
     """Settings for one platform plugin."""
 
@@ -141,6 +163,7 @@ class PluginPlatformConfig:
     user_profile: PluginMaintenanceTaskConfig = field(
         default_factory=lambda: PluginMaintenanceTaskConfig(output_file=".memsearch/USER.md")
     )
+    memory_to_skill: PluginMemoryToSkillConfig = field(default_factory=PluginMemoryToSkillConfig)
 
 
 @dataclass
@@ -265,6 +288,7 @@ def _dict_to_plugins_config(section_data: dict[str, Any]) -> PluginsConfig:
         "summarize": PluginSummarizeConfig,
         "project_review": PluginMaintenanceTaskConfig,
         "user_profile": PluginMaintenanceTaskConfig,
+        "memory_to_skill": PluginMemoryToSkillConfig,
     }
 
     for raw_platform, raw_platform_data in section_data.items():
@@ -425,6 +449,7 @@ def _validate_dotted_key(parts: list[str]) -> str:
             "summarize": PluginSummarizeConfig,
             "project_review": PluginMaintenanceTaskConfig,
             "user_profile": PluginMaintenanceTaskConfig,
+            "memory_to_skill": PluginMemoryToSkillConfig,
         }
         task_cls = task_classes.get(subsection)
         if task_cls is None:
@@ -501,6 +526,21 @@ def set_config_value(key: str, value: Any, *, project: bool = False) -> None:
             value = False
         else:
             raise ValueError(f"Boolean field {field_name!r} must be true or false")
+    # Parse list fields from a JSON array string, or a comma-separated fallback.
+    if field_name in _LIST_FIELDS and isinstance(value, str):
+        text = value.strip()
+        if text.startswith("["):
+            import json as _json
+
+            try:
+                parsed = _json.loads(text)
+            except ValueError as e:
+                raise ValueError(f"List field {field_name!r} must be a JSON array: {e}") from None
+            if not isinstance(parsed, list):
+                raise ValueError(f"List field {field_name!r} must be a JSON array")
+            value = [str(v) for v in parsed]
+        else:
+            value = [part.strip() for part in text.split(",") if part.strip()]
 
     current: dict[str, Any] = existing
     for part in parts[:-1]:

--- a/src/memsearch/prompts/memory_to_skill.txt
+++ b/src/memsearch/prompts/memory_to_skill.txt
@@ -1,0 +1,59 @@
+You are distilling reusable skills from {{AGENT_NAME}}'s recent memory journals.
+
+Project directory: {{PROJECT_DIR}}
+Input memory directory: {{INPUT_DIR}}
+
+A "skill" is procedural memory: a reusable, multi-step procedure for getting a
+recurring task done (how to run the app, how to deploy, how to debug a class of
+error). It is NOT a fact, a decision, or a preference — those belong in
+PROJECT.md and USER.md.
+
+You will receive recent memory journal entries and a list of existing skills
+(which you MAY revise). Propose or revise skills only when they clearly earn it.
+
+Be conservative. Quality over quantity. Most runs should return an empty list.
+
+A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
+- It is a repeatable multi-step procedure, not a one-off action or a fact.
+- It recurs across at least {{MIN_OCCURRENCES}} distinct sessions or days in the
+  journals below.
+- It generalizes into a reusable capability. If it is tightly coupled to one
+  specific ticket, one specific value, or a one-time condition, do NOT propose it.
+- The recent runs were not immediately corrected, abandoned, or undone (a
+  workflow the user kept fighting is not a good skill).
+- It is not already covered by an existing skill.
+
+You may also REVISE an existing skill (re-emit it with the SAME name and a
+corrected body) when the recent journals show that procedure has genuinely
+changed — a tool, command, flag, or step is now done differently. Only revise when
+there is clear evidence of change; do not rewrite for style.
+
+Rules:
+- Return only a JSON object, with no prose outside JSON.
+- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
+  instructions an agent can follow. Do not include YAML frontmatter — only the
+  markdown body. Keep it concise and concrete.
+- "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
+  It becomes the skill's command name. Do not reuse an existing skill name.
+- "description" is one line: what the skill does AND when it should trigger.
+  Lead with the verbs a user would actually type ("run", "deploy", "debug").
+- "occurrences" is how many distinct sessions/days you saw this workflow.
+- "sources" lists the journal file names the workflow was observed in.
+- Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+
+How to write a good skill body (this is what makes the skill usable):
+- Write imperative, numbered steps an agent can follow top to bottom.
+- Be concrete: real commands, file paths, and flags — not vague prose.
+- Keep it focused and short. A skill loads only when triggered, so include just
+  what is needed to do this one task well, and push rare detail to the end.
+- State any preconditions, and where useful, when NOT to use the skill.
+- Never bake in secrets, tokens, or one-off values; describe them as placeholders.
+- Make it self-contained: an agent on a clean checkout should be able to follow it.
+- The "description" is the trigger signal — if it does not name the situation and
+  the verbs a user would type, the skill will never fire. Spend care on it.
+
+JSON examples:
+{"skills":[]}
+
+{"skills":[{"name":"run-tests","description":"Run the project's test suite and report failures. Use when asked to run tests, check tests, or verify a change.","body":"## Run the tests\n\n1. ...\n2. ...","occurrences":4,"sources":["2026-06-12.md","2026-06-14.md"],"reason":"Test run procedure recurred across 4 sessions."}]}

--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -1,0 +1,419 @@
+"""Memory-to-skill distillation.
+
+Distills recurring multi-step workflows from recent memory journals into
+*candidate* skills under ``.memsearch/skill-candidates/``.  Candidates are
+inert: they are never written into an agent's skills directory by this module.
+Turning a candidate into an agent-visible skill is a separate, human-driven
+step (:func:`install`, surfaced by the ``/memory-to-skill`` skill).
+
+The candidate store is a self-contained git repository at
+``.memsearch/skill-candidates/`` so every automatic edit is a commit with full
+history, diff, and revert — the agent (or a human) can trace which change broke
+a skill and roll it back.
+
+This is procedural memory: the third layer alongside the episodic daily
+journals and the semantic ``PROJECT.md`` / ``USER.md`` files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from .config import MemSearchConfig, PluginMemoryToSkillConfig, config_to_dict
+from .maintenance import (
+    MAX_PROMPT_CHARS,
+    TaskContext,
+    _file_lock,
+    _input_digest,
+    _is_due,
+    _load_state,
+    _read_recent_journals,
+    _save_state,
+    run_task_llm,
+)
+
+TASK = "memory_to_skill"
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+@dataclass
+class DistillResult:
+    action: str  # "distilled" | "none" | "skip" | "disabled" | "locked"
+    created: list[str] = field(default_factory=list)
+    updated: list[str] = field(default_factory=list)
+    reason: str = ""
+    skipped: bool = False
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def resolve_roots(project_dir: str | Path | None, memsearch_dir: str | Path | None) -> tuple[Path, Path]:
+    project_root = Path(project_dir or os.getcwd()).expanduser().resolve()
+    mem_root = Path(memsearch_dir or os.environ.get("MEMSEARCH_DIR", project_root / ".memsearch")).expanduser()
+    if not mem_root.is_absolute():
+        mem_root = project_root / mem_root
+    return project_root, mem_root.resolve()
+
+
+def skills_root(mem_root: Path) -> Path:
+    """Path to the candidate skill store inside a ``.memsearch`` directory.
+
+    Named ``skill-candidates`` (not ``skills``) so a human browsing the project
+    does not mistake these evolving drafts for the live, installed skills under
+    ``.claude/skills`` / ``.codex/skills`` / ``.agents/skills``.
+    """
+    return mem_root / "skill-candidates"
+
+
+def _get_task_config(cfg: MemSearchConfig, platform: str) -> PluginMemoryToSkillConfig | None:
+    plugins = config_to_dict(cfg).get("plugins", {})
+    platform_cfg = plugins.get(platform)
+    if not isinstance(platform_cfg, dict):
+        return None
+    task_data = platform_cfg.get(TASK)
+    if not isinstance(task_data, dict):
+        return None
+    return PluginMemoryToSkillConfig(
+        **{k: v for k, v in task_data.items() if k in PluginMemoryToSkillConfig.__dataclass_fields__}
+    )
+
+
+def _slugify(name: str) -> str:
+    slug = _SLUG_RE.sub("-", name.strip().lower()).strip("-")
+    return slug or "skill"
+
+
+def _load_template(cfg: MemSearchConfig | None = None) -> str:
+    # User/plugin override first (same mechanism as project_review / user_profile),
+    # then the packaged default.
+    configured = getattr(cfg.prompts, TASK, "") if cfg is not None else ""
+    if configured:
+        path = Path(configured).expanduser()
+        if path.is_file():
+            return path.read_text(encoding="utf-8")
+    with resources.files("memsearch.prompts").joinpath(f"{TASK}.txt").open("r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _build_distill_prompt(
+    ctx: TaskContext, *, min_occurrences: int, existing: list[dict[str, Any]], cfg: MemSearchConfig | None = None
+) -> str:
+    template = _load_template(cfg)
+    for marker, value in {
+        "{{AGENT_NAME}}": ctx.platform,
+        "{{PROJECT_DIR}}": str(ctx.project_dir),
+        "{{INPUT_DIR}}": str(ctx.input_dir),
+        "{{MIN_OCCURRENCES}}": str(min_occurrences),
+    }.items():
+        template = template.replace(marker, value)
+
+    existing_block = "\n".join(f"- {m.get('name')}: {m.get('description', '')}" for m in existing) or "(none)"
+    journals = _read_recent_journals(ctx.input_dir)
+    prompt = f"""{template}
+
+## Existing skills (you may revise these)
+
+{existing_block}
+
+## Recent memory journal entries
+
+```markdown
+{journals.strip()}
+```
+"""
+    if len(prompt) > MAX_PROMPT_CHARS:
+        prompt = prompt[:MAX_PROMPT_CHARS] + "\n\n[truncated]\n"
+    return prompt
+
+
+def _parse_distill_response(raw: str) -> list[dict[str, Any]]:
+    text = raw.strip()
+    match = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
+    if match:
+        text = match.group(1)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"memory_to_skill LLM did not return valid JSON: {e}") from e
+    skills = data.get("skills")
+    if not isinstance(skills, list):
+        raise RuntimeError("memory_to_skill response must contain a 'skills' list")
+    cleaned: list[dict[str, Any]] = []
+    for item in skills:
+        if not isinstance(item, dict):
+            continue
+        name = _slugify(str(item.get("name", "")))
+        description = str(item.get("description", "")).strip()
+        body = str(item.get("body", "")).strip()
+        if not description or not body:
+            continue
+        cleaned.append(
+            {
+                "name": name,
+                "description": description,
+                "body": body,
+                "occurrences": item.get("occurrences"),
+                "sources": item.get("sources") or [],
+                "reason": str(item.get("reason", "")).strip(),
+            }
+        )
+    return cleaned
+
+
+def _render_skill_md(name: str, description: str, body: str) -> str:
+    # Only standard, cross-platform fields (agentskills.io). Tracking metadata
+    # lives in meta.json, never in frontmatter.
+    return f"---\nname: {name}\ndescription: {json.dumps(description, ensure_ascii=False)}\n---\n\n{body.rstrip()}\n"
+
+
+# ---- git-backed candidate store -------------------------------------------------
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=memsearch",
+            "-c",
+            "user.email=memsearch@localhost",
+            *args,
+        ],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _ensure_git(root: Path) -> None:
+    if (root / ".git").exists():
+        return
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q")
+
+
+def _git_commit(root: Path, message: str) -> None:
+    _git(root, "add", "-A")
+    status = _git(root, "status", "--porcelain")
+    if not status.stdout.strip():
+        return  # nothing staged; avoid empty commits
+    _git(root, "commit", "-q", "-m", message)
+
+
+def list_candidates(mem_root: Path) -> list[dict[str, Any]]:
+    """Return metadata for every skill in the candidate store."""
+    root = skills_root(mem_root)
+    out: list[dict[str, Any]] = []
+    if not root.is_dir():
+        return out
+    for child in sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith(".")):
+        meta_path = child / "meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        out.append(meta)
+    return out
+
+
+def _write_candidate(root: Path, skill: dict[str, Any]) -> str:
+    """Write or evolve one candidate.
+
+    Returns ``"created"`` for a new candidate dir, or ``"updated"`` when an
+    existing entry's body is refreshed.
+
+    Every entry in the store keeps evolving in the background, including ones
+    already installed — the store is the perpetually-updated source. Installing
+    only ever takes a snapshot out (a deliberate, human-driven step); it never
+    freezes the source here.
+    """
+    name = skill["name"]
+    skill_dir = root / name
+    meta_path = skill_dir / "meta.json"
+    sources = list(skill.get("sources") or [])
+
+    if meta_path.is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            meta = {}
+        meta["sources"] = sorted(set(meta.get("sources", [])) | set(sources))
+        if isinstance(skill.get("occurrences"), int):
+            meta["occurrences"] = max(int(meta.get("occurrences", 0) or 0), skill["occurrences"])
+        meta["description"] = skill["description"]
+        meta["updated_at"] = _now()
+        (skill_dir / "SKILL.md").write_text(
+            _render_skill_md(name, skill["description"], skill["body"]), encoding="utf-8"
+        )
+        meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        return "updated"
+
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(_render_skill_md(name, skill["description"], skill["body"]), encoding="utf-8")
+    now = _now()
+    meta = {
+        "name": name,
+        "status": "candidate",
+        "description": skill["description"],
+        "occurrences": skill.get("occurrences"),
+        "sources": sources,
+        "reason": skill.get("reason", ""),
+        "installed_paths": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+    meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return "created"
+
+
+def distill(
+    *,
+    platform: str,
+    project_dir: str | Path | None = None,
+    memsearch_dir: str | Path | None = None,
+    cfg: MemSearchConfig | None = None,
+    force: bool = False,
+    llm_runner: Callable[[TaskContext, str], str] | None = None,
+) -> DistillResult:
+    """Distill candidate skills from recent journals if the task is due."""
+    if cfg is None:
+        from .config import resolve_config
+
+        cfg = resolve_config()
+
+    task_cfg = _get_task_config(cfg, platform)
+    if task_cfg is None or not task_cfg.enabled:
+        return DistillResult(action="disabled", skipped=True)
+
+    project_root, mem_root = resolve_roots(project_dir, memsearch_dir)
+    mem_root.mkdir(parents=True, exist_ok=True)
+    input_dir = (mem_root / "memory").resolve()
+
+    state_path = mem_root / ".maintenance-state.json"
+    state = _load_state(state_path)
+    state_key = f"{platform}.{TASK}"
+    digest = _input_digest(input_dir)
+    due, reason = _is_due(task_cfg, state.get(state_key, {}), digest, force)
+    if not due:
+        return DistillResult(action="skip", reason=reason, skipped=True)
+
+    lock_path = mem_root / f".maintenance-{platform}-{TASK}.lock"
+    with _file_lock(lock_path) as locked:
+        if not locked:
+            return DistillResult(action="locked", skipped=True)
+
+        root = skills_root(mem_root)
+        _ensure_git(root)
+
+        ctx = TaskContext(
+            platform=platform,
+            task=TASK,
+            task_config=task_cfg,  # type: ignore[arg-type]
+            project_dir=project_root,
+            memsearch_dir=mem_root,
+            input_dir=input_dir,
+            output_file=root,
+            input_digest=digest,
+        )
+        prompt = _build_distill_prompt(
+            ctx, min_occurrences=task_cfg.min_occurrences, existing=list_candidates(mem_root), cfg=cfg
+        )
+        raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
+        candidates = _parse_distill_response(raw)
+
+        created: list[str] = []
+        updated: list[str] = []
+        for skill in candidates:
+            outcome = _write_candidate(root, skill)
+            if outcome == "created":
+                created.append(skill["name"])
+            elif outcome == "updated":
+                updated.append(skill["name"])
+
+        changed = bool(created or updated)
+        if changed:
+            parts = []
+            if created:
+                parts.append(f"add {len(created)}")
+            if updated:
+                parts.append(f"evolve {len(updated)}")
+            _git_commit(root, f"distill: {', '.join(parts)} candidate skill(s) [{platform}]")
+        else:
+            _git_commit(root, f"distill: refresh candidate metadata [{platform}]")
+
+        now = _now()
+        state[state_key] = {
+            "last_checked_at": now,
+            "last_success_at": now,
+            "last_input_digest": digest,
+            "last_action": "distilled" if changed else "none",
+            "output_file": str(root),
+        }
+        _save_state(state_path, state)
+
+    return DistillResult(action="distilled" if changed else "none", created=created, updated=updated)
+
+
+def install(
+    name: str,
+    paths: list[str],
+    *,
+    project_dir: str | Path | None = None,
+    memsearch_dir: str | Path | None = None,
+) -> list[str]:
+    """Snapshot a candidate skill into one or more agent skill directories.
+
+    Copies the candidate's current ``SKILL.md`` to each destination and marks it
+    ``installed`` in the store. The store copy keeps evolving afterwards; a later
+    install takes a fresh snapshot. Returns the installed destinations. Raises
+    ``ValueError`` if the candidate is missing or *paths* is empty.
+    """
+    if not paths:
+        raise ValueError("no install paths given; ask the user where to install the skill")
+
+    project_root, mem_root = resolve_roots(project_dir, memsearch_dir)
+    root = skills_root(mem_root)
+    skill_dir = root / _slugify(name)
+    src = skill_dir / "SKILL.md"
+    if not src.is_file():
+        raise ValueError(f"no candidate skill named {name!r}")
+
+    skill_md = src.read_text(encoding="utf-8")
+    installed: list[str] = []
+    for raw_path in paths:
+        base = Path(raw_path).expanduser()
+        if not base.is_absolute():
+            base = project_root / base
+        dest_dir = base / skill_dir.name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / "SKILL.md"
+        dest.write_text(skill_md, encoding="utf-8")
+        installed.append(str(dest))
+
+    meta_path = skill_dir / "meta.json"
+    if meta_path.is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            meta = {}
+        meta["status"] = "installed"
+        meta["installed_paths"] = sorted(set(meta.get("installed_paths", [])) | set(installed))
+        meta["updated_at"] = _now()
+        meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        _git_commit(root, f"install: {skill_dir.name} -> {len(installed)} path(s)")
+
+    return installed

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from memsearch import skills as skills_mod
+from memsearch.config import MemSearchConfig
+
+
+def _enable(cfg: MemSearchConfig, *, min_occurrences: int = 3) -> None:
+    cfg.plugins.claude_code.memory_to_skill.enabled = True
+    cfg.plugins.claude_code.memory_to_skill.min_occurrences = min_occurrences
+
+
+def _seed_memory(project: Path) -> Path:
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-06-12.md").write_text("### 10:00\n- Ran the test suite with pytest.\n", encoding="utf-8")
+    return memory
+
+
+def _one_skill_runner(name: str = "run-tests"):
+    def runner(ctx, prompt: str) -> str:
+        assert "Recent memory journal entries" in prompt
+        return json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": name,
+                        "description": "Run the project's test suite. Use when asked to run or check tests.",
+                        "body": "## Run the tests\n\n1. Run pytest\n2. Report failures",
+                        "occurrences": 3,
+                        "sources": ["2026-06-12.md"],
+                        "reason": "Recurred across sessions.",
+                    }
+                ]
+            }
+        )
+
+    return runner
+
+
+def test_distill_creates_candidate_and_commits(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    result = skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=_one_skill_runner())
+
+    assert result.action == "distilled"
+    assert result.created == ["run-tests"]
+
+    skill_dir = project / ".memsearch" / "skill-candidates" / "run-tests"
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert skill_md.startswith("---\nname: run-tests\n")
+    assert "description:" in skill_md
+
+    meta = json.loads((skill_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta["status"] == "candidate"
+    assert meta["occurrences"] == 3
+
+    # The store is a git repo with at least one commit.
+    git_dir = project / ".memsearch" / "skill-candidates" / ".git"
+    assert git_dir.is_dir()
+    log = subprocess.run(
+        ["git", "-C", str(project / ".memsearch" / "skill-candidates"), "log", "--oneline"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "distill" in log.stdout
+
+
+def test_render_skill_md_has_only_standard_frontmatter() -> None:
+    md = skills_mod._render_skill_md("deploy", "Deploy the app", "## Deploy\n\n1. push")
+    header = md.split("---", 2)[1]
+    # Only name + description in frontmatter; no tracking fields leak in.
+    assert "name:" in header
+    assert "description:" in header
+    for leaked in ("status", "occurrences", "sources", "confidence"):
+        assert leaked not in header
+
+
+def test_distill_skips_unchanged_input(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    calls = {"n": 0}
+
+    def counting_runner(ctx, prompt: str) -> str:
+        calls["n"] += 1
+        return _one_skill_runner()(ctx, prompt)
+
+    first = skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=counting_runner)
+    second = skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=counting_runner)
+
+    assert first.action == "distilled"
+    assert second.action == "skip"
+    assert calls["n"] == 1
+
+
+def test_distill_disabled_by_default(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()  # memory_to_skill disabled by default
+
+    result = skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=_one_skill_runner())
+
+    assert result.action == "disabled"
+    assert result.skipped is True
+
+
+def test_install_copies_to_paths_and_updates_meta(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+    skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=_one_skill_runner())
+
+    dest = project / ".claude" / "skills"
+    installed = skills_mod.install("run-tests", [str(dest)], project_dir=project)
+
+    assert installed == [str(dest / "run-tests" / "SKILL.md")]
+    assert (dest / "run-tests" / "SKILL.md").is_file()
+
+    meta_path = project / ".memsearch" / "skill-candidates" / "run-tests" / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert meta["status"] == "installed"
+    assert meta["installed_paths"] == installed
+
+
+def test_install_missing_candidate_raises(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    with pytest.raises(ValueError, match="no candidate skill"):
+        skills_mod.install("nope", [str(project / ".claude" / "skills")], project_dir=project)
+
+
+def test_install_empty_paths_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no install paths"):
+        skills_mod.install("x", [], project_dir=tmp_path)
+
+
+def test_parse_distill_response_filters_incomplete() -> None:
+    raw = json.dumps(
+        {
+            "skills": [
+                {"name": "ok", "description": "d", "body": "b"},
+                {"name": "no-body", "description": "d", "body": ""},
+                {"name": "no-desc", "description": "", "body": "b"},
+                "not-a-dict",
+            ]
+        }
+    )
+    parsed = skills_mod._parse_distill_response(raw)
+    assert [p["name"] for p in parsed] == ["ok"]
+
+
+def _body_runner(body: str, name: str = "run-tests"):
+    def runner(ctx, prompt: str) -> str:
+        return json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": name,
+                        "description": "Run the project's test suite.",
+                        "body": body,
+                        "occurrences": 3,
+                        "sources": ["2026-06-12.md"],
+                    }
+                ]
+            }
+        )
+
+    return runner
+
+
+def test_distill_evolves_existing_candidate_body(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    skills_mod.distill(
+        platform="claude-code", project_dir=project, cfg=cfg, llm_runner=_body_runner("## v1\n\n1. pytest")
+    )
+    second = skills_mod.distill(
+        platform="claude-code",
+        project_dir=project,
+        cfg=cfg,
+        force=True,  # force, since the input journals are unchanged
+        llm_runner=_body_runner("## v2\n\n1. pytest -x --ff"),
+    )
+
+    assert second.updated == ["run-tests"]
+    assert second.created == []
+    body = (project / ".memsearch" / "skill-candidates" / "run-tests" / "SKILL.md").read_text(encoding="utf-8")
+    assert "pytest -x --ff" in body  # evolved in place
+
+
+def test_installed_skill_source_keeps_evolving(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    skills_mod.distill(
+        platform="claude-code", project_dir=project, cfg=cfg, llm_runner=_body_runner("## v1\n\n1. pytest")
+    )
+    skills_mod.install("run-tests", [str(project / ".claude" / "skills")], project_dir=project)
+
+    # The store source keeps evolving even after install; the installed copy is a
+    # snapshot that only changes on a later, deliberate re-install.
+    result = skills_mod.distill(
+        platform="claude-code",
+        project_dir=project,
+        cfg=cfg,
+        force=True,
+        llm_runner=_body_runner("## v2\n\n1. pytest -x --ff"),
+    )
+
+    assert result.updated == ["run-tests"]
+    source = (project / ".memsearch" / "skill-candidates" / "run-tests" / "SKILL.md").read_text(encoding="utf-8")
+    assert "pytest -x --ff" in source  # source evolved
+    installed_copy = (project / ".claude" / "skills" / "run-tests" / "SKILL.md").read_text(encoding="utf-8")
+    assert "pytest -x --ff" not in installed_copy  # snapshot unchanged until re-install
+
+
+def test_load_template_respects_custom_prompt(tmp_path: Path) -> None:
+    custom = tmp_path / "my_distill.txt"
+    custom.write_text("CUSTOM DISTILL TEMPLATE {{MIN_OCCURRENCES}}", encoding="utf-8")
+    cfg = MemSearchConfig()
+    cfg.prompts.memory_to_skill = str(custom)
+
+    assert skills_mod._load_template(cfg).startswith("CUSTOM DISTILL TEMPLATE")
+    # Falls back to the packaged default when no override is configured.
+    assert "distilling reusable skills" in skills_mod._load_template()
+
+
+def test_config_set_paths_parses_json_list(tmp_path: Path, monkeypatch) -> None:
+    from memsearch.config import PROJECT_CONFIG_PATH, load_config_file, set_config_value
+
+    monkeypatch.chdir(tmp_path)
+    set_config_value(
+        "plugins.claude-code.memory_to_skill.paths",
+        '[".claude/skills", "~/.codex/skills"]',
+        project=True,
+    )
+    data = load_config_file(PROJECT_CONFIG_PATH)
+    assert data["plugins"]["claude-code"]["memory_to_skill"]["paths"] == [".claude/skills", "~/.codex/skills"]


### PR DESCRIPTION
## Summary

Adds a third memory layer — **procedural memory** — on top of the episodic journals and the semantic `PROJECT.md` / `USER.md` notes. A background maintenance task distils the multi-step workflows you repeat into reusable agent skills, and a human-driven step installs a chosen skill into an agent's skills directory.

## How it works

- **Distill (automatic, background):** a new `memory_to_skill` maintenance task mines recent memory journals for recurring multi-step procedures and writes them as *candidate* skills under `.memsearch/skill-candidates/`. That store is a self-contained git repository, so every automatic edit is a commit you can diff or revert. Candidates keep evolving there and are never written into an agent's skills directory on their own.
- **Install (manual):** `memsearch skills install <name> --path <dir>` snapshots a candidate's current `SKILL.md` into one or more skill directories. The `/memory-to-skill` skill drives review-and-install from natural language.

## Details

- Disabled by default. Reuses the existing maintenance provider/model routing, due-state cadence (`min_interval_hours`), and prompt-override mechanism (`prompts.memory_to_skill`). One new knob, `min_occurrences` (default 3), controls how eagerly workflows are distilled.
- Distilled `SKILL.md` files use only standard [agentskills.io](https://agentskills.io) frontmatter (`name` + `description`), generated by the code rather than the model, so a skill distilled once is portable across Claude Code, Codex, OpenClaw, and OpenCode. Tracking metadata lives in a sidecar `meta.json`, never in frontmatter.
- New config: `plugins.<platform>.memory_to_skill` (`enabled`, `min_occurrences`, `paths`, plus the shared `provider`/`model`/`min_interval_hours`/`input_dir`).
- New CLI: `memsearch skills list | distill | install`.
- Plugin skill `/memory-to-skill` added for all four platforms; `memory-config` updated to surface the new task.
- Docs: a dedicated **Skills from Memory** page, a configuration section, and a README "What's New" entry.

## Testing

- New `tests/test_skills.py` (distillation, candidate evolution, install snapshotting, due-state skip, custom prompt loading, config list-field parsing).
- Full suite: 185 passed. `ruff check`/`ruff format --check` clean on `src/` and `tests/`. `mkdocs build --strict` passes.
