### PR TITLE
Improve memory skill maintenance reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ Your agent can keep two higher-level notes current in the background: **`PROJECT
 
 Turn them on by asking your agent — *"enable MemSearch's PROJECT.md and USER.md maintenance"* — and it configures them through the `memory-config` skill, which can also choose the model/provider, the interval, and custom prompts, or diagnose the current setup. Prefer editing files? The settings live under `[plugins.<agent>.project_review]` and `[plugins.<agent>.user_profile]` in your MemSearch config (both read `.memsearch/memory` and write `.memsearch/PROJECT.md` / `.memsearch/USER.md` by default).
 
+If a background maintenance task seems silent, check `.memsearch/.maintenance-state.json` or ask the `memory-config` skill to inspect it; failed runs record `last_error` and retry on the next due run because failed input digests are not marked successful.
+
 #### Skills from Memory
 
 Beyond the episodic journals and the semantic `PROJECT.md` / `USER.md` notes, MemSearch grows a third memory layer — **procedural memory**: your agent turns the workflows you repeat into reusable, installable skills. You drive it entirely through your agent, in natural language — nothing to memorize:

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -165,6 +165,12 @@ Maintenance tasks run when the plugin wakes them and all of these are true:
 - the input markdown digest changed
 - `min_interval_hours` has elapsed since the last successful run
 
+Maintenance state is stored in `.memsearch/.maintenance-state.json`. If a
+background task fails, the matching `<platform>.<task>` entry records
+`last_action = "error"`, `last_failed_at`, `last_error`, and
+`failed_input_digest`. Failed input is not marked as the last successful digest,
+so the task can retry on the next due run instead of going permanently quiet.
+
 Set `provider = "native"` to reuse the agent's own non-interactive model path.
 To use a memsearch-managed API provider instead, define a named provider and
 reference it from the task:
@@ -214,6 +220,10 @@ memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --
 | `min_interval_hours` | `24` | Minimum gap between background runs |
 | `provider` / `model` | `native` | Same routing as the maintenance tasks |
 | `paths` | _(empty)_ | Where installed skills are copied; empty = asked at install time |
+
+The same maintenance state file records `memory_to_skill` failures under
+`<platform>.memory_to_skill.last_error`, which is the first place to check if
+background distillation is enabled but no candidates appear.
 
 ## Platform-Specific Config
 

--- a/plugins/_shared/prompts/memory_to_skill.txt
+++ b/plugins/_shared/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -264,7 +265,26 @@ def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int)
         timeout=timeout,
         check=False,
     )
-    return (result.stdout or result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (stdout, stderr) if part)
+        if len(detail) > 2000:
+            detail = detail[:1975] + "... [truncated]"
+        command = " ".join(shlex.quote(_describe_arg(part)) for part in cmd)
+        if len(command) > 300:
+            command = command[:275] + "... [truncated]"
+        message = f"Command failed ({result.returncode}): {command}"
+        if detail:
+            message = f"{message}\n{detail}"
+        raise RuntimeError(message)
+    return stdout or stderr
+
+
+def _describe_arg(arg: str, limit: int = 120) -> str:
+    if len(arg) <= limit:
+        return arg
+    return f"<arg:{len(arg)} chars>"
 
 
 def extract_task_json_output(output: str) -> str:

--- a/plugins/claude-code/prompts/memory_to_skill.txt
+++ b/plugins/claude-code/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -264,7 +265,26 @@ def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int)
         timeout=timeout,
         check=False,
     )
-    return (result.stdout or result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (stdout, stderr) if part)
+        if len(detail) > 2000:
+            detail = detail[:1975] + "... [truncated]"
+        command = " ".join(shlex.quote(_describe_arg(part)) for part in cmd)
+        if len(command) > 300:
+            command = command[:275] + "... [truncated]"
+        message = f"Command failed ({result.returncode}): {command}"
+        if detail:
+            message = f"{message}\n{detail}"
+        raise RuntimeError(message)
+    return stdout or stderr
+
+
+def _describe_arg(arg: str, limit: int = 120) -> str:
+    if len(arg) <= limit:
+        return arg
+    return f"<arg:{len(arg)} chars>"
 
 
 def extract_task_json_output(output: str) -> str:

--- a/plugins/claude-code/skills/memory-config/SKILL.md
+++ b/plugins/claude-code/skills/memory-config/SKILL.md
@@ -189,6 +189,10 @@ Model guidance:
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
 
+If advanced maintenance or `memory_to_skill` seems silent, check
+`.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
+`last_failed_at`; background hook errors may not surface in the chat.
+
 Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
 
 Prompt overrides:

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -13,6 +13,8 @@ Claude Code's built-in skills system.
 Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
 a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
 Candidates are never installed automatically; installing is always a human step.
