### PR TITLE
fix: batch Milvus upserts during indexing

### DIFF
--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -164,35 +164,16 @@ class MemSearch:
             return 0
 
         model = self._embedder.model_name
-        # Clean content for embedding: strip HTML comments and metadata noise
-        # so the embedding vector captures semantics, not UUIDs/paths.
-        # The original content is preserved in the Milvus record below.
-        contents = [clean_content_for_embedding(c.content) for c in chunks]
-        embeddings = await self._embedder.embed(contents)
+        total = 0
+        for batch in _chunk_batches(chunks, self._embedder.batch_size):
+            # Clean content for embedding: strip HTML comments and metadata noise
+            # so the embedding vector captures semantics, not UUIDs/paths.
+            # The original content is preserved in the Milvus record below.
+            contents = [clean_content_for_embedding(c.content) for c in batch]
+            embeddings = await self._embedder.embed(contents)
+            total += self._store.upsert(_records_for_chunks(batch, embeddings, model))
 
-        records: list[dict[str, Any]] = []
-        for i, chunk in enumerate(chunks):
-            chunk_id = compute_chunk_id(
-                chunk.source,
-                chunk.start_line,
-                chunk.end_line,
-                chunk.content_hash,
-                model,
-            )
-            records.append(
-                {
-                    "chunk_hash": chunk_id,
-                    "embedding": embeddings[i],
-                    "content": chunk.content,
-                    "source": chunk.source,
-                    "heading": chunk.heading,
-                    "heading_level": chunk.heading_level,
-                    "start_line": chunk.start_line,
-                    "end_line": chunk.end_line,
-                }
-            )
-
-        return self._store.upsert(records)
+        return total
 
     # ------------------------------------------------------------------
     # Search
@@ -412,3 +393,35 @@ class MemSearch:
 
     def __exit__(self, *exc: object) -> None:
         self.close()
+
+
+def _chunk_batches(chunks: list[Chunk], batch_size: int) -> Iterator[list[Chunk]]:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+    for i in range(0, len(chunks), batch_size):
+        yield chunks[i : i + batch_size]
+
+
+def _records_for_chunks(chunks: list[Chunk], embeddings: list[list[float]], model: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for chunk, embedding in zip(chunks, embeddings, strict=True):
+        chunk_id = compute_chunk_id(
+            chunk.source,
+            chunk.start_line,
+            chunk.end_line,
+            chunk.content_hash,
+            model,
+        )
+        records.append(
+            {
+                "chunk_hash": chunk_id,
+                "embedding": embedding,
+                "content": chunk.content,
+                "source": chunk.source,
+                "heading": chunk.heading,
+                "heading_level": chunk.heading_level,
+                "start_line": chunk.start_line,
+                "end_line": chunk.end_line,
+            }
+        )
+    return records

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -15,6 +15,9 @@ class EmbeddingProvider(Protocol):
     @property
     def dimension(self) -> int: ...
 
+    @property
+    def batch_size(self) -> int: ...
+
     async def embed(self, texts: list[str]) -> list[list[float]]: ...
 
 

--- a/src/memsearch/embeddings/google.py
+++ b/src/memsearch/embeddings/google.py
@@ -48,6 +48,10 @@ class GoogleEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/jina.py
+++ b/src/memsearch/embeddings/jina.py
@@ -68,6 +68,10 @@ class JinaEmbedding:
     def dimension(self) -> int:
         return self._dimensions
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/local.py
+++ b/src/memsearch/embeddings/local.py
@@ -63,6 +63,10 @@ class LocalEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/mistral.py
+++ b/src/memsearch/embeddings/mistral.py
@@ -52,6 +52,10 @@ class MistralEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/ollama.py
+++ b/src/memsearch/embeddings/ollama.py
@@ -37,6 +37,10 @@ class OllamaEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -118,6 +118,10 @@ class OnnxEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/openai.py
+++ b/src/memsearch/embeddings/openai.py
@@ -51,6 +51,10 @@ class OpenAIEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/src/memsearch/embeddings/voyage.py
+++ b/src/memsearch/embeddings/voyage.py
@@ -34,6 +34,10 @@ class VoyageEmbedding:
     def dimension(self) -> int:
         return self._dimension
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from .utils import batched_embed
 

--- a/tests/test_core_encoding.py
+++ b/tests/test_core_encoding.py
@@ -17,6 +17,10 @@ class FakeEmbedder:
     def dimension(self) -> int:
         return 4
 
+    @property
+    def batch_size(self) -> int:
+        return 32
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         return [[0.0] * self.dimension for _ in texts]
 

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -7,6 +7,7 @@ split into batches that respect the provider's batch_size limit.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -89,6 +90,10 @@ class FakeEmbedder:
     def dimension(self) -> int:
         return self._dim
 
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
     async def embed(self, texts: list[str]) -> list[list[float]]:
         from memsearch.embeddings.utils import batched_embed
 
@@ -113,6 +118,33 @@ def mem_with_fake(tmp_path: Path):
     ms.close()
 
 
+class RecordingStore:
+    """Records upsert batch sizes without opening a real Milvus connection."""
+
+    def __init__(self) -> None:
+        self.call_sizes: list[int] = []
+        self.records: list[dict[str, Any]] = []
+
+    def upsert(self, records: list[dict[str, Any]]) -> int:
+        self.call_sizes.append(len(records))
+        self.records.extend(records)
+        return len(records)
+
+
+@pytest.fixture
+def mem_with_recording_store():
+    """MemSearch instance wired to fake embedding and fake storage."""
+    fake = FakeEmbedder(batch_size=4, dim=4)
+    store = RecordingStore()
+    ms = MemSearch.__new__(MemSearch)
+    ms._paths = []
+    ms._max_chunk_size = 1500
+    ms._overlap_lines = 2
+    ms._embedder = fake
+    ms._store = store
+    return ms, fake, store
+
+
 def _make_chunks(n: int) -> list[Chunk]:
     return [
         Chunk(
@@ -135,6 +167,17 @@ async def test_embed_and_store_batching(mem_with_fake):
     assert n == 10
     # Should have been split into 3 batches: 4 + 4 + 2
     assert fake.call_sizes == [4, 4, 2]
+
+
+@pytest.mark.asyncio
+async def test_embed_and_store_upserts_by_embedding_batch(mem_with_recording_store):
+    ms, fake, store = mem_with_recording_store
+    chunks = _make_chunks(10)  # 10 chunks, batch size 4
+    n = await ms._embed_and_store(chunks)
+    assert n == 10
+    assert fake.call_sizes == [4, 4, 2]
+    assert store.call_sizes == [4, 4, 2]
+    assert len(store.records) == 10
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- batch indexing writes to Milvus using the embedding provider batch size
- expose provider batch size through the embedding provider interface
- add coverage to verify embedding and upsert batches stay aligned

## Tests
- uv run ruff check src/memsearch/core.py src/memsearch/embeddings tests/test_embed_batching.py tests/test_core_encoding.py
- uv run ruff format --check src/memsearch/core.py src/memsearch/embeddings tests/test_embed_batching.py tests/test_core_encoding.py
- uv run python -m pytest tests/test_core_encoding.py tests/test_embed_batching.py
- uv run python -m pytest