### PR TITLE
fix: reduce hallucination in distilled skills

### DIFF
--- a/docs/home/skills-from-memory.md
+++ b/docs/home/skills-from-memory.md
@@ -39,6 +39,11 @@ candidates. It is deliberately conservative — most runs distil nothing — bec
 it is unattended. This path is gated by `enabled` (off by default) to avoid
 surprise background model calls.
 
+The background pass only sees the journals, which are **lossy summaries**, and it
+is sandboxed away from the original transcripts — so it is told to capture only
+what the summaries state and not to invent exact commands. For higher-fidelity
+skills, prefer on-demand capture below, which can read the originals.
+
 **2. Manual capture (on demand, agent-driven).** When you tell the agent *"make a
 skill out of what we just did"*, the **live agent you are talking to** drafts the
 `SKILL.md` from its own context — no separate model call, no provider config, and
@@ -46,8 +51,10 @@ no recurrence threshold (your explicit request is the signal, so even a one-off 
 fine). It persists the result with `memsearch skills add`, which only handles the
 slug, standard frontmatter, `meta.json`, and the git commit. This path is **not**
 gated by `enabled` — an explicit request is never a surprise. The same skill can
-also mine *past* work on demand: it reads the journals and persists what recurs
-with `skills add`, again entirely in the agent.
+also mine *past* work on demand: it reads the journals, **opens the original
+transcripts** referenced by each journal anchor to confirm the exact commands and
+paths (avoiding the hallucinated detail the summary-only background pass can
+produce), and persists what recurs with `skills add` — all in the agent.
 
 The `memsearch skills distill` CLI runs the model-driven mining standalone, but it
 needs an **API provider** — the default `native` provider drives the host agent

--- a/plugins/_shared/prompts/memory_to_skill.txt
+++ b/plugins/_shared/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 

--- a/plugins/claude-code/prompts/memory_to_skill.txt
+++ b/plugins/claude-code/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -27,7 +27,9 @@ Candidates are never installed automatically; installing is always a human step.
 You already have the context, so **draft the skill yourself** — do not call the
 background distiller for this. Write a SKILL.md **body** (markdown, no
 frontmatter): imperative numbered steps for the recurring task, concrete commands
-and paths, no secrets, self-contained. Then persist it as a candidate:
+and paths, no secrets, self-contained.
+
+**Be exact — do not guess.** You have the live session for what you just did, so use the real commands, paths, and output, not approximations. If a detail is uncertain, verify it (re-read the relevant files or the transcript) or keep that step general — a wrong command is worse than a vague one. Then persist it as a candidate:
 
 ```bash
 printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
@@ -46,6 +48,8 @@ recurring workflows get captured automatically going forward) — do not force i
 ```bash
 memsearch skills list            # add -j for sources / installed paths
 ```
+
+Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 
 Pick one, resolve where to install (ask if unset), then install:
 
@@ -67,8 +71,9 @@ reusable one and persist it with `memsearch skills add` (one call per skill), th
 same way as **A**. Use your own judgment: only propose procedures that recur and
 generalize, not one-offs from a single day.
 
-The background pass does this automatically when enabled; doing it here on demand
-uses your own reasoning and needs no provider configuration.
+**Drill into the original transcript before drafting.** The journal bullets are a lossy summary — writing a skill from them alone produces plausible-but-wrong steps. Each journal entry carries an anchor comment `<!-- session:<id> turn:<id> transcript:<file> -->` (the file may be named `rollout:` or `db:` on some agents). For each workflow you pick, open that file and read the turns around the `turn:` id to recover the exact commands, flags, paths, and outputs, then write the skill from that. If you cannot open it or confirm a detail, keep that step general or omit it — never fabricate.
+
+The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
 
 ## D. Configure
 

--- a/plugins/codex/prompts/memory_to_skill.txt
+++ b/plugins/codex/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -25,7 +25,9 @@ Candidates are never installed automatically; installing is always a human step.
 You already have the context, so **draft the skill yourself** — do not call the
 background distiller for this. Write a SKILL.md **body** (markdown, no
 frontmatter): imperative numbered steps for the recurring task, concrete commands
-and paths, no secrets, self-contained. Then persist it as a candidate:
+and paths, no secrets, self-contained.
+
+**Be exact — do not guess.** You have the live session for what you just did, so use the real commands, paths, and output, not approximations. If a detail is uncertain, verify it (re-read the relevant files or the transcript) or keep that step general — a wrong command is worse than a vague one. Then persist it as a candidate:
 
 ```bash
 printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