+User requests may stop at candidate creation/review, or continue to installation
+in the same turn after explicit approval; match the requested stage.
 
 ## Intent routing
 
@@ -39,24 +41,35 @@ printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
 ```
 
 `add` handles slugging, standard frontmatter, meta.json, and the git commit — no
-LLM is involved. Then show it to the user and install it (see **B**). Finally,
-check whether background distillation is on; if not, offer to enable it (so
-recurring workflows get captured automatically going forward) — do not force it.
+LLM is involved. Then show it to the user; install it only if the user asked for
+that or explicitly approves (see **B**). Finally, check whether background
+distillation is on; if not, offer to enable it (so recurring workflows get
+captured automatically going forward) — do not force it.
 
 ## B. Review & install candidates (1→2)
 
 ```bash
 memsearch skills list            # add -j for sources / installed paths
+git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
+When showing candidates, mention the store's recent git history when it helps
+explain whether a candidate is new, evolved, removed, or re-created.
 
-Pick one, resolve where to install (ask if unset), then install:
+Treat installation as an interactive checkpoint. Show the candidate, apply any
+requested tweaks before installing, and confirm the install destination with the
+user. Resolve install targets from config first: if `paths` is a non-empty
+list, present those paths as the proposed destinations and pass each entry as a
+`--path` after confirmation. If it is empty, ask the user where to install; do
+not silently fall back to a default path.
 
 ```bash
 memsearch config get plugins.claude-code.memory_to_skill.paths 2>/dev/null || echo "[]"
-memsearch skills install <name> --path .claude/skills
+memsearch skills install <name> --path <configured-or-user-approved-path>
 ```
+After installation, remind the user to start a fresh agent session or reopen the
+conversation so the newly installed skill is loaded.
 
 If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
@@ -73,7 +86,7 @@ generalize, not one-offs from a single day.
 
 **Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original transcript. Each journal entry has an anchor naming the transcript file (`transcript:<file>.jsonl` with a `turn:` id). Run `memsearch transcript <file>` (add `--turn <id>` when the anchor has one) to get the original turns **with their tool calls** — it auto-detects the format and includes the executed commands and output. Write the skill from that. If the shown excerpt feels incomplete, skim nearby turns in the same original source before committing to exact commands or paths. Only if that command fails (unknown format) fall back to reading the JSONL directly. If you cannot confirm a detail, keep the step general or omit it — never fabricate.
 
-The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
+The background pass mines automatically when enabled, starting from the summaries; doing it here on demand lets you inspect the original transcripts more deliberately, so the result can be more accurate.
 
 ## D. Configure
 

--- a/plugins/codex/prompts/memory_to_skill.txt
+++ b/plugins/codex/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -264,7 +265,26 @@ def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int)
         timeout=timeout,
         check=False,
     )
-    return (result.stdout or result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (stdout, stderr) if part)
+        if len(detail) > 2000:
+            detail = detail[:1975] + "... [truncated]"
+        command = " ".join(shlex.quote(_describe_arg(part)) for part in cmd)
+        if len(command) > 300:
+            command = command[:275] + "... [truncated]"
+        message = f"Command failed ({result.returncode}): {command}"
+        if detail:
+            message = f"{message}\n{detail}"
+        raise RuntimeError(message)
+    return stdout or stderr
+
+
+def _describe_arg(arg: str, limit: int = 120) -> str:
+    if len(arg) <= limit:
+        return arg
+    return f"<arg:{len(arg)} chars>"
 
 
 def extract_task_json_output(output: str) -> str:

--- a/plugins/codex/skills/memory-config/SKILL.md
+++ b/plugins/codex/skills/memory-config/SKILL.md
@@ -187,6 +187,10 @@ Model guidance:
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
 
+If advanced maintenance or `memory_to_skill` seems silent, check
+`.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
+`last_failed_at`; background hook errors may not surface in the chat.
+
 Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
 
 Prompt overrides:

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -11,6 +11,8 @@ Codex's built-in skills system.
 Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
 a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
 Candidates are never installed automatically; installing is always a human step.
+User requests may stop at candidate creation/review, or continue to installation
+in the same turn after explicit approval; match the requested stage.
 
 ## Intent routing
 
@@ -37,24 +39,35 @@ printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
 ```
 
 `add` handles slugging, standard frontmatter, meta.json, and the git commit — no
