### PR TITLE
Bump versions for 0.4.10 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.9"
+version = "0.4.10"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.9"
+version = "0.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump memsearch and Claude Code plugin versions to 0.4.10
- bump OpenClaw plugin version to 0.3.10
- bump OpenCode plugin version to 0.3.7

## Tests
- uv build
- uv run python -m pytest tests/test_maintenance_runner.py tests/test_claude_hooks.py tests/test_opencode_turns.py
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- npm pack --dry-run --json (plugins/opencode)
- npm pack --dry-run --json (plugins/openclaw)