@@ -44,6 +46,8 @@ recurring workflows get captured automatically going forward) — do not force i
 ```bash
 memsearch skills list            # add -j for sources / installed paths
 ```
+
+Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 
 Pick one, resolve where to install (ask if unset), then install:
 
@@ -65,8 +69,9 @@ reusable one and persist it with `memsearch skills add` (one call per skill), th
 same way as **A**. Use your own judgment: only propose procedures that recur and
 generalize, not one-offs from a single day.
 
-The background pass does this automatically when enabled; doing it here on demand
-uses your own reasoning and needs no provider configuration.
+**Drill into the original transcript before drafting.** The journal bullets are a lossy summary — writing a skill from them alone produces plausible-but-wrong steps. Each journal entry carries an anchor comment `<!-- session:<id> turn:<id> transcript:<file> -->` (the file may be named `rollout:` or `db:` on some agents). For each workflow you pick, open that file and read the turns around the `turn:` id to recover the exact commands, flags, paths, and outputs, then write the skill from that. If you cannot open it or confirm a detail, keep that step general or omit it — never fabricate.
+
+The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
 
 ## D. Configure
 

--- a/plugins/openclaw/prompts/memory_to_skill.txt
+++ b/plugins/openclaw/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -25,7 +25,9 @@ Candidates are never installed automatically; installing is always a human step.
 You already have the context, so **draft the skill yourself** — do not call the
 background distiller for this. Write a SKILL.md **body** (markdown, no
 frontmatter): imperative numbered steps for the recurring task, concrete commands
-and paths, no secrets, self-contained. Then persist it as a candidate:
+and paths, no secrets, self-contained.
+
+**Be exact — do not guess.** You have the live session for what you just did, so use the real commands, paths, and output, not approximations. If a detail is uncertain, verify it (re-read the relevant files or the transcript) or keep that step general — a wrong command is worse than a vague one. Then persist it as a candidate:
 
 ```bash
 printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
@@ -44,6 +46,8 @@ recurring workflows get captured automatically going forward) — do not force i
 ```bash
 memsearch skills list            # add -j for sources / installed paths
 ```
+
+Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 
 Pick one, resolve where to install (ask if unset), then install:
 
@@ -65,8 +69,9 @@ reusable one and persist it with `memsearch skills add` (one call per skill), th
 same way as **A**. Use your own judgment: only propose procedures that recur and
 generalize, not one-offs from a single day.
 
-The background pass does this automatically when enabled; doing it here on demand
-uses your own reasoning and needs no provider configuration.
+**Drill into the original transcript before drafting.** The journal bullets are a lossy summary — writing a skill from them alone produces plausible-but-wrong steps. Each journal entry carries an anchor comment `<!-- session:<id> turn:<id> transcript:<file> -->` (the file may be named `rollout:` or `db:` on some agents). For each workflow you pick, open that file and read the turns around the `turn:` id to recover the exact commands, flags, paths, and outputs, then write the skill from that. If you cannot open it or confirm a detail, keep that step general or omit it — never fabricate.
+
+The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
 
 ## D. Configure
 

--- a/plugins/opencode/prompts/memory_to_skill.txt
+++ b/plugins/opencode/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -25,7 +25,9 @@ Candidates are never installed automatically; installing is always a human step.
 You already have the context, so **draft the skill yourself** — do not call the
 background distiller for this. Write a SKILL.md **body** (markdown, no
 frontmatter): imperative numbered steps for the recurring task, concrete commands
-and paths, no secrets, self-contained. Then persist it as a candidate:
+and paths, no secrets, self-contained.
+
+**Be exact — do not guess.** You have the live session for what you just did, so use the real commands, paths, and output, not approximations. If a detail is uncertain, verify it (re-read the relevant files or the transcript) or keep that step general — a wrong command is worse than a vague one. Then persist it as a candidate:
 
 ```bash
 printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