-LLM is involved. Then show it to the user and install it (see **B**). Finally,
-check whether background distillation is on; if not, offer to enable it (so
-recurring workflows get captured automatically going forward) — do not force it.
+LLM is involved. Then show it to the user; install it only if the user asked for
+that or explicitly approves (see **B**). Finally, check whether background
+distillation is on; if not, offer to enable it (so recurring workflows get
+captured automatically going forward) — do not force it.
 
 ## B. Review & install candidates (1→2)
 
 ```bash
 memsearch skills list            # add -j for sources / installed paths
+git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
+When showing candidates, mention the store's recent git history when it helps
+explain whether a candidate is new, evolved, removed, or re-created.
 
-Pick one, resolve where to install (ask if unset), then install:
+Treat installation as an interactive checkpoint. Show the candidate, apply any
+requested tweaks before installing, and confirm the install destination with the
+user. Resolve install targets from config first: if `paths` is a non-empty
+list, present those paths as the proposed destinations and pass each entry as a
+`--path` after confirmation. If it is empty, ask the user where to install; do
+not silently fall back to a default path.
 
 ```bash
 memsearch config get plugins.codex.memory_to_skill.paths 2>/dev/null || echo "[]"
-memsearch skills install <name> --path .agents/skills
+memsearch skills install <name> --path <configured-or-user-approved-path>
 ```
+After installation, remind the user to start a fresh agent session or reopen the
+conversation so the newly installed skill is loaded.
 
 If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
@@ -71,7 +84,7 @@ generalize, not one-offs from a single day.
 
 **Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original transcript. Each journal entry has an anchor naming the transcript file (`rollout:<file>.jsonl` (Codex uses `rollout:`, usually no `turn:`)). Run `memsearch transcript <file>` (add `--turn <id>` when the anchor has one) to get the original turns **with their tool calls** — it auto-detects the format and includes the executed commands and output. Write the skill from that. If the shown excerpt feels incomplete, skim nearby turns in the same original source before committing to exact commands or paths. Only if that command fails (unknown format) fall back to reading the JSONL directly. If you cannot confirm a detail, keep the step general or omit it — never fabricate.
 
-The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
+The background pass mines automatically when enabled, starting from the summaries; doing it here on demand lets you inspect the original transcripts more deliberately, so the result can be more accurate.
 
 ## D. Configure
 

--- a/plugins/openclaw/prompts/memory_to_skill.txt
+++ b/plugins/openclaw/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -264,7 +265,26 @@ def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int)
         timeout=timeout,
         check=False,
     )
-    return (result.stdout or result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (stdout, stderr) if part)
+        if len(detail) > 2000:
+            detail = detail[:1975] + "... [truncated]"
+        command = " ".join(shlex.quote(_describe_arg(part)) for part in cmd)
+        if len(command) > 300:
+            command = command[:275] + "... [truncated]"
+        message = f"Command failed ({result.returncode}): {command}"
+        if detail:
+            message = f"{message}\n{detail}"
+        raise RuntimeError(message)
+    return stdout or stderr
+
+
+def _describe_arg(arg: str, limit: int = 120) -> str:
+    if len(arg) <= limit:
+        return arg
+    return f"<arg:{len(arg)} chars>"
 
 
 def extract_task_json_output(output: str) -> str:

--- a/plugins/openclaw/skills/memory-config/SKILL.md
+++ b/plugins/openclaw/skills/memory-config/SKILL.md
@@ -187,6 +187,10 @@ Model guidance:
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
 
+If advanced maintenance or `memory_to_skill` seems silent, check
+`.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
+`last_failed_at`; background hook errors may not surface in the chat.
+
 Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
 
 Prompt overrides:

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -11,6 +11,8 @@ OpenClaw's built-in skills system.
 Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
 a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
 Candidates are never installed automatically; installing is always a human step.
+User requests may stop at candidate creation/review, or continue to installation
+in the same turn after explicit approval; match the requested stage.
 
 ## Intent routing
 
