### PR TITLE
fix: address memory-to-skill review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,20 +278,19 @@ The `memory-config` skill, installed with the plugins, can inspect the current s
 
 #### Skills from Memory
 
-Beyond episodic journals and the semantic `PROJECT.md` / `USER.md` notes, MemSearch can grow a third memory layer — **procedural memory**: reusable skills distilled from the workflows you repeat. When enabled, a background pass mines recent journals for recurring multi-step procedures and writes them as *candidate* skills under `.memsearch/skill-candidates/` (a git-tracked store that keeps evolving). Candidates are inert; turning one into an agent-visible skill is a deliberate, human step.
+Beyond episodic journals and the semantic `PROJECT.md` / `USER.md` notes, MemSearch can grow a third memory layer — **procedural memory**: reusable skills distilled from the workflows you repeat, written as *candidate* skills under `.memsearch/skill-candidates/` (a git-tracked store that keeps evolving). Candidates are inert; turning one into an agent-visible skill is a deliberate, human step. Candidates are created two ways: a **background** pass that mines recurring workflows (off by default), or **on demand** — just ask the agent "make a skill out of what we just did" and it captures it immediately (no background needed).
 
 ```bash
-# Enable distillation (disabled by default, like the maintenance tasks above)
+# Optional: enable the background mining pass (off by default; manual capture works without it)
 memsearch config set plugins.codex.memory_to_skill.enabled true --project
-# How many times a workflow must recur before it is distilled (default 3; lower = more eager)
-memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
 
 # Review candidates, then install one into an agent's skill directory
 memsearch skills list
 memsearch skills install <name> --path .claude/skills
 ```
 
