### PR TITLE
Guard maintenance subprocesses from plugin recursion

### DIFF
--- a/plugins/_shared/scripts/maintenance-runner.py
+++ b/plugins/_shared/scripts/maintenance-runner.py
@@ -287,6 +287,30 @@ def _describe_arg(arg: str, limit: int = 120) -> str:
     return f"<arg:{len(arg)} chars>"
 
 
+_CLAUDE_SAFE_MODE_ARGS: list[str] | None = None
+
+
+def claude_safe_mode_args() -> list[str]:
+    """Return Claude args that suppress hooks when supported."""
+    global _CLAUDE_SAFE_MODE_ARGS
+    if _CLAUDE_SAFE_MODE_ARGS is not None:
+        return _CLAUDE_SAFE_MODE_ARGS
+    try:
+        result = subprocess.run(
+            ["claude", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _CLAUDE_SAFE_MODE_ARGS = []
+    else:
+        help_text = f"{result.stdout}\n{result.stderr}"
+        _CLAUDE_SAFE_MODE_ARGS = ["--safe-mode"] if "--safe-mode" in help_text else []
+    return _CLAUDE_SAFE_MODE_ARGS
+
+
 def extract_task_json_output(output: str) -> str:
     """Extract the first maintenance JSON object from noisy host output."""
     for line in output.splitlines():
@@ -396,7 +420,14 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = [
+            "claude",
+            "-p",
+            *claude_safe_mode_args(),
+            "--strict-mcp-config",
+            "--no-session-persistence",
+            "--no-chrome",
+        ]
         # Skill distillation needs to read original transcripts for exact commands.
         # Open a narrow hole — Bash limited to the two read-only memsearch drill
         # commands — only for that task; other maintenance keeps all tools off.
@@ -412,6 +443,7 @@ def run_native_provider(ctx, prompt: str) -> str:
             prompt,
         ]
         env["CLAUDECODE"] = ""
+        env["MEMSEARCH_DISABLE"] = "1"
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -4,6 +4,14 @@
 
 set -euo pipefail
 
+# Internal maintenance/summarization subprocesses may invoke Claude Code again.
+# When they do, the child process must not run memsearch hooks, or it can write
+# empty nested session headings and keep maintenance inputs changing forever.
+if [ "${MEMSEARCH_DISABLE:-}" = "1" ]; then
+  echo '{}'
+  exit 0
+fi
+
 # Read stdin JSON into $INPUT
 # Use timeout to prevent indefinite blocking in WSL 2 where stdin pipe may not close properly.
 # macOS lacks `timeout` — use perl alarm(2) as a portable fallback with a 2-second deadline.

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -140,7 +140,12 @@ elif command -v claude &>/dev/null; then
 
 Transcript:
 ${PARSED}"
-  SUMMARY=$(MEMSEARCH_NO_WATCH=1 CLAUDECODE= claude -p \
+  CLAUDE_SAFE_MODE_ARGS=()
+  if claude --help 2>/dev/null | grep -q -- '--safe-mode'; then
+    CLAUDE_SAFE_MODE_ARGS=(--safe-mode)
+  fi
+  SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_DISABLE=1 CLAUDECODE= claude -p \
+    "${CLAUDE_SAFE_MODE_ARGS[@]}" \
     --strict-mcp-config \
     --tools "" \
     --model "$SUMMARIZE_MODEL" \

--- a/plugins/claude-code/scripts/maintenance-runner.py
+++ b/plugins/claude-code/scripts/maintenance-runner.py
@@ -287,6 +287,30 @@ def _describe_arg(arg: str, limit: int = 120) -> str:
     return f"<arg:{len(arg)} chars>"
 
 
+_CLAUDE_SAFE_MODE_ARGS: list[str] | None = None
+
+
+def claude_safe_mode_args() -> list[str]:
+    """Return Claude args that suppress hooks when supported."""
+    global _CLAUDE_SAFE_MODE_ARGS
+    if _CLAUDE_SAFE_MODE_ARGS is not None:
+        return _CLAUDE_SAFE_MODE_ARGS
+    try:
+        result = subprocess.run(
+            ["claude", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _CLAUDE_SAFE_MODE_ARGS = []
+    else:
+        help_text = f"{result.stdout}\n{result.stderr}"
+        _CLAUDE_SAFE_MODE_ARGS = ["--safe-mode"] if "--safe-mode" in help_text else []
+    return _CLAUDE_SAFE_MODE_ARGS
+
+
 def extract_task_json_output(output: str) -> str:
     """Extract the first maintenance JSON object from noisy host output."""
     for line in output.splitlines():
@@ -396,7 +420,14 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = [
+            "claude",
+            "-p",
+            *claude_safe_mode_args(),
+            "--strict-mcp-config",
+            "--no-session-persistence",
+            "--no-chrome",
+        ]
         # Skill distillation needs to read original transcripts for exact commands.
         # Open a narrow hole — Bash limited to the two read-only memsearch drill
         # commands — only for that task; other maintenance keeps all tools off.
@@ -412,6 +443,7 @@ def run_native_provider(ctx, prompt: str) -> str:
             prompt,
         ]
         env["CLAUDECODE"] = ""
+        env["MEMSEARCH_DISABLE"] = "1"
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":

--- a/plugins/codex/scripts/maintenance-runner.py
+++ b/plugins/codex/scripts/maintenance-runner.py
@@ -287,6 +287,30 @@ def _describe_arg(arg: str, limit: int = 120) -> str:
     return f"<arg:{len(arg)} chars>"
 
 
+_CLAUDE_SAFE_MODE_ARGS: list[str] | None = None
+
+
+def claude_safe_mode_args() -> list[str]:
+    """Return Claude args that suppress hooks when supported."""
+    global _CLAUDE_SAFE_MODE_ARGS
+    if _CLAUDE_SAFE_MODE_ARGS is not None:
+        return _CLAUDE_SAFE_MODE_ARGS
+    try:
+        result = subprocess.run(
+            ["claude", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _CLAUDE_SAFE_MODE_ARGS = []
+    else:
+        help_text = f"{result.stdout}\n{result.stderr}"
+        _CLAUDE_SAFE_MODE_ARGS = ["--safe-mode"] if "--safe-mode" in help_text else []
+    return _CLAUDE_SAFE_MODE_ARGS
+
+
 def extract_task_json_output(output: str) -> str:
     """Extract the first maintenance JSON object from noisy host output."""
     for line in output.splitlines():
@@ -396,7 +420,14 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = [
+            "claude",
+            "-p",
+            *claude_safe_mode_args(),
+            "--strict-mcp-config",
+            "--no-session-persistence",
+            "--no-chrome",
+        ]
         # Skill distillation needs to read original transcripts for exact commands.
         # Open a narrow hole — Bash limited to the two read-only memsearch drill
         # commands — only for that task; other maintenance keeps all tools off.
@@ -412,6 +443,7 @@ def run_native_provider(ctx, prompt: str) -> str:
             prompt,
         ]
         env["CLAUDECODE"] = ""
+        env["MEMSEARCH_DISABLE"] = "1"
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":

--- a/plugins/openclaw/scripts/maintenance-runner.py
+++ b/plugins/openclaw/scripts/maintenance-runner.py
@@ -287,6 +287,30 @@ def _describe_arg(arg: str, limit: int = 120) -> str:
     return f"<arg:{len(arg)} chars>"
 
 
+_CLAUDE_SAFE_MODE_ARGS: list[str] | None = None
+
+
+def claude_safe_mode_args() -> list[str]:
+    """Return Claude args that suppress hooks when supported."""
+    global _CLAUDE_SAFE_MODE_ARGS
+    if _CLAUDE_SAFE_MODE_ARGS is not None:
+        return _CLAUDE_SAFE_MODE_ARGS
+    try:
+        result = subprocess.run(
+            ["claude", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _CLAUDE_SAFE_MODE_ARGS = []
+    else:
+        help_text = f"{result.stdout}\n{result.stderr}"
+        _CLAUDE_SAFE_MODE_ARGS = ["--safe-mode"] if "--safe-mode" in help_text else []
+    return _CLAUDE_SAFE_MODE_ARGS
+
+
 def extract_task_json_output(output: str) -> str:
     """Extract the first maintenance JSON object from noisy host output."""
     for line in output.splitlines():
@@ -396,7 +420,14 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = [
+            "claude",
+            "-p",
+            *claude_safe_mode_args(),
+            "--strict-mcp-config",
+            "--no-session-persistence",
+            "--no-chrome",
+        ]
         # Skill distillation needs to read original transcripts for exact commands.
         # Open a narrow hole — Bash limited to the two read-only memsearch drill
         # commands — only for that task; other maintenance keeps all tools off.
@@ -412,6 +443,7 @@ def run_native_provider(ctx, prompt: str) -> str:
             prompt,
         ]
         env["CLAUDECODE"] = ""
+        env["MEMSEARCH_DISABLE"] = "1"
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -459,6 +459,28 @@ def summarize_with_llm(
     return None
 
 
+def wake_maintenance(project_dir: str) -> None:
+    """Start maintenance in a hook-disabled child environment."""
+    runner = Path(__file__).resolve().parent / "maintenance-runner.py"
+    subprocess.Popen(
+        [
+            "python3",
+            str(runner),
+            "--platform",
+            "opencode",
+            "--project-dir",
+            project_dir,
+            "--memsearch-dir",
+            os.path.join(project_dir, ".memsearch"),
+        ],
+        env={**os.environ, "MEMSEARCH_NO_WATCH": "1", "MEMSEARCH_DISABLE": "1"},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
 def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     """Find OpenCode sessions that belong to the given project directory."""
     sessions = conn.execute(
@@ -790,16 +812,8 @@ def main() -> None:
                 )
 
             if any_new:
-                os.system(
-                    f"{args.memsearch_cmd} index '{memory_dir}' "
-                    f"--collection {args.collection_name} &"
-                )
-                os.system(
-                    f"python3 {shlex.quote(str(Path(__file__).resolve().parent / 'maintenance-runner.py'))} "
-                    f"--platform opencode "
-                    f"--project-dir {shlex.quote(args.project_dir)} "
-                    f"--memsearch-dir {shlex.quote(os.path.join(args.project_dir, '.memsearch'))} &"
-                )
+                os.system(f"{args.memsearch_cmd} index '{memory_dir}' --collection {args.collection_name} &")
+                wake_maintenance(args.project_dir)
         except Exception:
             pass
         finally:

--- a/plugins/opencode/scripts/maintenance-runner.py
+++ b/plugins/opencode/scripts/maintenance-runner.py
@@ -287,6 +287,30 @@ def _describe_arg(arg: str, limit: int = 120) -> str:
     return f"<arg:{len(arg)} chars>"
 
 
+_CLAUDE_SAFE_MODE_ARGS: list[str] | None = None
+
+
+def claude_safe_mode_args() -> list[str]:
+    """Return Claude args that suppress hooks when supported."""
+    global _CLAUDE_SAFE_MODE_ARGS
+    if _CLAUDE_SAFE_MODE_ARGS is not None:
+        return _CLAUDE_SAFE_MODE_ARGS
+    try:
+        result = subprocess.run(
+            ["claude", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _CLAUDE_SAFE_MODE_ARGS = []
+    else:
+        help_text = f"{result.stdout}\n{result.stderr}"
+        _CLAUDE_SAFE_MODE_ARGS = ["--safe-mode"] if "--safe-mode" in help_text else []
+    return _CLAUDE_SAFE_MODE_ARGS
+
+
 def extract_task_json_output(output: str) -> str:
     """Extract the first maintenance JSON object from noisy host output."""
     for line in output.splitlines():
@@ -396,7 +420,14 @@ def run_native_provider(ctx, prompt: str) -> str:
     env = {**os.environ, "MEMSEARCH_NO_WATCH": "1"}
 
     if ctx.platform == "claude-code":
-        cmd = ["claude", "-p", "--strict-mcp-config", "--no-session-persistence", "--no-chrome"]
+        cmd = [
+            "claude",
+            "-p",
+            *claude_safe_mode_args(),
+            "--strict-mcp-config",
+            "--no-session-persistence",
+            "--no-chrome",
+        ]
         # Skill distillation needs to read original transcripts for exact commands.
         # Open a narrow hole — Bash limited to the two read-only memsearch drill
         # commands — only for that task; other maintenance keeps all tools off.
@@ -412,6 +443,7 @@ def run_native_provider(ctx, prompt: str) -> str:
             prompt,
         ]
         env["CLAUDECODE"] = ""
+        env["MEMSEARCH_DISABLE"] = "1"
         return run_command(cmd, env=env, cwd=ctx.project_dir, timeout=120)
 
     if ctx.platform == "codex":

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    env = {
+        **os.environ,
+        "MEMSEARCH_DISABLE": "1",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(tmp_path / ".memsearch"),
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "{}"
+    assert not (tmp_path / ".memsearch").exists()

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -94,6 +94,7 @@ def test_codex_native_runner_uses_profile_and_last_message(tmp_path: Path, monke
     assert captured["cmd"][0:2] == ["codex", "exec"]
     assert captured["cmd"][captured["cmd"].index("-p") + 1] == "zilliz"
     assert "-o" in captured["cmd"]
+    assert "features.hooks=false" in captured["cmd"]
     assert captured["env"]["MEMSEARCH_IN_STOP_WORKER"] == "1"
 
 
@@ -117,6 +118,7 @@ def test_claude_native_runner_passes_prompt_as_user_input(tmp_path: Path, monkey
     result = runner.run_native_provider(ctx, "maintenance prompt")
 
     assert json.loads(result) == {"action": "none", "reason": "ok"}
+    assert captured["env"]["MEMSEARCH_DISABLE"] == "1"
     assert captured["cmd"][0:2] == ["claude", "-p"]
     assert captured["cmd"][-1] == "maintenance prompt"
     assert captured["cmd"][captured["cmd"].index("--system-prompt") + 1] != "maintenance prompt"
@@ -201,6 +203,7 @@ def test_opencode_native_runner_uses_sanitized_isolated_config(tmp_path: Path, m
     assert captured["env"]["OPENCODE_CONFIG_DIR"] == ""
     assert captured["env"]["OPENCODE_CONFIG_CONTENT"] == ""
     assert captured["env"]["OPENCODE_DISABLE_PROJECT_CONFIG"] == "true"
+    assert captured["env"]["MEMSEARCH_NO_WATCH"] == "1"
     assert isolated_config["model"] == "dir/model"
     assert isolated_config["username"] == "from-content"
     assert isolated_config["provider"]["openai"]["apiKey"] == f"{{file:{config_dir / 'token.txt'}}}"

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -142,6 +142,41 @@ def test_opencode_isolated_config_sanitizes_plugins(tmp_path: Path, monkeypatch)
     assert not (isolated_root / "opencode" / "opencode.jsonc").exists()
 
 
+def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        captured["stdin"] = kwargs["stdin"]
+        captured["stdout"] = kwargs["stdout"]
+        captured["stderr"] = kwargs["stderr"]
+        captured["start_new_session"] = kwargs["start_new_session"]
+
+        class Process:
+            pass
+
+        return Process()
+
+    monkeypatch.setattr(capture_daemon.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("MEMSEARCH_NO_WATCH", "0")
+    monkeypatch.delenv("MEMSEARCH_DISABLE", raising=False)
+
+    capture_daemon.wake_maintenance(str(project))
+
+    assert captured["cmd"][:4] == ["python3", str(SCRIPT_DIR / "maintenance-runner.py"), "--platform", "opencode"]
+    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(project / ".memsearch")
+    assert captured["env"]["MEMSEARCH_NO_WATCH"] == "1"
+    assert captured["env"]["MEMSEARCH_DISABLE"] == "1"
+    assert captured["stdin"] == capture_daemon.subprocess.DEVNULL
+    assert captured["stdout"] == capture_daemon.subprocess.DEVNULL
+    assert captured["stderr"] == capture_daemon.subprocess.DEVNULL
+    assert captured["start_new_session"] is True
+
+
 def _make_opencode_db(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row


### PR DESCRIPTION
## Summary
- disable plugin hooks for internal maintenance subprocesses
- add safe-mode detection for supported child CLI invocations
- make the OpenCode daemon start maintenance with explicit hook-disabled environment variables
- cover the recursion guards with focused tests

## Tests
- uv run python -m pytest
- uv run python -m pytest tests/test_claude_hooks.py tests/test_maintenance_runner.py tests/test_opencode_turns.py
- uv run ruff format --check src/ tests/ plugins/opencode/scripts/capture-daemon.py
- uv run ruff check src/ tests/ plugins/opencode/scripts/capture-daemon.py
- git diff --check