### PR TITLE
fix: do not run native skill distillation from the bare CLI

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -192,7 +192,8 @@ changes from natural-language requests.
 A third maintenance task, `memory_to_skill`, distills recurring workflows into
 reusable agent skills. The `enabled` flag here gates only the **background**
 mining pass (disabled by default, to avoid surprise background model calls);
-manual capture and explicit `memsearch skills distill` work regardless. It shares
+on-demand capture and mining via the `/memory-to-skill` skill work regardless
+(they run in the live agent). It shares
 the maintenance tasks' provider/model routing, prompt override
 (`prompts.memory_to_skill`), `input_dir`, and `min_interval_hours` cadence.
 

--- a/docs/home/skills-from-memory.md
+++ b/docs/home/skills-from-memory.md
@@ -45,10 +45,13 @@ skill out of what we just did"*, the **live agent you are talking to** drafts th
 no recurrence threshold (your explicit request is the signal, so even a one-off is
 fine). It persists the result with `memsearch skills add`, which only handles the
 slug, standard frontmatter, `meta.json`, and the git commit. This path is **not**
-gated by `enabled` — an explicit request is never a surprise.
+gated by `enabled` — an explicit request is never a surprise. The same skill can
+also mine *past* work on demand: it reads the journals and persists what recurs
+with `skills add`, again entirely in the agent.
 
-You can also run the model-driven mining yourself at any time with `memsearch
-skills distill` (also ungated, since it is explicit).
+The `memsearch skills distill` CLI runs the model-driven mining standalone, but it
+needs an **API provider** — the default `native` provider drives the host agent
+and only works from the background pass, not as a bare CLI call.
 
 ## Install (1 → 2, always manual)
 

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -58,16 +58,17 @@ If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
 history (**C**), or enable the background pass (**D**).
 
-## C. Distill from history (0→1, model-driven)
+## C. Mine history for recurring workflows (0→1)
 
-```bash
-memsearch skills distill --plugin claude-code --force
-```
+To pull skills out of past work (not just the current session), read the recent
+journals yourself — they live in `.memsearch/memory/*.md` — and look for
+multi-step procedures that recur across several sessions. Draft each genuinely
+reusable one and persist it with `memsearch skills add` (one call per skill), the
+same way as **A**. Use your own judgment: only propose procedures that recur and
+generalize, not one-offs from a single day.
 
-This is explicit, so it runs even if the background flag is off. It mines recent
-journals for workflows that recur at least `min_occurrences` times, writes them as
-candidates, and you then review/install via **B**. Most runs add nothing — the bar
-is intentionally high.
+The background pass does this automatically when enabled; doing it here on demand
+uses your own reasoning and needs no provider configuration.
 
 ## D. Configure
 
