### PR TITLE
fix: tighten transcript truncation, platform-neutral prompt, OpenCode drill

### DIFF
--- a/plugins/_shared/prompts/memory_to_skill.txt
+++ b/plugins/_shared/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/plugins/claude-code/prompts/memory_to_skill.txt
+++ b/plugins/claude-code/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/plugins/codex/prompts/memory_to_skill.txt
+++ b/plugins/codex/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/plugins/openclaw/prompts/memory_to_skill.txt
+++ b/plugins/openclaw/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/plugins/opencode/prompts/memory_to_skill.txt
+++ b/plugins/opencode/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -69,7 +69,7 @@ reusable one and persist it with `memsearch skills add` (one call per skill), th
 same way as **A**. Use your own judgment: only propose procedures that recur and
 generalize, not one-offs from a single day.
 
-**Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original transcript. Each journal entry has an anchor naming the transcript file (a `session:` id (and `turn:` when present)). Run `memsearch transcript <file>` (add `--turn <id>` when the anchor has one) to get the original turns **with their tool calls** — it auto-detects the format and includes the executed commands and output. Write the skill from that. Only if that command fails (unknown format) fall back to reading the JSONL directly. If you cannot confirm a detail, keep the step general or omit it — never fabricate.
+**Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original conversation. OpenCode stores transcripts in its session database (not a file), and the journal anchor carries a `session:` id (and `turn:` when present). Run `python3 __INSTALL_DIR__/scripts/parse-transcript.py <session_id>` (add `--turn <id>` when the anchor has one) to read the original turns with their tool calls — that is where the executed commands and output live. Write the skill from that. If you cannot read it or confirm a detail, keep the step general or omit it — never fabricate.
 
 The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
 

--- a/src/memsearch/prompts/memory_to_skill.txt
+++ b/src/memsearch/prompts/memory_to_skill.txt
@@ -57,10 +57,12 @@ Accuracy — confirm from the original, do not hallucinate:
 - The journal entries are LOSSY SUMMARIES; they drop the exact commands, flags,
   and paths. Do not reconstruct those from the summary alone.
 - Before writing a step's exact command, confirm it from the original transcript.
-  Each journal entry has an anchor comment naming the transcript file, e.g.
-  `<!-- session:<id> turn:<id> transcript:<file> -->`. Run
+  Each journal entry has an anchor comment naming the original conversation; the
+  key differs by agent — `transcript:<file>` (Claude Code), `rollout:<file>`
+  (Codex), or `db:`/a `session:` id (OpenCode). For a file-based transcript, run
   `memsearch transcript <file>` (optionally `--turn <id>`) to read the original
   turns WITH their tool calls — that is where the real commands and output live.
+  For a session/db anchor (OpenCode), use that platform's transcript script.
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.

--- a/src/memsearch/transcript.py
+++ b/src/memsearch/transcript.py
@@ -23,7 +23,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-MAX_OUTPUT_CHARS = 800  # per tool-call output, to keep drilled context bounded
+# Truncation strategy: commands are the point, so they are kept in full; tool
+# output is secondary (kept short), and the whole rendering is capped. One budget,
+# applied the same way on every path.
+MAX_OUTPUT_CHARS = 200  # per tool-call output (keep just the key first lines)
+MAX_RENDER_CHARS = 12_000  # total rendered transcript, head-truncated past this
 
 
 class UnknownTranscriptFormat(Exception):
@@ -256,4 +260,7 @@ def format_turns(turns: list[Turn]) -> str:
             if tc.output:
                 lines.append(f"  → {tc.output}")
         lines.append("")
-    return "\n".join(lines).strip() + "\n"
+    rendered = "\n".join(lines).strip() + "\n"
+    if len(rendered) > MAX_RENDER_CHARS:
+        rendered = rendered[:MAX_RENDER_CHARS] + "\n…[transcript truncated]\n"
+    return rendered

--- a/tests/test_transcript_parser.py
+++ b/tests/test_transcript_parser.py
@@ -132,3 +132,30 @@ def test_select_turns_by_id(tmp_path: Path) -> None:
     turns = tr.parse_transcript(p)
     sel = tr.select_turns(turns, "bbbb2222", context=0)
     assert [t.text for t in sel] == ["two"]
+
+
+def test_tool_output_is_clipped(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path / "c.jsonl",
+        [
+            {"type": "user", "uuid": "u1", "message": {"content": "go"}},
+            {
+                "type": "assistant",
+                "uuid": "a1",
+                "message": {"content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "x"}}]},
+            },
+            {
+                "type": "user",
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "t1", "content": "Z" * 5000}]},
+            },
+        ],
+    )
+    turns = tr.parse_transcript(p)
+    assert len(turns[1].tools[0].output) <= tr.MAX_OUTPUT_CHARS + 20  # clipped, not the full 5000
+
+
+def test_render_is_capped(tmp_path: Path) -> None:
+    rows = [{"type": "user", "uuid": f"u{i}", "message": {"content": "x" * 60}} for i in range(2000)]
+    out = tr.format_turns(tr.parse_transcript(_write(tmp_path / "big.jsonl", rows)))
+    assert len(out) <= tr.MAX_RENDER_CHARS + 80
+    assert "truncated" in out


### PR DESCRIPTION
Follow-up to #584, addressing review findings.

- **One truncation strategy.** Rendering kept full conversation text plus 800-char tool outputs, which ballooned (a long Codex rollout was ~1.1M chars), and the maintenance tool then head-cut the blob to 12k — so the model often saw only the start. Now: commands kept in full (they are what a skill needs), tool output kept short (200 chars), and the whole rendering capped at 12k (matching the maintenance cap, so no double-truncation and on-demand isn't an unbounded dump).
- **Platform-neutral distill prompt.** The shared prompt assumed a `transcript:` anchor; it now names `transcript:` (Claude Code) / `rollout:` (Codex) / `db:`/`session:` (OpenCode) and says to use `memsearch transcript` for file-based transcripts or the platform's own script otherwise.
- **OpenCode drill (option B).** OpenCode stores transcripts in a SQLite session DB, not a file, so the file-based `memsearch transcript` doesn't apply. Its `memory-to-skill` skill now drills via OpenCode's existing `parse-transcript.py <session_id>` (which already supports `--turn`/`--limit`).

No new CLI flags. Tests cover output clipping and the render cap; full suite passes, ruff clean, mkdocs --strict passes.

Note (not in this PR): the `transcript` command only becomes available on PATH once a release including #584 ships; until then callers fall back gracefully (the skill reads the file directly; the background tool proceeds summary-only).