@@ -44,6 +46,8 @@ recurring workflows get captured automatically going forward) — do not force i
 ```bash
 memsearch skills list            # add -j for sources / installed paths
 ```
+
+Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 
 Pick one, resolve where to install (ask if unset), then install:
 
@@ -65,8 +69,9 @@ reusable one and persist it with `memsearch skills add` (one call per skill), th
 same way as **A**. Use your own judgment: only propose procedures that recur and
 generalize, not one-offs from a single day.
 
-The background pass does this automatically when enabled; doing it here on demand
-uses your own reasoning and needs no provider configuration.
+**Drill into the original transcript before drafting.** The journal bullets are a lossy summary — writing a skill from them alone produces plausible-but-wrong steps. Each journal entry carries an anchor comment `<!-- session:<id> turn:<id> transcript:<file> -->` (the file may be named `rollout:` or `db:` on some agents). For each workflow you pick, open that file and read the turns around the `turn:` id to recover the exact commands, flags, paths, and outputs, then write the skill from that. If you cannot open it or confirm a detail, keep that step general or omit it — never fabricate.
+
+The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
 
 ## D. Configure
 

--- a/src/memsearch/prompts/memory_to_skill.txt
+++ b/src/memsearch/prompts/memory_to_skill.txt
@@ -53,6 +53,17 @@ How to write a good skill body (this is what makes the skill usable):
 - The "description" is the trigger signal — if it does not name the situation and
   the verbs a user would type, the skill will never fire. Spend care on it.
 
+Accuracy — do not hallucinate:
+- The journal entries are LOSSY SUMMARIES of the original conversations, not the
+  full detail. You are working from summaries only.
+- Capture only commands, flags, paths, and steps that the summaries actually state.
+  Do NOT invent or guess specifics that are not present — a plausible-but-wrong
+  command is worse than none.
+- When a detail is not in the journals, keep that step general (describe the intent)
+  or leave it out, rather than fabricating an exact command.
+- Prefer fewer, correct steps over a complete-looking but partly-invented procedure.
+  If a workflow cannot be captured accurately from the summaries, omit it.
+
 JSON examples:
 {"skills":[]}
 


### PR DESCRIPTION
Follow-up to #575/#576/#577.

## Problem

Distilled skills often had wrong commands/paths. The daily journals are **lossy summaries** of the original conversations (each entry is a few bullets plus an anchor `<!-- session:… turn:… transcript:<file> -->`), so a skill written from the summary alone tends to be plausible but hallucinated.

Only the **live-agent** path can reach the original transcripts: the background/CLI distill tool is sandboxed to `project / .memsearch` and transcripts live under `~/.claude/projects/…` (outside those roots), and native runs with no tools at all. So fidelity has to come from the on-demand agent path.

## Fix (prompts/skill text only)

- **On-demand agent path** (`/memory-to-skill`): instruct the agent to open the original transcript referenced by each journal anchor and confirm exact commands/flags/paths **before drafting**, rather than writing from the summary. Added at the *capture* and *mine-history* steps.
- **Review-before-install**: at the install step (where the human is in the loop), skim the candidate and re-check or flag any uncertain/loosely-summarized step before recommending it — installing copies the candidate as-is.
- **Background/CLI path** (sandboxed to summaries): added an explicit anti-hallucination guard to the distill prompt — capture only what the summaries state, keep unverifiable steps general, omit a workflow rather than invent detail.
- Docs note the accuracy trade-off and recommend on-demand capture for fidelity.

## Testing

Full suite passes; `ruff check`/`format --check` clean; `mkdocs build --strict` passes. (Prose-only change to prompts/skills/docs.)
