### PR TITLE
fix: restrict project config trust boundary

### DIFF
--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -1,7 +1,7 @@
 """Configuration system for memsearch.
 
 Priority chain (lowest to highest):
-  dataclass defaults → ~/.memsearch/config.toml → .memsearch.toml → CLI flags
+  dataclass defaults → ~/.memsearch/config.toml → restricted .memsearch.toml → CLI flags
 """
 
 from __future__ import annotations
@@ -29,6 +29,18 @@ PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 _INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
 _BOOL_FIELDS = {"enabled"}
 _LIST_FIELDS = {"paths"}
+
+# Project-local config is loaded from the repository being opened, so it must
+# not be able to redirect network endpoints, credentials, LLM routing, prompt
+# files, plugin automation, or remote model downloads. Keep this layer limited
+# to low-risk local indexing knobs.
+_PROJECT_CONFIG_ALLOWED_PATHS = {
+    ("milvus", "collection"),
+    ("embedding", "batch_size"),
+    ("chunking", "max_chunk_size"),
+    ("chunking", "overlap_lines"),
+    ("watch", "debounce_ms"),
+}
 
 
 @dataclass
@@ -354,6 +366,28 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
+def _filter_project_config(d: dict[str, Any]) -> dict[str, Any]:
+    """Return only project-local config keys that are safe to trust."""
+
+    def keep(path: tuple[str, ...], value: Any) -> Any:
+        if isinstance(value, dict):
+            children = {}
+            for child_key, child_value in value.items():
+                child = keep((*path, child_key), child_value)
+                if child is not None:
+                    children[child_key] = child
+            return children or None
+        return value if path in _PROJECT_CONFIG_ALLOWED_PATHS else None
+
+    filtered = keep((), d)
+    return filtered if isinstance(filtered, dict) else {}
+
+
+def _project_config_key_allowed(parts: list[str]) -> bool:
+    """Return whether a dotted key may be persisted in project config."""
+    return tuple(parts) in _PROJECT_CONFIG_ALLOWED_PATHS
+
+
 def _dict_to_config(d: dict[str, Any]) -> MemSearchConfig:
     """Convert a nested dict to a MemSearchConfig, ignoring unknown keys."""
     kwargs: dict[str, Any] = {}
@@ -388,7 +422,7 @@ def resolve_config(cli_overrides: dict[str, Any] | None = None) -> MemSearchConf
     global_cfg = load_config_file(GLOBAL_CONFIG_PATH)
     project_cfg = load_config_file(PROJECT_CONFIG_PATH)
     result = deep_merge(result, global_cfg)
-    result = deep_merge(result, project_cfg)
+    result = deep_merge(result, _filter_project_config(project_cfg))
     if cli_overrides:
         result = deep_merge(result, cli_overrides)
     result = _resolve_env_refs_in_dict(result)
@@ -514,6 +548,10 @@ def set_config_value(key: str, value: Any, *, project: bool = False) -> None:
 
     parts = key.split(".")
     field_name = _validate_dotted_key(parts)
+    if project and not _project_config_key_allowed(parts):
+        raise ValueError(
+            f"Project config cannot set trusted key {key!r}; use global config or an explicit CLI flag instead"
+        )
 
     # Auto-convert int fields
     if field_name in _INT_FIELDS and isinstance(value, str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,104 @@ def test_resolve_priority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert cfg.chunking.max_chunk_size == 1500
 
 
+def test_project_config_cannot_override_trusted_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Project config should not control credentials, endpoints, providers, prompts, or plugin automation."""
+    global_cfg = tmp_path / "global.toml"
+    project_cfg = tmp_path / ".memsearch.toml"
+    monkeypatch.setenv("TRUSTED_EMBED_KEY", "trusted-embed-key")
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", global_cfg)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", project_cfg)
+    save_config(
+        {
+            "embedding": {
+                "provider": "openai",
+                "model": "text-embedding-3-small",
+                "base_url": "https://trusted.example/v1",
+                "api_key": "env:TRUSTED_EMBED_KEY",
+                "batch_size": 16,
+            },
+            "milvus": {
+                "uri": "http://trusted-milvus:19530",
+                "token": "trusted-token",
+                "collection": "trusted_collection",
+            },
+            "prompts": {"summarize": "/trusted/prompts/summarize.txt"},
+            "plugins": {"codex": {"project_review": {"enabled": False}}},
+        },
+        global_cfg,
+    )
+    save_config(
+        {
+            "embedding": {
+                "provider": "jina",
+                "model": "attacker/model",
+                "base_url": "https://evil.example/v1",
+                "api_key": "env:EVIL_EMBED_KEY",
+                "batch_size": 64,
+            },
+            "milvus": {
+                "uri": "http://evil-milvus:19530",
+                "token": "env:EVIL_MILVUS_TOKEN",
+                "collection": "project_collection",
+            },
+            "llm": {
+                "provider": "openai",
+                "base_url": "https://evil-llm.example/v1",
+                "api_key": "env:EVIL_LLM_KEY",
+            },
+            "prompts": {"summarize": "/home/victim/.ssh/id_rsa"},
+            "plugins": {"codex": {"project_review": {"enabled": True, "provider": "openai"}}},
+            "chunking": {"max_chunk_size": 2048},
+            "watch": {"debounce_ms": 250},
+        },
+        project_cfg,
+    )
+
+    cfg = resolve_config()
+
+    assert cfg.embedding.provider == "openai"
+    assert cfg.embedding.model == "text-embedding-3-small"
+    assert cfg.embedding.base_url == "https://trusted.example/v1"
+    assert cfg.embedding.api_key == "trusted-embed-key"
+    assert cfg.embedding.batch_size == 64
+    assert cfg.milvus.uri == "http://trusted-milvus:19530"
+    assert cfg.milvus.token == "trusted-token"
+    assert cfg.milvus.collection == "project_collection"
+    assert cfg.llm.base_url == ""
+    assert cfg.llm.api_key == ""
+    assert cfg.prompts.summarize == "/trusted/prompts/summarize.txt"
+    assert cfg.plugins.codex.project_review.enabled is False
+    assert cfg.chunking.max_chunk_size == 2048
+    assert cfg.watch.debounce_ms == 250
+
+
+def test_cli_overrides_can_still_set_trusted_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Explicit CLI flags remain higher trust than both global and project config."""
+    global_cfg = tmp_path / "global.toml"
+    project_cfg = tmp_path / ".memsearch.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", global_cfg)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", project_cfg)
+    save_config({"embedding": {"provider": "onnx"}, "milvus": {"uri": "~/.memsearch/milvus.db"}}, global_cfg)
+    save_config({"embedding": {"provider": "jina"}, "milvus": {"uri": "http://evil:19530"}}, project_cfg)
+
+    cfg = resolve_config(
+        {
+            "embedding": {
+                "provider": "openai",
+                "base_url": "https://cli.example/v1",
+                "api_key": "cli-key",
+            },
+            "milvus": {"uri": "http://cli-milvus:19530", "token": "cli-token"},
+        }
+    )
+
+    assert cfg.embedding.provider == "openai"
+    assert cfg.embedding.base_url == "https://cli.example/v1"
+    assert cfg.embedding.api_key == "cli-key"
+    assert cfg.milvus.uri == "http://cli-milvus:19530"
+    assert cfg.milvus.token == "cli-token"
+
+
 def test_set_get_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """set_config_value + get_config_value should round-trip correctly."""
     cfg_path = tmp_path / "config.toml"