-The `/memory-to-skill` skill (installed with the plugins) drives the review-and-install flow: it lists candidates, asks where to install, and copies the chosen skill into `.claude/skills` (Claude Code), `.codex/skills` (Codex), `.agents/skills` (OpenCode/Cursor/…), or any path you configure. Because the store keeps evolving, re-installing simply takes a fresh snapshot. The distilled `SKILL.md` follows the [Agent Skills](https://agentskills.io) open standard, so a skill distilled once is portable across agents.
+The `/memory-to-skill` skill (installed with the plugins) drives the flow from natural language — capture what you just did, review & install candidates, mine history on demand, or configure the background pass. Skills install into each agent's own directory: `.claude/skills` (Claude Code), `.agents/skills` (Codex, OpenCode, Cursor, …), `.openclaw/skills` (OpenClaw), or any path you set; `--path` is repeatable. The distilled `SKILL.md` follows the [Agent Skills](https://agentskills.io) open standard, so a skill distilled once is portable across agents.
 
 ### What can you use it for?
 

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -190,14 +190,16 @@ changes from natural-language requests.
 ## Skills from Memory (procedural memory)
 
 A third maintenance task, `memory_to_skill`, distills recurring workflows into
-reusable agent skills. It is **disabled by default** and shares the maintenance
-tasks' provider/model routing, prompt-override mechanism
-(`prompts.memory_to_skill`), and `min_interval_hours` cadence.
+reusable agent skills. The `enabled` flag here gates only the **background**
+mining pass (disabled by default, to avoid surprise background model calls);
+manual capture and explicit `memsearch skills distill` work regardless. It shares
+the maintenance tasks' provider/model routing, prompt override
+(`prompts.memory_to_skill`), `input_dir`, and `min_interval_hours` cadence.
 
 ```bash
 memsearch config set plugins.codex.memory_to_skill.enabled true --project
 memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
-memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project   # optional; empty = asked at install
+memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --project   # optional; empty = asked at install
 ```
 
 | Field | Default | Meaning |

--- a/docs/home/skills-from-memory.md
+++ b/docs/home/skills-from-memory.md
@@ -14,82 +14,98 @@ reusable procedure (how to run the app, deploy, debug a class of error) that an
 agent can load and follow. Because it follows the open standard, a skill distilled
 once is portable across Claude Code, Codex, OpenCode, and other agents.
 
-## How it works
+## Stages
 
-There are two stages. Only the second one involves you.
+**0** memory journals → **1** candidate (`.memsearch/skill-candidates/`) → **2**
+installed (an agent's skill directory). The candidate store is a self-contained
+**git repository**, so every edit is a commit you can `git log`, `git diff`, or
+`git revert`. Candidates keep evolving there — including ones you have already
+installed; the store is the perpetually-updated source, and installing only ever
+takes a snapshot out. Candidates are **never** written into an agent's skill
+directory automatically.
 
-**1. Distill (automatic, background).** Like the
+## Two ways a candidate gets created (0 → 1)
+
+Skill *content* can be generated two ways. Generating content needs a model;
+**only this step uses one**. Persisting (`add`) and installing are plain
+file/git operations.
+
+**1. Background distillation (automatic, model-driven).** Like the
 [advanced maintenance](configuration.md#advanced-plugin-maintenance) tasks, a
-`memory_to_skill` task runs in the background on the session-end /
-`min_interval_hours` cadence. It mines recent journals for recurring multi-step
-procedures and writes them as **candidate** skills under
-`.memsearch/skill-candidates/`.
+`memory_to_skill` task runs on the session-end / `min_interval_hours` cadence,
+using the configured provider (default `native`). It mines recent journals for
+workflows that **recur at least `min_occurrences` times** and writes them as
+candidates. It is deliberately conservative — most runs distil nothing — because
+it is unattended. This path is gated by `enabled` (off by default) to avoid
+surprise background model calls.
 
-That store is a self-contained **git repository**, so every automatic edit is a
-commit you can `git log`, `git diff`, or `git revert`. Candidates keep evolving
-there over time — including ones you have already installed; the store is the
-perpetually-updated source. Candidates are inert: they are **never** written into
-an agent's skill directory on their own.
+**2. Manual capture (on demand, agent-driven).** When you tell the agent *"make a
+skill out of what we just did"*, the **live agent you are talking to** drafts the
+`SKILL.md` from its own context — no separate model call, no provider config, and
+no recurrence threshold (your explicit request is the signal, so even a one-off is
+fine). It persists the result with `memsearch skills add`, which only handles the
+slug, standard frontmatter, `meta.json`, and the git commit. This path is **not**
+gated by `enabled` — an explicit request is never a surprise.
 
-It is deliberately conservative — most runs distil nothing. A workflow becomes a
-candidate only when it is a genuine multi-step procedure, recurs at least
-`min_occurrences` times, generalizes into a reusable capability, and was not
-immediately corrected or abandoned.
+You can also run the model-driven mining yourself at any time with `memsearch
+skills distill` (also ungated, since it is explicit).
 
-**2. Install (manual, human-driven).** You review a candidate — optionally inspect
-its history and edit it — then copy its current version into an agent's skill
-directory. Installing is the only thing that makes a skill agent-visible.
-Re-installing later simply takes a fresh snapshot of the evolved source.
+## Install (1 → 2, always manual)
 
-## Enable and tune
-
-Disabled by default, like the maintenance tasks. Configure per platform:
-
-```bash
-memsearch config set plugins.codex.memory_to_skill.enabled true --project
-memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
-memsearch config set plugins.codex.memory_to_skill.provider native --project
-# Optional: pre-set install targets (otherwise the skill asks you)
-memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project
-# Optional: custom distillation prompt
-memsearch config set prompts.memory_to_skill .memsearch/prompts/memory-to-skill.txt --project
-```
-
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `enabled` | `false` | Turn background distillation on |
-| `min_occurrences` | `3` | How many times a workflow must recur before it is distilled |
-| `min_interval_hours` | `24` | Minimum gap between background runs |
-| `provider` / `model` | `native` | Same routing as the maintenance tasks |
-| `paths` | _(empty)_ | Where installed skills are copied; empty = you are asked at install time |
-
-See [Configuration](configuration.md) for how provider/model routing and prompt
-overrides work — they are shared with the maintenance tasks.
-
-## Review and install
+Review a candidate — optionally inspect its history and edit it — then copy its
+current version into an agent's skill directory. Installing is the only thing that
+makes a skill agent-visible; re-installing takes a fresh snapshot of the evolved
+source.
 
 ```bash
 memsearch skills list                                   # review candidates (-j for detail)
 memsearch skills install <name> --path .claude/skills   # snapshot into a skills directory
 ```
 
-Different agents read skills from different directories:
+Each agent reads skills from its own directory:
 
 | Agent | Project dir | Global dir |
 | --- | --- | --- |
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` |
-| Codex | `.codex/skills/` | `~/.codex/skills/` |
+| Codex | `.agents/skills/` | `~/.agents/skills/` |
+| OpenCode | `.agents/skills/` | `~/.agents/skills/` |
 | OpenClaw | `.openclaw/skills/` | `~/.openclaw/skills/` |
-| OpenCode / Cursor / … | `.agents/skills/` | `~/.agents/skills/` |
 
-`.agents/skills/` is the shared standard read by OpenCode, Cursor, and others —
-but **not** by Claude Code. `--path` is repeatable, so you can install one skill
-to several agents at once.
+`.agents/skills/` is the shared standard read by Codex, OpenCode, Cursor, and
+others — but **not** by Claude Code. `--path` is repeatable, so one skill can be
+installed to several agents at once.
+
+## Enable and tune the background pass
+
+Disabled by default, like the maintenance tasks. (Manual capture and explicit
+`distill` work whether or not this is enabled.)
+
+```bash
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
+memsearch config set plugins.codex.memory_to_skill.provider native --project
+# Optional: pre-set install targets (otherwise the skill asks you)
+memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --project
+# Optional: custom distillation prompt
+memsearch config set prompts.memory_to_skill .memsearch/prompts/memory-to-skill.txt --project
+```
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Turn the **background** pass on (manual paths ignore this) |
+| `min_occurrences` | `3` | How many times a workflow must recur before background mining distils it |
+| `min_interval_hours` | `24` | Minimum gap between background runs |
+| `input_dir` | `.memsearch/memory` | Which journals to read |
+| `provider` / `model` | `native` | Same routing as the maintenance tasks |
+| `paths` | _(empty)_ | Where installed skills are copied; empty = you are asked at install time |
+
+See [Configuration](configuration.md) for how provider/model routing and prompt
+overrides work — they are shared with the maintenance tasks.
 
 ## The `/memory-to-skill` skill
 
-The plugins install a `/memory-to-skill` skill that drives this whole flow from
-natural language: it checks whether distillation is enabled (and offers to enable
-it), lists candidates, asks where to install, and copies the chosen skill out. It
-never enables the feature, changes install paths, or installs a candidate without
-your go-ahead.
+The plugins install a `/memory-to-skill` skill that drives the whole flow from
+natural language and routes by intent: **capture** what you just did (draft → add →
+install), **review & install** existing candidates, **distill** from history on
+demand, or **configure** the background pass. It never enables the feature, changes
+install paths, or installs a candidate without your go-ahead.

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -1,111 +1,104 @@
 ---
 name: memory-to-skill
-description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Claude Code own skills system."
+description: "Turn workflows from your MemSearch memory into reusable skills. Use when the user asks to make/create/extract/distill a skill from what they just did or from past work, review skill candidates, install a distilled skill, or 'turn this into a skill'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Claude Code's own skills system."
 context: fork
 allowed-tools: Bash
 ---
 
-You manage MemSearch's **procedural memory**: candidate skills distilled from the
-project's memory journals. This is the third memory layer, alongside the daily
-journals (episodic) and PROJECT.md / USER.md (semantic).
+You manage MemSearch's **procedural memory**: skills distilled from the work you
+repeat — a third layer beside the daily journals (episodic) and PROJECT.md /
+USER.md (semantic). State once that this is MemSearch skill distillation, not
+Claude Code's built-in skills system.
 
-State once in your summary that this is MemSearch skill distillation, not Claude Code's
-built-in skills system. Do not repeat that on every line.
-
-Two stages, and you only ever drive the second one:
-- **Distill (automatic, background):** MemSearch watches recent journals and writes
-  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
-  evolving them there over time. Every entry — even ones already installed — stays
-  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
-- **Install (this skill, human-driven):** the user reviews a candidate and you copy
-  its current version into agent skill directories. Installing is the only path that
-  makes a skill agent-visible, and re-installing is how an installed skill gets
-  updated — the store keeps evolving; install takes a fresh snapshot.
+Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
+a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
+Candidates are never installed automatically; installing is always a human step.
 
 ## Intent routing
 
-Inspect the user's request:
-- No specific request, "what skills / review candidates" -> **List candidates**.
-- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
-- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+- "make/turn this into a skill", "from what we just did" → **A. Capture now**.
+- "what skills / review candidates / install X" → **B. Review & install**.
+- "mine my history / find recurring workflows" → **C. Distill from history**.
+- "enable / configure / how eager" → **D. Configure**.
+- Unclear or empty → run **B**'s `list`; if empty, offer A or C.
 
-## 1. Check the feature is enabled
+## A. Capture what you just did (0→1→2)
 
-```bash
-memsearch config get plugins.claude-code.memory_to_skill.enabled 2>/dev/null || echo "false"
-```
-
-If this is not `true`, background distillation is **off**. Tell the user, and offer
-to turn it on (do not enable it silently). On their confirmation:
-
-```bash
-memsearch config set plugins.claude-code.memory_to_skill.enabled true --project
-```
-
-Mention they can tune how eagerly skills are extracted with
-`plugins.claude-code.memory_to_skill.min_occurrences` (default 3 — how many times a
-workflow must recur before it becomes a candidate). Lower = more eager.
-
-## 2. List candidates
+You already have the context, so **draft the skill yourself** — do not call the
+background distiller for this. Write a SKILL.md **body** (markdown, no
+frontmatter): imperative numbered steps for the recurring task, concrete commands
+and paths, no secrets, self-contained. Then persist it as a candidate:
 
 ```bash
-memsearch skills list
+printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
+  --name "<short-slug>" \
+  --description "<what it does AND when it should trigger — lead with the verbs a user types>" \
+  --body-file -
 ```
 
-Show candidate names, status (candidate / installed), how often each recurred, and
-the one-line description. Use `memsearch skills list -j` for structured detail
-(sources, installed paths).
+`add` handles slugging, standard frontmatter, meta.json, and the git commit — no
+LLM is involved. Then show it to the user and install it (see **B**). Finally,
+check whether background distillation is on; if not, offer to enable it (so
+recurring workflows get captured automatically going forward) — do not force it.
 
-## 3. Distill on demand (optional)
+## B. Review & install candidates (1→2)
 
-If the user wants to extract right now rather than wait for the background pass:
+```bash
+memsearch skills list            # add -j for sources / installed paths
+```
+
+Pick one, resolve where to install (ask if unset), then install:
+
+```bash
+memsearch config get plugins.claude-code.memory_to_skill.paths 2>/dev/null || echo "[]"
+memsearch skills install <name> --path .claude/skills
+```
+
+If the list is **empty**, background distillation is likely off or has not run.
+Offer the user a choice: capture from recent work now (**A**), distill from
+history (**C**), or enable the background pass (**D**).
+
+## C. Distill from history (0→1, model-driven)
 
 ```bash
 memsearch skills distill --plugin claude-code --force
 ```
 
-Then list again. Most runs add nothing — that is expected; the bar for a reusable
-skill is intentionally high.
+This is explicit, so it runs even if the background flag is off. It mines recent
+journals for workflows that recur at least `min_occurrences` times, writes them as
+candidates, and you then review/install via **B**. Most runs add nothing — the bar
+is intentionally high.
 
-## 4. Install a candidate
-
-Installing copies a candidate's current `SKILL.md` into one or more skill
-directories. Before installing you may review the candidate, inspect its history
-(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
-guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
-are committed and then snapshotted out.
-
-First resolve **where** to install:
+## D. Configure
 
 ```bash
-memsearch config get plugins.claude-code.memory_to_skill.paths 2>/dev/null || echo "[]"
-```
-
-If this is empty (`[]`), **do not guess** — ask the user where to install, then
-persist their choice. Offer these options and explain the trade-off:
-- `.claude/skills` — **project-local (recommended)**: scoped to this repo; a skill
-  distilled from this project's memory is usually most relevant here.
-- `~/.claude/skills` — global: available across all your projects.
-- a custom path, or several paths (one skill can be installed to multiple dirs).
-
-Note for cross-agent users, each agent reads skills from its own directory:
-Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
-and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
-**not** by Claude Code. To cover several agents, install to multiple paths.
-
-Persist the chosen paths (example for project-local), then install:
-
-```bash
+memsearch config get plugins.claude-code.memory_to_skill.enabled 2>/dev/null || echo "false"
+# enable the background pass (do not enable silently)
+memsearch config set plugins.claude-code.memory_to_skill.enabled true --project
+# how eagerly history-mining distils (default 3; lower = more eager)
+memsearch config set plugins.claude-code.memory_to_skill.min_occurrences 3 --project
+# pre-set install targets (otherwise you are asked at install time)
 memsearch config set plugins.claude-code.memory_to_skill.paths '[".claude/skills"]' --project
-memsearch skills install <name> --path .claude/skills
 ```
 
-`--path` is repeatable for multiple destinations. After installing, tell the user the
-installed location(s) and that the skill is now agent-visible.
+Note: `enabled` only gates the **background** (session-end) pass. The explicit
+commands above (`skills add`, `skills distill`, `skills install`) always work.
+
+## Install paths
+
+- `.claude/skills` — **project-local (recommended)**: a skill from this project's
+  memory is usually most relevant here.
+- `~/.claude/skills` — global: available across all your projects.
+- a custom path, or several (one skill can be installed to multiple dirs).
+
+Each agent reads skills from its own directory: Claude Code `.claude/skills/`;
+Codex and OpenCode `.agents/skills/` (the shared standard, also read by Cursor
+etc.); OpenClaw `.openclaw/skills/`. Claude Code does **not** read `.agents/skills/`.
+Install to multiple paths to cover several agents.
 
 ## Guardrails
 
-- Never enable the feature, change install paths, or install a candidate without the
-  user's go-ahead.
-- Edit candidates only under the user's guidance, and only via the git-tracked store
-  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.
+- Never enable the feature, change install paths, or install a candidate without
+  the user's go-ahead.
+- Do not hand-edit the store; create candidates with `memsearch skills add` and let
+  the git-tracked store at `.memsearch/skill-candidates/` keep history.

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -189,7 +189,7 @@ fi
 echo "[2/6] Installing memsearch skills..."
 mkdir -p "$HOME/.agents/skills"
 
-for skill_name in memory-recall memory-config; do
+for skill_name in memory-recall memory-config memory-to-skill; do
   SKILL_SRC="$INSTALL_DIR/skills/$skill_name"
   SKILL_DST="$HOME/.agents/skills/$skill_name"
   if [ -d "$SKILL_DST" ] || [ -L "$SKILL_DST" ]; then
@@ -204,7 +204,7 @@ done
 
 # --- 3. Replace __INSTALL_DIR__ placeholder in SKILL.md ---
 echo "[3/6] Configuring skill paths..."
-for skill_name in memory-recall memory-config; do
+for skill_name in memory-recall memory-config memory-to-skill; do
   SKILL_DST="$HOME/.agents/skills/$skill_name"
   if [ -f "$SKILL_DST/SKILL.md" ]; then
     replace_text_in_file "$SKILL_DST/SKILL.md" "__INSTALL_DIR__" "$INSTALL_DIR"
@@ -248,10 +248,11 @@ echo "  • Stop: summarizes each turn and saves to memory"
 echo "  • UserPromptSubmit: reminds Codex about memory-recall skill"
 echo "  • memory-recall skill: search past memories when relevant"
 echo "  • memory-config skill: diagnose and configure memsearch"
+echo "  • memory-to-skill skill: turn recurring workflows into reusable skills"
 echo ""
 echo "Memory files:   <project>/.memsearch/memory/*.md"
 echo "Hooks config:   $HOOKS_FILE"
-echo "Skill location: $HOME/.agents/skills/{memory-recall,memory-config}"
+echo "Skill location: $HOME/.agents/skills/{memory-recall,memory-config,memory-to-skill}"
 echo "Feature flag:   hooks = true in $CONFIG_FILE"
 echo ""
 echo "To verify: start a new codex session and check for [memsearch] status line."

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -1,109 +1,102 @@
 ---
 name: memory-to-skill
-description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Codex own skills system."
+description: "Turn workflows from your MemSearch memory into reusable skills. Use when the user asks to make/create/extract/distill a skill from what they just did or from past work, review skill candidates, install a distilled skill, or 'turn this into a skill'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not Codex's own skills system."
 ---
 
-You manage MemSearch's **procedural memory**: candidate skills distilled from the
-project's memory journals. This is the third memory layer, alongside the daily
-journals (episodic) and PROJECT.md / USER.md (semantic).
+You manage MemSearch's **procedural memory**: skills distilled from the work you
+repeat — a third layer beside the daily journals (episodic) and PROJECT.md /
+USER.md (semantic). State once that this is MemSearch skill distillation, not
+Codex's built-in skills system.
 
-State once in your summary that this is MemSearch skill distillation, not Codex's
-built-in skills system. Do not repeat that on every line.
-
-Two stages, and you only ever drive the second one:
-- **Distill (automatic, background):** MemSearch watches recent journals and writes
-  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
-  evolving them there over time. Every entry — even ones already installed — stays
-  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
-- **Install (this skill, human-driven):** the user reviews a candidate and you copy
-  its current version into agent skill directories. Installing is the only path that
-  makes a skill agent-visible, and re-installing is how an installed skill gets
-  updated — the store keeps evolving; install takes a fresh snapshot.
+Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
+a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
+Candidates are never installed automatically; installing is always a human step.
 
 ## Intent routing
 
-Inspect the user's request:
-- No specific request, "what skills / review candidates" -> **List candidates**.
-- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
-- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+- "make/turn this into a skill", "from what we just did" → **A. Capture now**.
+- "what skills / review candidates / install X" → **B. Review & install**.
+- "mine my history / find recurring workflows" → **C. Distill from history**.
+- "enable / configure / how eager" → **D. Configure**.
+- Unclear or empty → run **B**'s `list`; if empty, offer A or C.
 
-## 1. Check the feature is enabled
+## A. Capture what you just did (0→1→2)
 
-```bash
-memsearch config get plugins.codex.memory_to_skill.enabled 2>/dev/null || echo "false"
-```
-
-If this is not `true`, background distillation is **off**. Tell the user, and offer
-to turn it on (do not enable it silently). On their confirmation:
-
-```bash
-memsearch config set plugins.codex.memory_to_skill.enabled true --project
-```
-
-Mention they can tune how eagerly skills are extracted with
-`plugins.codex.memory_to_skill.min_occurrences` (default 3 — how many times a
-workflow must recur before it becomes a candidate). Lower = more eager.
-
-## 2. List candidates
+You already have the context, so **draft the skill yourself** — do not call the
+background distiller for this. Write a SKILL.md **body** (markdown, no
+frontmatter): imperative numbered steps for the recurring task, concrete commands
+and paths, no secrets, self-contained. Then persist it as a candidate:
 
 ```bash
-memsearch skills list
+printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
+  --name "<short-slug>" \
+  --description "<what it does AND when it should trigger — lead with the verbs a user types>" \
+  --body-file -
 ```
 
-Show candidate names, status (candidate / installed), how often each recurred, and
-the one-line description. Use `memsearch skills list -j` for structured detail
-(sources, installed paths).
+`add` handles slugging, standard frontmatter, meta.json, and the git commit — no
+LLM is involved. Then show it to the user and install it (see **B**). Finally,
+check whether background distillation is on; if not, offer to enable it (so
+recurring workflows get captured automatically going forward) — do not force it.
 
-## 3. Distill on demand (optional)
+## B. Review & install candidates (1→2)
 
-If the user wants to extract right now rather than wait for the background pass:
+```bash
+memsearch skills list            # add -j for sources / installed paths
+```
+
+Pick one, resolve where to install (ask if unset), then install:
+
+```bash
+memsearch config get plugins.codex.memory_to_skill.paths 2>/dev/null || echo "[]"
+memsearch skills install <name> --path .agents/skills
+```
+
+If the list is **empty**, background distillation is likely off or has not run.
+Offer the user a choice: capture from recent work now (**A**), distill from
+history (**C**), or enable the background pass (**D**).
+
+## C. Distill from history (0→1, model-driven)
 
 ```bash
 memsearch skills distill --plugin codex --force
 ```
 
-Then list again. Most runs add nothing — that is expected; the bar for a reusable
-skill is intentionally high.
+This is explicit, so it runs even if the background flag is off. It mines recent
+journals for workflows that recur at least `min_occurrences` times, writes them as
+candidates, and you then review/install via **B**. Most runs add nothing — the bar
+is intentionally high.
 
-## 4. Install a candidate
-
-Installing copies a candidate's current `SKILL.md` into one or more skill
-directories. Before installing you may review the candidate, inspect its history
-(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
-guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
-are committed and then snapshotted out.
-
-First resolve **where** to install:
+## D. Configure
 
 ```bash
-memsearch config get plugins.codex.memory_to_skill.paths 2>/dev/null || echo "[]"
+memsearch config get plugins.codex.memory_to_skill.enabled 2>/dev/null || echo "false"
+# enable the background pass (do not enable silently)
+memsearch config set plugins.codex.memory_to_skill.enabled true --project
+# how eagerly history-mining distils (default 3; lower = more eager)
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project
+# pre-set install targets (otherwise you are asked at install time)
+memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --project
 ```
 
-If this is empty (`[]`), **do not guess** — ask the user where to install, then
-persist their choice. Offer these options and explain the trade-off:
-- `.codex/skills` — **project-local (recommended)**: scoped to this repo; a skill
-  distilled from this project's memory is usually most relevant here.
-- `~/.codex/skills` — global: available across all your projects.
-- a custom path, or several paths (one skill can be installed to multiple dirs).
+Note: `enabled` only gates the **background** (session-end) pass. The explicit
+commands above (`skills add`, `skills distill`, `skills install`) always work.
 
-Note for cross-agent users, each agent reads skills from its own directory:
-Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
-and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
-**not** by Claude Code. To cover several agents, install to multiple paths.
+## Install paths
 
-Persist the chosen paths (example for project-local), then install:
+- `.agents/skills` — **project-local (recommended)**: a skill from this project's
+  memory is usually most relevant here.
+- `~/.agents/skills` — global: available across all your projects.
+- a custom path, or several (one skill can be installed to multiple dirs).
 
-```bash
-memsearch config set plugins.codex.memory_to_skill.paths '[".codex/skills"]' --project
-memsearch skills install <name> --path .codex/skills
-```
-
-`--path` is repeatable for multiple destinations. After installing, tell the user the
-installed location(s) and that the skill is now agent-visible.
+Each agent reads skills from its own directory: Claude Code `.claude/skills/`;
+Codex and OpenCode `.agents/skills/` (the shared standard, also read by Cursor
+etc.); OpenClaw `.openclaw/skills/`. Claude Code does **not** read `.agents/skills/`.
+Install to multiple paths to cover several agents.
 
 ## Guardrails
 
-- Never enable the feature, change install paths, or install a candidate without the
-  user's go-ahead.
-- Edit candidates only under the user's guidance, and only via the git-tracked store
-  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.
+- Never enable the feature, change install paths, or install a candidate without
+  the user's go-ahead.
+- Do not hand-edit the store; create candidates with `memsearch skills add` and let
+  the git-tracked store at `.memsearch/skill-candidates/` keep history.

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -1,109 +1,102 @@
 ---
 name: memory-to-skill
-description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenClaw own skills system."
+description: "Turn workflows from your MemSearch memory into reusable skills. Use when the user asks to make/create/extract/distill a skill from what they just did or from past work, review skill candidates, install a distilled skill, or 'turn this into a skill'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenClaw's own skills system."
 ---
 
-You manage MemSearch's **procedural memory**: candidate skills distilled from the
-project's memory journals. This is the third memory layer, alongside the daily
-journals (episodic) and PROJECT.md / USER.md (semantic).
+You manage MemSearch's **procedural memory**: skills distilled from the work you
+repeat — a third layer beside the daily journals (episodic) and PROJECT.md /
+USER.md (semantic). State once that this is MemSearch skill distillation, not
+OpenClaw's built-in skills system.
 
-State once in your summary that this is MemSearch skill distillation, not OpenClaw's
-built-in skills system. Do not repeat that on every line.
-
-Two stages, and you only ever drive the second one:
-- **Distill (automatic, background):** MemSearch watches recent journals and writes
-  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
-  evolving them there over time. Every entry — even ones already installed — stays
-  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
-- **Install (this skill, human-driven):** the user reviews a candidate and you copy
-  its current version into agent skill directories. Installing is the only path that
-  makes a skill agent-visible, and re-installing is how an installed skill gets
-  updated — the store keeps evolving; install takes a fresh snapshot.
+Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
+a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
+Candidates are never installed automatically; installing is always a human step.
 
 ## Intent routing
 
-Inspect the user's request:
-- No specific request, "what skills / review candidates" -> **List candidates**.
-- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
-- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+- "make/turn this into a skill", "from what we just did" → **A. Capture now**.
+- "what skills / review candidates / install X" → **B. Review & install**.
+- "mine my history / find recurring workflows" → **C. Distill from history**.
+- "enable / configure / how eager" → **D. Configure**.
+- Unclear or empty → run **B**'s `list`; if empty, offer A or C.
 
-## 1. Check the feature is enabled
+## A. Capture what you just did (0→1→2)
 
-```bash
-memsearch config get plugins.openclaw.memory_to_skill.enabled 2>/dev/null || echo "false"
-```
-
-If this is not `true`, background distillation is **off**. Tell the user, and offer
-to turn it on (do not enable it silently). On their confirmation:
-
-```bash
-memsearch config set plugins.openclaw.memory_to_skill.enabled true --project
-```
-
-Mention they can tune how eagerly skills are extracted with
-`plugins.openclaw.memory_to_skill.min_occurrences` (default 3 — how many times a
-workflow must recur before it becomes a candidate). Lower = more eager.
-
-## 2. List candidates
+You already have the context, so **draft the skill yourself** — do not call the
+background distiller for this. Write a SKILL.md **body** (markdown, no
+frontmatter): imperative numbered steps for the recurring task, concrete commands
+and paths, no secrets, self-contained. Then persist it as a candidate:
 
 ```bash
-memsearch skills list
+printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
+  --name "<short-slug>" \
+  --description "<what it does AND when it should trigger — lead with the verbs a user types>" \
+  --body-file -
 ```
 
-Show candidate names, status (candidate / installed), how often each recurred, and
-the one-line description. Use `memsearch skills list -j` for structured detail
-(sources, installed paths).
+`add` handles slugging, standard frontmatter, meta.json, and the git commit — no
+LLM is involved. Then show it to the user and install it (see **B**). Finally,
+check whether background distillation is on; if not, offer to enable it (so
+recurring workflows get captured automatically going forward) — do not force it.
 
-## 3. Distill on demand (optional)
+## B. Review & install candidates (1→2)
 
-If the user wants to extract right now rather than wait for the background pass:
+```bash
+memsearch skills list            # add -j for sources / installed paths
+```
+
+Pick one, resolve where to install (ask if unset), then install:
+
+```bash
+memsearch config get plugins.openclaw.memory_to_skill.paths 2>/dev/null || echo "[]"
+memsearch skills install <name> --path .openclaw/skills
+```
+
+If the list is **empty**, background distillation is likely off or has not run.
+Offer the user a choice: capture from recent work now (**A**), distill from
+history (**C**), or enable the background pass (**D**).
+
+## C. Distill from history (0→1, model-driven)
 
 ```bash
 memsearch skills distill --plugin openclaw --force
 ```
 
-Then list again. Most runs add nothing — that is expected; the bar for a reusable
-skill is intentionally high.
+This is explicit, so it runs even if the background flag is off. It mines recent
+journals for workflows that recur at least `min_occurrences` times, writes them as
+candidates, and you then review/install via **B**. Most runs add nothing — the bar
+is intentionally high.
 
-## 4. Install a candidate
-
-Installing copies a candidate's current `SKILL.md` into one or more skill
-directories. Before installing you may review the candidate, inspect its history
-(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
-guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
-are committed and then snapshotted out.
-
-First resolve **where** to install:
+## D. Configure
 
 ```bash
-memsearch config get plugins.openclaw.memory_to_skill.paths 2>/dev/null || echo "[]"
-```
-
-If this is empty (`[]`), **do not guess** — ask the user where to install, then
-persist their choice. Offer these options and explain the trade-off:
-- `.openclaw/skills` — **project-local (recommended)**: scoped to this repo; a skill
-  distilled from this project's memory is usually most relevant here.
-- `~/.openclaw/skills` — global: available across all your projects.
-- a custom path, or several paths (one skill can be installed to multiple dirs).
-
-Note for cross-agent users, each agent reads skills from its own directory:
-Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
-and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
-**not** by Claude Code. To cover several agents, install to multiple paths.
-
-Persist the chosen paths (example for project-local), then install:
-
-```bash
+memsearch config get plugins.openclaw.memory_to_skill.enabled 2>/dev/null || echo "false"
+# enable the background pass (do not enable silently)
+memsearch config set plugins.openclaw.memory_to_skill.enabled true --project
+# how eagerly history-mining distils (default 3; lower = more eager)
+memsearch config set plugins.openclaw.memory_to_skill.min_occurrences 3 --project
+# pre-set install targets (otherwise you are asked at install time)
 memsearch config set plugins.openclaw.memory_to_skill.paths '[".openclaw/skills"]' --project
-memsearch skills install <name> --path .openclaw/skills
 ```
 
-`--path` is repeatable for multiple destinations. After installing, tell the user the
-installed location(s) and that the skill is now agent-visible.
+Note: `enabled` only gates the **background** (session-end) pass. The explicit
+commands above (`skills add`, `skills distill`, `skills install`) always work.
+
+## Install paths
+
+- `.openclaw/skills` — **project-local (recommended)**: a skill from this project's
+  memory is usually most relevant here.
+- `~/.openclaw/skills` — global: available across all your projects.
+- a custom path, or several (one skill can be installed to multiple dirs).
+
+Each agent reads skills from its own directory: Claude Code `.claude/skills/`;
+Codex and OpenCode `.agents/skills/` (the shared standard, also read by Cursor
+etc.); OpenClaw `.openclaw/skills/`. Claude Code does **not** read `.agents/skills/`.
+Install to multiple paths to cover several agents.
 
 ## Guardrails
 
-- Never enable the feature, change install paths, or install a candidate without the
-  user's go-ahead.
-- Edit candidates only under the user's guidance, and only via the git-tracked store
-  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.
+- Never enable the feature, change install paths, or install a candidate without
+  the user's go-ahead.
+- Do not hand-edit the store; create candidates with `memsearch skills add` and let
+  the git-tracked store at `.memsearch/skill-candidates/` keep history.

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -43,7 +43,7 @@ echo ""
 
 # 3. Symlink skills to ~/.agents/skills/ (OpenCode-compatible)
 mkdir -p "${AGENTS_SKILLS_DIR}"
-for skill_name in memory-recall memory-config; do
+for skill_name in memory-recall memory-config memory-to-skill; do
   SKILL_LINK="${AGENTS_SKILLS_DIR}/${skill_name}"
   if [ -L "${SKILL_LINK}" ] || [ -d "${SKILL_LINK}" ]; then
     echo "[SKIP] Skill already exists at ${SKILL_LINK}"

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -1,109 +1,102 @@
 ---
 name: memory-to-skill
-description: "Turn recurring workflows in your MemSearch memory into reusable skills. Use when the user asks to create/extract/distill a skill from past work or memory, review skill candidates, install a distilled skill, or asks 'make a skill out of what we have been doing'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenCode own skills system."
+description: "Turn workflows from your MemSearch memory into reusable skills. Use when the user asks to make/create/extract/distill a skill from what they just did or from past work, review skill candidates, install a distilled skill, or 'turn this into a skill'. Manages MemSearch procedural-memory candidates under .memsearch/skill-candidates/, not OpenCode's own skills system."
 ---
 
-You manage MemSearch's **procedural memory**: candidate skills distilled from the
-project's memory journals. This is the third memory layer, alongside the daily
-journals (episodic) and PROJECT.md / USER.md (semantic).
+You manage MemSearch's **procedural memory**: skills distilled from the work you
+repeat — a third layer beside the daily journals (episodic) and PROJECT.md /
+USER.md (semantic). State once that this is MemSearch skill distillation, not
+OpenCode's built-in skills system.
 
-State once in your summary that this is MemSearch skill distillation, not OpenCode's
-built-in skills system. Do not repeat that on every line.
-
-Two stages, and you only ever drive the second one:
-- **Distill (automatic, background):** MemSearch watches recent journals and writes
-  *candidate* skills into `.memsearch/skill-candidates/` (a git repo), and keeps
-  evolving them there over time. Every entry — even ones already installed — stays
-  a perpetually-updated draft. You never edit that store blindly; it is git-tracked.
-- **Install (this skill, human-driven):** the user reviews a candidate and you copy
-  its current version into agent skill directories. Installing is the only path that
-  makes a skill agent-visible, and re-installing is how an installed skill gets
-  updated — the store keeps evolving; install takes a fresh snapshot.
+Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
+a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
+Candidates are never installed automatically; installing is always a human step.
 
 ## Intent routing
 
-Inspect the user's request:
-- No specific request, "what skills / review candidates" -> **List candidates**.
-- "make/extract/distill a skill now", "from what we just did" -> **Distill on demand**, then List.
-- "install / publish / turn X into a real skill / update the installed skill" -> **Install**.
+- "make/turn this into a skill", "from what we just did" → **A. Capture now**.
+- "what skills / review candidates / install X" → **B. Review & install**.
+- "mine my history / find recurring workflows" → **C. Distill from history**.
+- "enable / configure / how eager" → **D. Configure**.
+- Unclear or empty → run **B**'s `list`; if empty, offer A or C.
 
-## 1. Check the feature is enabled
+## A. Capture what you just did (0→1→2)
 
-```bash
-memsearch config get plugins.opencode.memory_to_skill.enabled 2>/dev/null || echo "false"
-```
-
-If this is not `true`, background distillation is **off**. Tell the user, and offer
-to turn it on (do not enable it silently). On their confirmation:
-
-```bash
-memsearch config set plugins.opencode.memory_to_skill.enabled true --project
-```
-
-Mention they can tune how eagerly skills are extracted with
-`plugins.opencode.memory_to_skill.min_occurrences` (default 3 — how many times a
-workflow must recur before it becomes a candidate). Lower = more eager.
-
-## 2. List candidates
+You already have the context, so **draft the skill yourself** — do not call the
+background distiller for this. Write a SKILL.md **body** (markdown, no
+frontmatter): imperative numbered steps for the recurring task, concrete commands
+and paths, no secrets, self-contained. Then persist it as a candidate:
 
 ```bash
-memsearch skills list
+printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
+  --name "<short-slug>" \
+  --description "<what it does AND when it should trigger — lead with the verbs a user types>" \
+  --body-file -
 ```
 
-Show candidate names, status (candidate / installed), how often each recurred, and
-the one-line description. Use `memsearch skills list -j` for structured detail
-(sources, installed paths).
+`add` handles slugging, standard frontmatter, meta.json, and the git commit — no
+LLM is involved. Then show it to the user and install it (see **B**). Finally,
+check whether background distillation is on; if not, offer to enable it (so
+recurring workflows get captured automatically going forward) — do not force it.
 
-## 3. Distill on demand (optional)
+## B. Review & install candidates (1→2)
 
-If the user wants to extract right now rather than wait for the background pass:
+```bash
+memsearch skills list            # add -j for sources / installed paths
+```
+
+Pick one, resolve where to install (ask if unset), then install:
+
+```bash
+memsearch config get plugins.opencode.memory_to_skill.paths 2>/dev/null || echo "[]"
+memsearch skills install <name> --path .agents/skills
+```
+
+If the list is **empty**, background distillation is likely off or has not run.
+Offer the user a choice: capture from recent work now (**A**), distill from
+history (**C**), or enable the background pass (**D**).
+
+## C. Distill from history (0→1, model-driven)
 
 ```bash
 memsearch skills distill --plugin opencode --force
 ```
 
-Then list again. Most runs add nothing — that is expected; the bar for a reusable
-skill is intentionally high.
+This is explicit, so it runs even if the background flag is off. It mines recent
+journals for workflows that recur at least `min_occurrences` times, writes them as
+candidates, and you then review/install via **B**. Most runs add nothing — the bar
+is intentionally high.
 
-## 4. Install a candidate
-
-Installing copies a candidate's current `SKILL.md` into one or more skill
-directories. Before installing you may review the candidate, inspect its history
-(`git -C .memsearch/skill-candidates log -- <name>/SKILL.md`), and — with the user's
-guidance — edit `.memsearch/skill-candidates/<name>/SKILL.md` to taste. Those edits
-are committed and then snapshotted out.
-
-First resolve **where** to install:
+## D. Configure
 
 ```bash
-memsearch config get plugins.opencode.memory_to_skill.paths 2>/dev/null || echo "[]"
-```
-
-If this is empty (`[]`), **do not guess** — ask the user where to install, then
-persist their choice. Offer these options and explain the trade-off:
-- `.agents/skills` — **project-local (recommended)**: scoped to this repo; a skill
-  distilled from this project's memory is usually most relevant here.
-- `~/.agents/skills` — global: available across all your projects.
-- a custom path, or several paths (one skill can be installed to multiple dirs).
-
-Note for cross-agent users, each agent reads skills from its own directory:
-Claude Code `.claude/skills/`, Codex `.codex/skills/`, OpenClaw `.openclaw/skills/`,
-and the shared `.agents/skills/` standard (read by OpenCode, Cursor, etc.) — but
-**not** by Claude Code. To cover several agents, install to multiple paths.
-
-Persist the chosen paths (example for project-local), then install:
-
-```bash
+memsearch config get plugins.opencode.memory_to_skill.enabled 2>/dev/null || echo "false"
+# enable the background pass (do not enable silently)
+memsearch config set plugins.opencode.memory_to_skill.enabled true --project
+# how eagerly history-mining distils (default 3; lower = more eager)
+memsearch config set plugins.opencode.memory_to_skill.min_occurrences 3 --project
+# pre-set install targets (otherwise you are asked at install time)
 memsearch config set plugins.opencode.memory_to_skill.paths '[".agents/skills"]' --project
-memsearch skills install <name> --path .agents/skills
 ```
 
-`--path` is repeatable for multiple destinations. After installing, tell the user the
-installed location(s) and that the skill is now agent-visible.
+Note: `enabled` only gates the **background** (session-end) pass. The explicit
+commands above (`skills add`, `skills distill`, `skills install`) always work.
+
+## Install paths
+
+- `.agents/skills` — **project-local (recommended)**: a skill from this project's
+  memory is usually most relevant here.
+- `~/.agents/skills` — global: available across all your projects.
+- a custom path, or several (one skill can be installed to multiple dirs).
+
+Each agent reads skills from its own directory: Claude Code `.claude/skills/`;
+Codex and OpenCode `.agents/skills/` (the shared standard, also read by Cursor
+etc.); OpenClaw `.openclaw/skills/`. Claude Code does **not** read `.agents/skills/`.
+Install to multiple paths to cover several agents.
 
 ## Guardrails
 
-- Never enable the feature, change install paths, or install a candidate without the
-  user's go-ahead.
-- Edit candidates only under the user's guidance, and only via the git-tracked store
-  at `.memsearch/skill-candidates/`. History (and revert) is available via git there.
+- Never enable the feature, change install paths, or install a candidate without
+  the user's go-ahead.
+- Do not hand-edit the store; create candidates with `memsearch skills add` and let
+  the git-tracked store at `.memsearch/skill-candidates/` keep history.

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1042,31 +1042,56 @@ def config_list(mode: str) -> None:
 
 @cli.group("skills")
 def skills_group() -> None:
-    """Distill, list, and install candidate skills from memory (procedural memory)."""
+    """Distill, capture, list, and install candidate skills from memory (procedural memory)."""
 
 
 @skills_group.command("distill")
 @click.option("--plugin", required=True, help="Plugin platform name (claude-code, codex, opencode, openclaw).")
 @click.option("--force", is_flag=True, help="Run even if input is unchanged or not yet due.")
 def skills_distill(plugin: str, force: bool) -> None:
-    """Distill candidate skills from recent memory journals."""
+    """Mine recent memory journals for recurring workflows (model-driven).
+
+    This is an explicit invocation, so it runs regardless of the
+    ``memory_to_skill.enabled`` flag (which only gates the background pass).
+    """
     from . import skills as skills_mod
 
     cfg = _safe_resolve_config()
-    result = skills_mod.distill(platform=plugin, cfg=cfg, force=force)
-    if result.action == "disabled":
-        click.echo(
-            f"memory_to_skill is disabled for {plugin!r}. "
-            f"Enable with: memsearch config set plugins.{plugin}.memory_to_skill.enabled true --project"
-        )
-        return
+    result = skills_mod.distill(platform=plugin, cfg=cfg, force=force, require_enabled=False)
     if result.skipped:
         click.echo(f"Skipped: {result.reason or result.action}")
         return
-    if result.created:
-        click.echo(f"Distilled {len(result.created)} candidate skill(s): {', '.join(result.created)}")
+    changed = result.created + result.updated
+    if changed:
+        click.echo(f"Distilled {len(changed)} candidate skill(s): {', '.join(changed)}")
     else:
         click.echo("No new candidate skills.")
+
+
+@skills_group.command("add")
+@click.option("--name", required=True, help="Skill name (slugified to the command and directory name).")
+@click.option("--description", required=True, help="One line: what the skill does and when it should trigger.")
+@click.option(
+    "--body-file",
+    required=True,
+    type=click.File("r"),
+    help="File containing the SKILL.md body (markdown, no frontmatter). Use - for stdin.",
+)
+def skills_add(name: str, description: str, body_file) -> None:
+    """Persist an agent-drafted skill as a candidate (manual capture path).
+
+    The agent supplies the content; this writes a structurally-correct candidate
+    (frontmatter, meta.json, git commit) without any LLM call.
+    """
+    from . import skills as skills_mod
+
+    try:
+        slug = skills_mod.add(name, description, body_file.read())
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1) from None
+    click.echo(f"Added candidate skill: {slug}")
+    click.echo(f"Install it with: memsearch skills install {slug} --path <dir>")
 
 
 @skills_group.command("list")

--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -37,9 +37,13 @@ from .maintenance import (
     _is_due,
     _load_state,
     _read_recent_journals,
+    _resolve_task_path,
     _save_state,
     run_task_llm,
 )
+
+# Cap each existing skill body included in the revision prompt, to bound size.
+MAX_EXISTING_BODY_CHARS = 2000
 
 TASK = "memory_to_skill"
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
@@ -94,6 +98,34 @@ def _slugify(name: str) -> str:
     return slug or "skill"
 
 
+def _skill_body(skill_md: str) -> str:
+    """Return the markdown body of a SKILL.md, stripping YAML frontmatter."""
+    if skill_md.startswith("---"):
+        parts = skill_md.split("---", 2)
+        if len(parts) == 3:
+            return parts[2].strip()
+    return skill_md.strip()
+
+
+def _render_existing_block(root: Path, existing: list[dict[str, Any]]) -> str:
+    """Render existing skills with their current bodies, so revisions improve
+    the current version rather than rewriting it blindly from recent logs."""
+    if not existing:
+        return "(none)"
+    blocks: list[str] = []
+    for m in existing:
+        name = m.get("name", "")
+        desc = m.get("description", "")
+        body = ""
+        skill_md = root / str(name) / "SKILL.md"
+        if skill_md.is_file():
+            body = _skill_body(skill_md.read_text(encoding="utf-8"))
+            if len(body) > MAX_EXISTING_BODY_CHARS:
+                body = body[:MAX_EXISTING_BODY_CHARS] + "\n…[truncated]"
+        blocks.append(f"### {name}\n{desc}\n\nCurrent body:\n```markdown\n{body}\n```")
+    return "\n\n".join(blocks)
+
+
 def _load_template(cfg: MemSearchConfig | None = None) -> str:
     # User/plugin override first (same mechanism as project_review / user_profile),
     # then the packaged default.
@@ -118,7 +150,7 @@ def _build_distill_prompt(
     }.items():
         template = template.replace(marker, value)
 
-    existing_block = "\n".join(f"- {m.get('name')}: {m.get('description', '')}" for m in existing) or "(none)"
+    existing_block = _render_existing_block(skills_root(ctx.memsearch_dir), existing)
     journals = _read_recent_journals(ctx.input_dir)
     prompt = f"""{template}
 
@@ -287,21 +319,28 @@ def distill(
     memsearch_dir: str | Path | None = None,
     cfg: MemSearchConfig | None = None,
     force: bool = False,
+    require_enabled: bool = True,
     llm_runner: Callable[[TaskContext, str], str] | None = None,
 ) -> DistillResult:
-    """Distill candidate skills from recent journals if the task is due."""
+    """Distill candidate skills from recent journals if the task is due.
+
+    *require_enabled* controls whether the ``enabled`` flag gates this run. The
+    session-end background runner passes ``True`` (so disabling the task stops
+    surprise background calls); an explicit CLI invocation passes ``False``,
+    since an explicit request is never a surprise.
+    """
     if cfg is None:
         from .config import resolve_config
 
         cfg = resolve_config()
 
-    task_cfg = _get_task_config(cfg, platform)
-    if task_cfg is None or not task_cfg.enabled:
+    task_cfg = _get_task_config(cfg, platform) or PluginMemoryToSkillConfig()
+    if require_enabled and not task_cfg.enabled:
         return DistillResult(action="disabled", skipped=True)
 
     project_root, mem_root = resolve_roots(project_dir, memsearch_dir)
     mem_root.mkdir(parents=True, exist_ok=True)
-    input_dir = (mem_root / "memory").resolve()
+    input_dir = _resolve_task_path(task_cfg.input_dir or str(mem_root / "memory"), project_root, mem_root)
 
     state_path = mem_root / ".maintenance-state.json"
     state = _load_state(state_path)
@@ -366,6 +405,37 @@ def distill(
         _save_state(state_path, state)
 
     return DistillResult(action="distilled" if changed else "none", created=created, updated=updated)
+
+
+def add(
+    name: str,
+    description: str,
+    body: str,
+    *,
+    project_dir: str | Path | None = None,
+    memsearch_dir: str | Path | None = None,
+) -> str:
+    """Persist a caller-provided skill as a candidate (manual capture path).
+
+    Used when a live agent has already drafted a skill from what the user just
+    did — the agent supplies the content and this only handles slugging,
+    standard frontmatter, the meta.json schema, and the git commit, so a
+    manually captured candidate is structurally identical to a distilled one.
+    Returns the slugified candidate name. No LLM and no provider config needed.
+    """
+    if not description.strip() or not body.strip():
+        raise ValueError("a skill needs both a description and a body")
+
+    _project_root, mem_root = resolve_roots(project_dir, memsearch_dir)
+    root = skills_root(mem_root)
+    _ensure_git(root)
+    slug = _slugify(name)
+    outcome = _write_candidate(
+        root,
+        {"name": slug, "description": description.strip(), "body": body.strip(), "sources": [], "reason": "manual"},
+    )
+    _git_commit(root, f"add: {outcome} candidate skill {slug} (manual)")
+    return slug
 
 
 def install(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -254,3 +254,81 @@ def test_config_set_paths_parses_json_list(tmp_path: Path, monkeypatch) -> None:
     )
     data = load_config_file(PROJECT_CONFIG_PATH)
     assert data["plugins"]["claude-code"]["memory_to_skill"]["paths"] == [".claude/skills", "~/.codex/skills"]
+
+
+def test_add_persists_candidate_without_llm(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    slug = skills_mod.add(
+        "My Deploy Flow", "Deploy to staging. Use when asked to deploy.", "## Deploy\n\n1. push", project_dir=project
+    )
+
+    assert slug == "my-deploy-flow"
+    skill_dir = project / ".memsearch" / "skill-candidates" / "my-deploy-flow"
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8").startswith("---\nname: my-deploy-flow\n")
+    meta = json.loads((skill_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta["status"] == "candidate"
+    assert (project / ".memsearch" / "skill-candidates" / ".git").is_dir()
+
+
+def test_add_rejects_empty_body(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="description and a body"):
+        skills_mod.add("x", "desc", "   ", project_dir=tmp_path)
+
+
+def test_distill_runs_when_disabled_if_require_enabled_false(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()  # memory_to_skill disabled by default
+
+    result = skills_mod.distill(
+        platform="claude-code", project_dir=project, cfg=cfg, require_enabled=False, llm_runner=_one_skill_runner()
+    )
+
+    assert result.action == "distilled"
+    assert result.created == ["run-tests"]
+
+
+def test_distill_honors_custom_input_dir(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)  # default location, with different content
+    custom = tmp_path / "journals"
+    custom.mkdir()
+    (custom / "2026-06-13.md").write_text("### 11:00\n- CUSTOM-INPUT-DIR marker.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    _enable(cfg)
+    cfg.plugins.claude_code.memory_to_skill.input_dir = str(custom)
+
+    captured = {}
+
+    def runner(ctx, prompt: str) -> str:
+        captured["prompt"] = prompt
+        return json.dumps({"skills": []})
+
+    skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=runner)
+    assert "CUSTOM-INPUT-DIR marker" in captured["prompt"]
+
+
+def test_revision_prompt_includes_current_body(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    skills_mod.distill(
+        platform="claude-code",
+        project_dir=project,
+        cfg=cfg,
+        llm_runner=_body_runner("## v1 body\n\n1. UNIQUE-OLD-STEP"),
+    )
+
+    captured = {}
+
+    def checking_runner(ctx, prompt: str) -> str:
+        captured["prompt"] = prompt
+        return json.dumps({"skills": []})
+
+    skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, force=True, llm_runner=checking_runner)
+    # The model must see the current body when revising, not just name/description.
+    assert "UNIQUE-OLD-STEP" in captured["prompt"]


### PR DESCRIPTION
Follow-up to #575, addressing review findings.

## Fixes

1. **Install scripts now install `memory-to-skill`.** The Codex and OpenCode install scripts only copied `memory-recall` and `memory-config`, so source-install users had no entry point to the feature. Added it to both (copy, path config, summary output).

2. **Codex uses `.agents/skills`, not `.codex/skills`.** Our own Codex/OpenCode install scripts install skills to `.agents/skills`, and that is what those agents read. Fixed the install-path examples and the cross-agent notes in the skill files, plus the docs and README.

3. **`distill` honors `input_dir`.** It hardcoded `.memsearch/memory` and ignored the configured `input_dir`; it now resolves the configured path the same way the maintenance tasks do.

4. **Revisions see the current body.** The revision prompt only included each existing skill's name/description while the writer overwrote the body, so a revision could regress a mature candidate. The current body is now included in the prompt (truncated), so revisions improve rather than rewrite blindly.

5. **Manual capture no longer requires enabling the background pass.** The `enabled` flag now gates only the background (session-end) run; explicit `memsearch skills distill` runs regardless. A new `memsearch skills add` lets a live agent persist a skill it drafted from the current session — no LLM call and no provider config, since generation already happened in the agent. The `/memory-to-skill` skill is rewritten with intent routing: capture what you just did, review & install candidates, distill from history on demand, or configure the background pass.

## Docs

- `docs/home/skills-from-memory.md` rewritten to explain the two ways candidates are created (background mining vs manual capture), that only generation uses a model, and the per-agent install directories (corrected Codex).
- `configuration.md` and README updated accordingly.

## Testing

- `tests/test_skills.py`: added coverage for `add`, `require_enabled`, `input_dir`, and that the revision prompt includes the current body.
- Full suite passes; `ruff check`/`format --check` clean on `src/`+`tests/`; `mkdocs build --strict` passes.