@@ -82,7 +83,7 @@ memsearch config set plugins.claude-code.memory_to_skill.paths '[".claude/skills
 ```
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
-commands above (`skills add`, `skills distill`, `skills install`) always work.
+commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.
 
 ## Install paths
 

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -56,16 +56,17 @@ If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
 history (**C**), or enable the background pass (**D**).
 
-## C. Distill from history (0→1, model-driven)
+## C. Mine history for recurring workflows (0→1)
 
-```bash
-memsearch skills distill --plugin codex --force
-```
+To pull skills out of past work (not just the current session), read the recent
+journals yourself — they live in `.memsearch/memory/*.md` — and look for
+multi-step procedures that recur across several sessions. Draft each genuinely
+reusable one and persist it with `memsearch skills add` (one call per skill), the
+same way as **A**. Use your own judgment: only propose procedures that recur and
+generalize, not one-offs from a single day.
 
-This is explicit, so it runs even if the background flag is off. It mines recent
-journals for workflows that recur at least `min_occurrences` times, writes them as
-candidates, and you then review/install via **B**. Most runs add nothing — the bar
-is intentionally high.
+The background pass does this automatically when enabled; doing it here on demand
+uses your own reasoning and needs no provider configuration.
 
 ## D. Configure
 
@@ -80,7 +81,7 @@ memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --
 ```
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
-commands above (`skills add`, `skills distill`, `skills install`) always work.
+commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.
 
 ## Install paths
 

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -56,16 +56,17 @@ If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
 history (**C**), or enable the background pass (**D**).
 
-## C. Distill from history (0→1, model-driven)
+## C. Mine history for recurring workflows (0→1)
 
-```bash
-memsearch skills distill --plugin openclaw --force
-```
+To pull skills out of past work (not just the current session), read the recent
+journals yourself — they live in `.memsearch/memory/*.md` — and look for
+multi-step procedures that recur across several sessions. Draft each genuinely
+reusable one and persist it with `memsearch skills add` (one call per skill), the
+same way as **A**. Use your own judgment: only propose procedures that recur and
+generalize, not one-offs from a single day.
 
-This is explicit, so it runs even if the background flag is off. It mines recent
-journals for workflows that recur at least `min_occurrences` times, writes them as
-candidates, and you then review/install via **B**. Most runs add nothing — the bar
-is intentionally high.
+The background pass does this automatically when enabled; doing it here on demand
+uses your own reasoning and needs no provider configuration.
 
 ## D. Configure
 
@@ -80,7 +81,7 @@ memsearch config set plugins.openclaw.memory_to_skill.paths '[".openclaw/skills"
 ```
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
-commands above (`skills add`, `skills distill`, `skills install`) always work.
+commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.
 
 ## Install paths
 

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -56,16 +56,17 @@ If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
 history (**C**), or enable the background pass (**D**).
 
-## C. Distill from history (0→1, model-driven)
+## C. Mine history for recurring workflows (0→1)
 
-```bash
-memsearch skills distill --plugin opencode --force
-```
+To pull skills out of past work (not just the current session), read the recent
+journals yourself — they live in `.memsearch/memory/*.md` — and look for
+multi-step procedures that recur across several sessions. Draft each genuinely
+reusable one and persist it with `memsearch skills add` (one call per skill), the
+same way as **A**. Use your own judgment: only propose procedures that recur and
+generalize, not one-offs from a single day.
 
-This is explicit, so it runs even if the background flag is off. It mines recent
-journals for workflows that recur at least `min_occurrences` times, writes them as
-candidates, and you then review/install via **B**. Most runs add nothing — the bar
-is intentionally high.
+The background pass does this automatically when enabled; doing it here on demand
+uses your own reasoning and needs no provider configuration.
 
 ## D. Configure
 
@@ -80,7 +81,7 @@ memsearch config set plugins.opencode.memory_to_skill.paths '[".agents/skills"]'
 ```
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
-commands above (`skills add`, `skills distill`, `skills install`) always work.
+commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.
 
 ## Install paths
 

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1049,14 +1049,27 @@ def skills_group() -> None:
 @click.option("--plugin", required=True, help="Plugin platform name (claude-code, codex, opencode, openclaw).")
 @click.option("--force", is_flag=True, help="Run even if input is unchanged or not yet due.")
 def skills_distill(plugin: str, force: bool) -> None:
-    """Mine recent memory journals for recurring workflows (model-driven).
+    """Mine recent memory journals for recurring workflows using a configured API provider.
 
     This is an explicit invocation, so it runs regardless of the
     ``memory_to_skill.enabled`` flag (which only gates the background pass).
+    Requires an API provider: the default ``native`` provider drives the host
+    agent and only works from the background pass — for on-demand mining, use the
+    ``/memory-to-skill`` skill, which reasons over the journals directly.
     """
     from . import skills as skills_mod
 
     cfg = _safe_resolve_config()
+    task_cfg = skills_mod._get_task_config(cfg, plugin)
+    provider = ((task_cfg.provider if task_cfg else "") or "native").strip()
+    if provider == "native":
+        click.echo(
+            "Standalone 'skills distill' needs an API provider; the default 'native' provider only works "
+            "via the background pass. For on-demand mining use the /memory-to-skill skill, or configure a "
+            f"provider, e.g.: memsearch config set plugins.{plugin}.memory_to_skill.provider <name> --project",
+            err=True,
+        )
+        raise SystemExit(2)
     result = skills_mod.distill(platform=plugin, cfg=cfg, force=force, require_enabled=False)
     if result.skipped:
         click.echo(f"Skipped: {result.reason or result.action}")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -332,3 +332,18 @@ def test_revision_prompt_includes_current_body(tmp_path: Path) -> None:
     skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, force=True, llm_runner=checking_runner)
     # The model must see the current body when revising, not just name/description.
     assert "UNIQUE-OLD-STEP" in captured["prompt"]
+
+
+def test_cli_distill_native_gives_guidance_not_crash(monkeypatch) -> None:
+    from click.testing import CliRunner
+
+    from memsearch import cli as cli_module
+    from memsearch.cli import cli
+
+    # Default config => native provider; standalone CLI distill cannot run native.
+    monkeypatch.setattr(cli_module, "resolve_config", lambda *_a, **_k: MemSearchConfig())
+    result = CliRunner().invoke(cli, ["skills", "distill", "--plugin", "codex"])
+
+    assert result.exit_code == 2
+    assert "needs an API provider" in result.stderr
+    assert "Native maintenance providers" not in (result.stderr + result.output)  # no raw traceback


### PR DESCRIPTION
Follow-up to #575 / #576.

## Problem

`memsearch skills distill --plugin codex --force` crashed by default. The standalone CLI calls the package `distill()` with no `llm_runner`, so the default `native` provider hit `run_task_llm`'s guard: `RuntimeError: Native maintenance providers must be handled by the plugin runner`. Worse, the `/memory-to-skill` skill told the agent to run exactly that command, so every native user (anyone without a configured API provider) broke on the "mine history" path.

## Why

Native generation means "drive the host agent" (`claude -p` / `codex exec`), and that invocation lives in the plugin layer, not the package — by design. The `project_review` / `user_profile` maintenance tasks never hit this because they are background-only: their sole caller is the plugin runner, which always supplies a native-capable `llm_runner`. `skills distill` was a new package-level CLI caller that bypassed that.

## Fix

- **On-demand mining runs in the live agent.** The `/memory-to-skill` skill now reads the journals itself and persists recurring workflows with `memsearch skills add` — the same agent-driven path as capturing what you just did — instead of shelling out to `skills distill`. This uses the agent already in the session (richest context, no redundant subprocess) and needs no provider config.
- **`skills distill` fails gracefully for native.** It still works for configured API providers; with the default `native` provider it now prints clear guidance and exits 2 instead of raising a traceback.
- Docs updated to say on-demand capture/mining happen in the agent, and that the standalone `skills distill` CLI needs an API provider.

## Testing

- New `test_cli_distill_native_gives_guidance_not_crash`.
- Full suite passes; `ruff check`/`format --check` clean; `mkdocs build --strict` passes; CLI smoke-tested (graceful message, exit 2).