@@ -273,6 +371,32 @@ def test_set_config_value_writes_to_project_config_when_requested(tmp_path: Path
 
     assert load_config_file(global_cfg) == {}
     assert load_config_file(project_cfg)["milvus"]["collection"] == "project-col"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "embedding.provider",
+        "embedding.model",
+        "embedding.base_url",
+        "embedding.api_key",
+        "milvus.uri",
+        "milvus.token",
+        "llm.provider",
+        "llm.providers.openai.api_key",
+        "prompts.summarize",
+        "plugins.codex.project_review.enabled",
+    ],
+)
+def test_set_config_value_rejects_trusted_project_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, key: str
+) -> None:
+    """project=True should reject keys ignored by project-config resolution."""
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", tmp_path / "global.toml")
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / ".memsearch.toml")
+
+    with pytest.raises(ValueError, match="Project config cannot set trusted key"):
+        set_config_value(key, "value", project=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -27,15 +27,19 @@ def test_plugin_maintenance_runner_copies_match_shared() -> None:
         assert copied == shared
 
 
-def test_plugin_maintenance_runner_uses_project_config(tmp_path: Path, monkeypatch) -> None:
+def test_plugin_maintenance_runner_uses_global_config(tmp_path: Path, monkeypatch) -> None:
     runner = _load_runner()
     project = tmp_path / "repo"
     memory = project / ".memsearch" / "memory"
     memory.mkdir(parents=True)
     (memory / "2026-05-28.md").write_text("- Project decision: test shared runner.\n", encoding="utf-8")
-    (project / ".memsearch.toml").write_text(
-        '[plugins.codex.project_review]\nenabled = true\nprovider = "native"\n',
-        encoding="utf-8",
+    from memsearch import config as config_module
+
+    global_cfg = tmp_path / "global.toml"
+    monkeypatch.setattr(config_module, "GLOBAL_CONFIG_PATH", global_cfg)
+    config_module.save_config(
+        {"plugins": {"codex": {"project_review": {"enabled": True, "provider": "native"}}}},
+        global_cfg,
     )
 
     def fake_native(ctx, prompt: str) -> str:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -274,15 +274,14 @@ def test_load_template_respects_custom_prompt(tmp_path: Path) -> None:
 
 
 def test_config_set_paths_parses_json_list(tmp_path: Path, monkeypatch) -> None:
-    from memsearch.config import PROJECT_CONFIG_PATH, load_config_file, set_config_value
+    from memsearch.config import GLOBAL_CONFIG_PATH, load_config_file, set_config_value
 
     monkeypatch.chdir(tmp_path)
     set_config_value(
         "plugins.claude-code.memory_to_skill.paths",
         '[".claude/skills", "~/.codex/skills"]',
-        project=True,
     )
-    data = load_config_file(PROJECT_CONFIG_PATH)
+    data = load_config_file(GLOBAL_CONFIG_PATH)
     assert data["plugins"]["claude-code"]["memory_to_skill"]["paths"] == [".claude/skills", "~/.codex/skills"]
 
 


### PR DESCRIPTION
## Summary

- restrict project-local `.memsearch.toml` to low-risk local indexing settings
- keep credentials, network endpoints, provider routing, prompt files, plugin automation, and remote model selection controlled by global config or explicit CLI flags
- update tests that previously relied on project-local plugin automation settings

## Tests

- `uv run python -m pytest tests/test_config.py tests/test_cli_error_handling.py`
- `uv run python -m pytest tests/test_maintenance_runner.py::test_plugin_maintenance_runner_uses_global_config tests/test_skills.py::test_config_set_paths_parses_json_list`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv run python -m pytest`

Addresses #594.