@@ -37,24 +39,35 @@ printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
 ```
 
 `add` handles slugging, standard frontmatter, meta.json, and the git commit — no
-LLM is involved. Then show it to the user and install it (see **B**). Finally,
-check whether background distillation is on; if not, offer to enable it (so
-recurring workflows get captured automatically going forward) — do not force it.
+LLM is involved. Then show it to the user; install it only if the user asked for
+that or explicitly approves (see **B**). Finally, check whether background
+distillation is on; if not, offer to enable it (so recurring workflows get
+captured automatically going forward) — do not force it.
 
 ## B. Review & install candidates (1→2)
 
 ```bash
 memsearch skills list            # add -j for sources / installed paths
+git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
+When showing candidates, mention the store's recent git history when it helps
+explain whether a candidate is new, evolved, removed, or re-created.
 
-Pick one, resolve where to install (ask if unset), then install:
+Treat installation as an interactive checkpoint. Show the candidate, apply any
+requested tweaks before installing, and confirm the install destination with the
+user. Resolve install targets from config first: if `paths` is a non-empty
+list, present those paths as the proposed destinations and pass each entry as a
+`--path` after confirmation. If it is empty, ask the user where to install; do
+not silently fall back to a default path.
 
 ```bash
 memsearch config get plugins.openclaw.memory_to_skill.paths 2>/dev/null || echo "[]"
-memsearch skills install <name> --path .openclaw/skills
+memsearch skills install <name> --path <configured-or-user-approved-path>
 ```
+After installation, remind the user to start a fresh agent session or reopen the
+conversation so the newly installed skill is loaded.
 
 If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
@@ -71,7 +84,7 @@ generalize, not one-offs from a single day.
 
 **Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original transcript. Each journal entry has an anchor naming the transcript file (`session:<id>` and `transcript:<path>`). Run `memsearch transcript <file>` (add `--turn <id>` when the anchor has one) to get the original turns **with their tool calls** — it auto-detects the format and includes the executed commands and output. Write the skill from that. If the shown excerpt feels incomplete, skim nearby turns in the same original source before committing to exact commands or paths. Only if that command fails (unknown format) fall back to reading the JSONL directly. If you cannot confirm a detail, keep the step general or omit it — never fabricate.
 
-The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
+The background pass mines automatically when enabled, starting from the summaries; doing it here on demand lets you inspect the original transcripts more deliberately, so the result can be more accurate.
 
 ## D. Configure
 

--- a/plugins/opencode/prompts/memory_to_skill.txt
+++ b/plugins/opencode/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -264,7 +265,26 @@ def run_command(cmd: list[str], *, env: dict[str, str], cwd: Path, timeout: int)
         timeout=timeout,
         check=False,
     )
-    return (result.stdout or result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (stdout, stderr) if part)
+        if len(detail) > 2000:
+            detail = detail[:1975] + "... [truncated]"
+        command = " ".join(shlex.quote(_describe_arg(part)) for part in cmd)
+        if len(command) > 300:
+            command = command[:275] + "... [truncated]"
+        message = f"Command failed ({result.returncode}): {command}"
+        if detail:
+            message = f"{message}\n{detail}"
+        raise RuntimeError(message)
+    return stdout or stderr
+
+
+def _describe_arg(arg: str, limit: int = 120) -> str:
+    if len(arg) <= limit:
+        return arg
+    return f"<arg:{len(arg)} chars>"
 
 
 def extract_task_json_output(output: str) -> str:

--- a/plugins/opencode/skills/memory-config/SKILL.md
+++ b/plugins/opencode/skills/memory-config/SKILL.md
@@ -189,6 +189,10 @@ Model guidance:
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
 
+If advanced maintenance or `memory_to_skill` seems silent, check
+`.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
+`last_failed_at`; background hook errors may not surface in the chat.
+
 Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
 
 Prompt overrides:

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -11,6 +11,8 @@ OpenCode's built-in skills system.
 Stages: **0** memory journals → **1** candidate (`.memsearch/skill-candidates/`,
 a git-tracked store that keeps evolving) → **2** installed (an agent skill dir).
 Candidates are never installed automatically; installing is always a human step.
+User requests may stop at candidate creation/review, or continue to installation
+in the same turn after explicit approval; match the requested stage.
 
 ## Intent routing
 
@@ -37,24 +39,35 @@ printf '%s' "## <title>\n\n1. ...\n2. ..." | memsearch skills add \
 ```
 
 `add` handles slugging, standard frontmatter, meta.json, and the git commit — no
