### PR TITLE
Bump versions for 0.4.8 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.7"
+version = "0.4.8"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -75,7 +75,7 @@ def skills_root(mem_root: Path) -> Path:
 
     Named ``skill-candidates`` (not ``skills``) so a human browsing the project
     does not mistake these evolving drafts for the live, installed skills under
-    ``.claude/skills`` / ``.codex/skills`` / ``.agents/skills``.
+    ``.claude/skills`` / ``.agents/skills`` / ``.openclaw/skills``.
     """
     return mem_root / "skill-candidates"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump memsearch to 0.4.8 for the patch release.
- Bump plugin package versions for OpenClaw and OpenCode.
- Align marketplace metadata and correct the skill candidate directory docstring.

## Tests
- uv run python -m pytest
- uv build --out-dir /tmp/memsearch-dist-v0.4.8
- npm pack --dry-run