-LLM is involved. Then show it to the user and install it (see **B**). Finally,
-check whether background distillation is on; if not, offer to enable it (so
-recurring workflows get captured automatically going forward) — do not force it.
+LLM is involved. Then show it to the user; install it only if the user asked for
+that or explicitly approves (see **B**). Finally, check whether background
+distillation is on; if not, offer to enable it (so recurring workflows get
+captured automatically going forward) — do not force it.
 
 ## B. Review & install candidates (1→2)
 
 ```bash
 memsearch skills list            # add -j for sources / installed paths
+git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
+When showing candidates, mention the store's recent git history when it helps
+explain whether a candidate is new, evolved, removed, or re-created.
 
-Pick one, resolve where to install (ask if unset), then install:
+Treat installation as an interactive checkpoint. Show the candidate, apply any
+requested tweaks before installing, and confirm the install destination with the
+user. Resolve install targets from config first: if `paths` is a non-empty
+list, present those paths as the proposed destinations and pass each entry as a
+`--path` after confirmation. If it is empty, ask the user where to install; do
+not silently fall back to a default path.
 
 ```bash
 memsearch config get plugins.opencode.memory_to_skill.paths 2>/dev/null || echo "[]"
-memsearch skills install <name> --path .agents/skills
+memsearch skills install <name> --path <configured-or-user-approved-path>
 ```
+After installation, remind the user to start a fresh agent session or reopen the
+conversation so the newly installed skill is loaded.
 
 If the list is **empty**, background distillation is likely off or has not run.
 Offer the user a choice: capture from recent work now (**A**), distill from
@@ -71,7 +84,7 @@ generalize, not one-offs from a single day.
 
 **Drill into the original before drafting.** The journal bullets are a lossy summary; the exact commands, flags, and paths live in the original conversation. OpenCode stores transcripts in its session database (not a file), and the journal anchor carries a `session:` id (and `turn:` when present). Run `python3 __INSTALL_DIR__/scripts/parse-transcript.py <session_id>` (add `--turn <id>` when the anchor has one) to read the original turns with their tool calls — that is where the executed commands and output live. Write the skill from that. If the shown excerpt feels incomplete, skim nearby turns in the same original source before committing to exact commands or paths. If you cannot read it or confirm a detail, keep the step general or omit it — never fabricate.
 
-The background pass mines automatically when enabled, but it can only see the summaries; doing it here on demand lets you read the original transcripts, so the result is more accurate.
+The background pass mines automatically when enabled, starting from the summaries; doing it here on demand lets you inspect the original transcripts more deliberately, so the result can be more accurate.
 
 ## D. Configure
 

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -113,36 +113,47 @@ def run_due_tasks(
                 output_file=output_file,
                 input_digest=digest,
             )
-            prompt = _build_prompt(ctx, cfg)
-            raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
-            parsed = _parse_task_response(raw)
-            now = _now()
+            try:
+                prompt = _build_prompt(ctx, cfg)
+                raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
+                parsed = _parse_task_response(raw)
+                now = _now()
 
-            if parsed["action"] == "replace":
-                content = str(parsed.get("content") or "").strip()
-                if not content:
-                    raise RuntimeError(f"{task_name} returned replace without content")
-                output_file.write_text(content.rstrip() + "\n", encoding="utf-8")
-                action = "replace"
-            else:
-                action = "none"
+                if parsed["action"] == "replace":
+                    content = str(parsed.get("content") or "").strip()
+                    if not content:
+                        raise RuntimeError(f"{task_name} returned replace without content")
+                    output_file.write_text(content.rstrip() + "\n", encoding="utf-8")
+                    action = "replace"
+                else:
+                    action = "none"
 
-            state[state_key] = {
-                "last_checked_at": now,
-                "last_success_at": now,
-                "last_input_digest": digest,
-                "last_action": action,
-                "output_file": str(output_file),
-            }
-            _save_state(state_path, state)
-            results.append(
-                MaintenanceResult(
-                    task=task_name,
-                    action=action,
-                    reason=str(parsed.get("reason") or ""),
-                    output_file=str(output_file),
+                state[state_key] = {
+                    "last_checked_at": now,
+                    "last_success_at": now,
+                    "last_input_digest": digest,
+                    "last_action": action,
+                    "output_file": str(output_file),
+                }
+                _save_state(state_path, state)
+                results.append(
+                    MaintenanceResult(
+                        task=task_name,
+                        action=action,
+                        reason=str(parsed.get("reason") or ""),
+                        output_file=str(output_file),
+                    )
                 )
-            )
+            except Exception as exc:
+                _record_failure_state(
+                    state,
+                    state_path,
+                    state_key,
+                    input_digest=digest,
+                    output_file=output_file,
+                    error=exc,
+                )
+                raise
 
     return results
 
@@ -559,6 +570,39 @@ def _load_state(path: Path) -> dict[str, Any]:
 
 def _save_state(path: Path, state: dict[str, Any]) -> None:
     path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _format_error(error: BaseException, limit: int = 2000) -> str:
+    message = f"{type(error).__name__}: {error}"
+    if len(message) > limit:
+        return message[: limit - len("... [truncated]")] + "... [truncated]"
+    return message
+
+
+def _record_failure_state(
+    state: dict[str, Any],
+    state_path: Path,
+    state_key: str,
+    *,
+    input_digest: str,
+    output_file: Path,
+    error: BaseException,
+) -> None:
+    now = _now()
+    previous = state.get(state_key, {})
+    entry = dict(previous) if isinstance(previous, dict) else {}
+    entry.update(
+        {
+            "last_checked_at": now,
+            "last_failed_at": now,
+            "failed_input_digest": input_digest,
+            "last_action": "error",
+            "last_error": _format_error(error),
+            "output_file": str(output_file),
+        }
+    )
+    state[state_key] = entry
+    _save_state(state_path, state)
 
 
 @contextlib.contextmanager

--- a/src/memsearch/prompts/memory_to_skill.txt
+++ b/src/memsearch/prompts/memory_to_skill.txt
@@ -9,9 +9,12 @@ error). It is NOT a fact, a decision, or a preference — those belong in
 PROJECT.md and USER.md.
 
 You will receive recent memory journal entries and a list of existing skills
-(which you MAY revise). Propose or revise skills only when they clearly earn it.
+(which you MAY revise). Propose or revise candidate skills when the journals show
+the same user-requested operation repeating enough times to be useful.
 
-Be conservative. Quality over quantity. Most runs should return an empty list.
+Candidates are review drafts, not installed skills. Do not enforce a fixed ratio,
+quota, or expectation that most runs return nothing. The number of candidates
+should follow the evidence in the journals.
 
 A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
 - It is a repeatable multi-step procedure, not a one-off action or a fact.
@@ -19,9 +22,10 @@ A NEW workflow qualifies as a candidate ONLY when ALL of these hold:
   journals below.
 - It generalizes into a reusable capability. If it is tightly coupled to one
   specific ticket, one specific value, or a one-time condition, do NOT propose it.
-- The recent runs were not immediately corrected, abandoned, or undone (a
-  workflow the user kept fighting is not a good skill).
 - It is not already covered by an existing skill.
+- The overall procedure was not abandoned, undone, or contradicted by later
+  evidence. Do not reject a workflow merely because individual runs included
+  failed attempts, retries, or corrected commands.
 
 You may also REVISE an existing skill (re-emit it with the SAME name and a
 corrected body) when the recent journals show that procedure has genuinely
@@ -30,17 +34,21 @@ there is clear evidence of change; do not rewrite for style.
 
 Rules:
 - Return only a JSON object, with no prose outside JSON.
-- Use {"skills": []} when nothing in the journals qualifies. This is the common case.
+- Use {"skills": []} when no repeated workflow qualifies.
 - For each candidate, write a clean, portable SKILL.md body in "body": step-by-step
   instructions an agent can follow. Do not include YAML frontmatter — only the
   markdown body. Keep it concise and concrete.
 - "name" must be a short lowercase slug (letters, digits, dashes), e.g. "run-tests".
-  It becomes the skill's command name. Do not reuse an existing skill name.
+  It becomes the skill's command name. For new candidates, do not reuse an
+  existing skill name; for revisions, reuse the exact existing name.
 - "description" is one line: what the skill does AND when it should trigger.
   Lead with the verbs a user would actually type ("run", "deploy", "debug").
 - "occurrences" is how many distinct sessions/days you saw this workflow.
 - "sources" lists the journal file names the workflow was observed in.
 - Do not copy raw journal text wholesale into the body; abstract it into a procedure.
+- If a workflow qualifies but some exact commands, paths, or flags are not
+  confirmed, still create the candidate. Keep those details general and add a
+  short "Before installing" verification step instead of inventing specifics.
 
 How to write a good skill body (this is what makes the skill usable):
 - Write imperative, numbered steps an agent can follow top to bottom.
@@ -66,6 +74,8 @@ Accuracy — confirm from the original, do not hallucinate:
 - If you cannot read the transcript or confirm a detail, capture only what the
   summary clearly states; keep the step general or omit it — a plausible-but-wrong
   command is worse than none. Never invent specifics.
+- Do not drop the whole candidate only because a few low-level details remain
+  unconfirmed; make the uncertainty visible for human review before installation.
 - Prefer fewer, verified steps over a complete-looking but partly-guessed procedure.
 
 JSON examples:

--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -37,6 +37,7 @@ from .maintenance import (
     _is_due,
     _load_state,
     _read_recent_journals,
+    _record_failure_state,
     _resolve_task_path,
     _save_state,
     run_task_llm,
@@ -368,41 +369,52 @@ def distill(
             output_file=root,
             input_digest=digest,
         )
-        prompt = _build_distill_prompt(
-            ctx, min_occurrences=task_cfg.min_occurrences, existing=list_candidates(mem_root), cfg=cfg
-        )
-        raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
-        candidates = _parse_distill_response(raw)
+        try:
+            prompt = _build_distill_prompt(
+                ctx, min_occurrences=task_cfg.min_occurrences, existing=list_candidates(mem_root), cfg=cfg
+            )
+            raw = llm_runner(ctx, prompt) if llm_runner else run_task_llm(ctx, prompt, cfg)
+            candidates = _parse_distill_response(raw)
 
-        created: list[str] = []
-        updated: list[str] = []
-        for skill in candidates:
-            outcome = _write_candidate(root, skill)
-            if outcome == "created":
-                created.append(skill["name"])
-            elif outcome == "updated":
-                updated.append(skill["name"])
+            created: list[str] = []
+            updated: list[str] = []
+            for skill in candidates:
+                outcome = _write_candidate(root, skill)
+                if outcome == "created":
+                    created.append(skill["name"])
+                elif outcome == "updated":
+                    updated.append(skill["name"])
 
-        changed = bool(created or updated)
-        if changed:
-            parts = []
-            if created:
-                parts.append(f"add {len(created)}")
-            if updated:
-                parts.append(f"evolve {len(updated)}")
-            _git_commit(root, f"distill: {', '.join(parts)} candidate skill(s) [{platform}]")
-        else:
-            _git_commit(root, f"distill: refresh candidate metadata [{platform}]")
+            changed = bool(created or updated)
+            if changed:
+                parts = []
+                if created:
+                    parts.append(f"add {len(created)}")
+                if updated:
+                    parts.append(f"evolve {len(updated)}")
+                _git_commit(root, f"distill: {', '.join(parts)} candidate skill(s) [{platform}]")
+            else:
+                _git_commit(root, f"distill: refresh candidate metadata [{platform}]")
 
-        now = _now()
-        state[state_key] = {
-            "last_checked_at": now,
-            "last_success_at": now,
-            "last_input_digest": digest,
-            "last_action": "distilled" if changed else "none",
-            "output_file": str(root),
-        }
-        _save_state(state_path, state)
+            now = _now()
+            state[state_key] = {
+                "last_checked_at": now,
+                "last_success_at": now,
+                "last_input_digest": digest,
+                "last_action": "distilled" if changed else "none",
+                "output_file": str(root),
+            }
+            _save_state(state_path, state)
+        except Exception as exc:
+            _record_failure_state(
+                state,
+                state_path,
+                state_key,
+                input_digest=digest,
+                output_file=root,
+                error=exc,
+            )
+            raise
 
     return DistillResult(action="distilled" if changed else "none", created=created, updated=updated)
 

--- a/tests/test_embeddings_openai.py
+++ b/tests/test_embeddings_openai.py
@@ -43,8 +43,9 @@ async def test_embed_deterministic(provider):
     text = "Deterministic embedding test"
     r1 = await provider.embed([text])
     r2 = await provider.embed([text])
-    # OpenAI embeddings should be deterministic
-    assert r1[0][:5] == r2[0][:5]
+    # External providers can return tiny float-level differences while still
+    # being effectively deterministic for indexing and search.
+    assert r1[0][:5] == pytest.approx(r2[0][:5], abs=1e-4)
 
 
 def test_model_name(provider):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from memsearch.config import LLMProviderConfig, MemSearchConfig, PluginMaintenanceTaskConfig
 from memsearch.maintenance import TaskContext, _read_recent_journals, run_due_tasks, run_memory_command, run_task_llm
 
@@ -119,6 +121,40 @@ def test_maintenance_replace_writes_output_and_state(tmp_path: Path) -> None:
     state = json.loads((project / ".memsearch" / ".maintenance-state.json").read_text(encoding="utf-8"))
     assert state["codex.project_review"]["last_action"] == "replace"
     assert state["codex.project_review"]["last_input_digest"].startswith("sha256:")
+
+
+def test_maintenance_failure_records_state(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("### 10:00\n- User discussed maintenance runner.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "openai"
+
+    calls = 0
+
+    def runner(ctx, prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("provider timeout")
+        return json.dumps({"action": "none", "reason": "retry succeeded"})
+
+    with pytest.raises(RuntimeError, match="provider timeout"):
+        run_due_tasks(platform="codex", project_dir=project, cfg=cfg, llm_runner=runner)
+
+    state = json.loads((project / ".memsearch" / ".maintenance-state.json").read_text(encoding="utf-8"))
+    task_state = state["codex.project_review"]
+    assert task_state["last_action"] == "error"
+    assert task_state["last_failed_at"]
+    assert task_state["failed_input_digest"].startswith("sha256:")
+    assert "provider timeout" in task_state["last_error"]
+
+    retry = run_due_tasks(platform="codex", project_dir=project, cfg=cfg, llm_runner=runner)
+    assert retry[0].action == "none"
+    assert calls == 2
 
 
 def test_maintenance_skips_unchanged_input(tmp_path: Path) -> None:

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 
 def _load_runner():
@@ -202,3 +205,34 @@ def test_opencode_native_runner_uses_sanitized_isolated_config(tmp_path: Path, m
     assert isolated_config["username"] == "from-content"
     assert isolated_config["provider"]["openai"]["apiKey"] == f"{{file:{config_dir / 'token.txt'}}}"
     assert "plugin" not in isolated_config
+
+
+def test_run_command_raises_with_exit_details(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["tool"], returncode=2, stdout="partial output", stderr="bad credentials"
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        runner.run_command(["tool", "run", "x" * 200], env={}, cwd=tmp_path, timeout=1)
+
+    message = str(exc_info.value)
+    assert "Command failed (2): tool run '<arg:200 chars>'" in message
+    assert "partial output" in message
+    assert "bad credentials" in message
+    assert "x" * 120 not in message
+
+
+def test_run_command_success_prefers_stdout(tmp_path: Path, monkeypatch) -> None:
+    runner = _load_runner()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(args=["tool"], returncode=0, stdout='{"ok": true}', stderr="warning")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    assert runner.run_command(["tool"], env={}, cwd=tmp_path, timeout=1) == '{"ok": true}'

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -116,6 +116,36 @@ def test_distill_disabled_by_default(tmp_path: Path) -> None:
     assert result.skipped is True
 
 
+def test_distill_failure_records_state(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    calls = 0
+
+    def runner(ctx, prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("native runner failed")
+        return json.dumps({"skills": []})
+
+    with pytest.raises(RuntimeError, match="native runner failed"):
+        skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=runner)
+
+    state = json.loads((project / ".memsearch" / ".maintenance-state.json").read_text(encoding="utf-8"))
+    task_state = state["claude-code.memory_to_skill"]
+    assert task_state["last_action"] == "error"
+    assert task_state["last_failed_at"]
+    assert task_state["failed_input_digest"].startswith("sha256:")
+    assert "native runner failed" in task_state["last_error"]
+
+    retry = skills_mod.distill(platform="claude-code", project_dir=project, cfg=cfg, llm_runner=runner)
+    assert retry.action == "none"
+    assert calls == 2
+
+
 def test_install_copies_to_paths_and_updates_meta(tmp_path: Path) -> None:
     project = tmp_path / "repo"
     _seed_memory(project)


### PR DESCRIPTION
Summary:
- Record maintenance and skill distillation failures in maintenance state so retries remain observable.
- Relax memory-to-skill candidate generation and clarify candidate review, install paths, store history, and session reload guidance.
- Document maintenance-state troubleshooting and stabilize the OpenAI embedding integration test tolerance.

Tests:
- uv run python -m pytest
- uv run ruff check src/memsearch/maintenance.py src/memsearch/skills.py plugins/_shared/scripts/maintenance-runner.py tests/test_maintenance.py tests/test_skills.py tests/test_maintenance_runner.py tests/test_embeddings_openai.py
- git diff --check