### PR TITLE
fix: restrict project config wizard to allowlisted keys

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,11 +59,13 @@ Higher-priority sources override lower-priority ones.
 
 #### `memsearch config init`
 
-Launch an interactive wizard that walks through all configuration sections and writes a TOML config file.
+Launch an interactive wizard and write a TOML config file. Global mode walks
+through all configuration sections. Project mode writes only allowlisted local
+indexing keys to `.memsearch.toml`.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--project` | `false` | Write to `.memsearch.toml` (project-level) instead of the global config |
+| `--project` | `false` | Write allowlisted local indexing keys to `.memsearch.toml` |
 
 ```bash
 $ memsearch config init
@@ -116,6 +118,7 @@ Create a project-level config:
 $ memsearch config init --project
 memsearch configuration wizard
 Writing to: .memsearch.toml
+Project config is limited to low-risk local indexing keys.
 ...
 ```
 
@@ -127,35 +130,42 @@ Set a single configuration value by dotted key. Keys follow the `section.field` 
 |------|---------|-------------|
 | `KEY` | *(required)* | Dotted config key (e.g., `milvus.uri`) |
 | `VALUE` | *(required)* | Value to set |
-| `--project` | `false` | Write to `.memsearch.toml` instead of global config |
+| `--project` | `false` | Write an allowlisted local indexing key to `.memsearch.toml` instead of global config |
 
 ```bash
 $ memsearch config set milvus.uri http://localhost:19530
 Set milvus.uri = http://localhost:19530 in /home/user/.memsearch/config.toml
 
-$ memsearch config set embedding.provider google --project
-Set embedding.provider = google in .memsearch.toml
+$ memsearch config set embedding.batch_size 32 --project
+Set embedding.batch_size = 32 in .memsearch.toml
 
-$ memsearch config set chunking.max_chunk_size 2000
-Set chunking.max_chunk_size = 2000 in /home/user/.memsearch/config.toml
+$ memsearch config set chunking.max_chunk_size 2000 --project
+Set chunking.max_chunk_size = 2000 in .memsearch.toml
 ```
 
-Plugin config keys use `plugins.<platform>.<task>.<field>`:
+Project config is restricted before it is merged. Use `--project` only for
+allowlisted local indexing keys such as `milvus.collection`,
+`embedding.batch_size`, `chunking.max_chunk_size`, `chunking.overlap_lines`, and
+`watch.debounce_ms`. Trusted settings such as provider routing, endpoints, API
+keys, prompt files, and plugin automation must go in global config or explicit
+CLI flags.
+
+Plugin config keys use `plugins.<platform>.<task>.<field>` and are global:
 
 ```bash
-$ memsearch config set plugins.codex.summarize.enabled false --project
-Set plugins.codex.summarize.enabled = false in .memsearch.toml
+$ memsearch config set plugins.codex.summarize.enabled false
+Set plugins.codex.summarize.enabled = false in /home/user/.memsearch/config.toml
 
-$ memsearch config set plugins.codex.project_review.enabled true --project
-Set plugins.codex.project_review.enabled = true in .memsearch.toml
+$ memsearch config set plugins.codex.project_review.enabled true
+Set plugins.codex.project_review.enabled = true in /home/user/.memsearch/config.toml
 
-$ memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md --project
-Set plugins.codex.project_review.output_file = .memsearch/PROJECT.md in .memsearch.toml
+$ memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md
+Set plugins.codex.project_review.output_file = .memsearch/PROJECT.md in /home/user/.memsearch/config.toml
 ```
 
 Supported plugin platforms are `claude-code`, `codex`, `opencode`, and
-`openclaw`. Supported plugin tasks are `summarize`, `project_review`, and
-`user_profile`.
+`openclaw`. Supported plugin tasks are `summarize`, `project_review`,
+`user_profile`, and `memory_to_skill`.
 
 #### `memsearch config get`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -524,7 +524,8 @@ Writing to: /home/user/.memsearch/config.toml
 Config saved to /home/user/.memsearch/config.toml
 ```
 
-Use `--project` to write to `.memsearch.toml` in the current directory instead:
+Use `--project` to write allowlisted local indexing overrides to
+`.memsearch.toml` in the current directory:
 
 ```bash
 $ memsearch config init --project
@@ -535,7 +536,7 @@ $ memsearch config init --project
 | Scope | Path | Use case |
 |-------|------|----------|
 | Global | `~/.memsearch/config.toml` | Machine-wide defaults (Milvus URI, preferred provider) |
-| Project | `.memsearch.toml` | Per-project overrides (collection name, custom model) |
+| Project | `.memsearch.toml` | Low-risk local indexing overrides (collection name, batch size, chunking, watch debounce) |
 
 Both files use TOML format:
 
@@ -629,7 +630,7 @@ api_key = "env:AZURE_OPENAI_API_KEY"
 ```
 
 ```toml
-# .memsearch.toml — local vLLM example
+# ~/.memsearch/config.toml — local vLLM example
 [embedding]
 provider = "openai"
 model = "BAAI/bge-small-en-v1.5"
@@ -637,7 +638,9 @@ base_url = "http://localhost:8000/v1"
 api_key = "dummy"
 ```
 
-These settings can also be passed via CLI flags (`--base-url`, `--api-key`) or the Python API (`embedding_base_url`, `embedding_api_key`).
+These trusted settings belong in global config. They can also be passed via CLI
+flags (`--base-url`, `--api-key`) or the Python API (`embedding_base_url`,
+`embedding_api_key`).
 
 ### Get and set individual values
 
@@ -648,8 +651,8 @@ Set milvus.uri = http://localhost:19530 in /home/user/.memsearch/config.toml
 $ memsearch config get milvus.uri
 http://localhost:19530
 
-$ memsearch config set embedding.provider ollama --project
-Set embedding.provider = ollama in .memsearch.toml
+$ memsearch config set embedding.batch_size 32 --project
+Set embedding.batch_size = 32 in .memsearch.toml
 ```
 
 ### View resolved configuration

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -8,6 +8,13 @@ memsearch uses a layered TOML config system. Most users don't need to configure 
 2. `<project>/.memsearch.toml` — project-level overrides
 3. CLI flags — highest priority
 
+Since v0.4.11, project-level `.memsearch.toml` is intentionally restricted
+before it is merged. It can only set low-risk local indexing keys:
+`milvus.collection`, `embedding.batch_size`, `chunking.max_chunk_size`,
+`chunking.overlap_lines`, and `watch.debounce_ms`. Put trusted settings such as
+provider routing, API endpoints, API keys, prompt files, and `plugins.*`
+automation in global config or pass them as explicit CLI flags.
+
 ## Quick Setup
 
 ```bash
@@ -99,11 +106,11 @@ memsearch config set plugins.codex.summarize.provider openai
 Set `plugins.<platform>.summarize.provider` to `native`, or leave it empty, to
 preserve the current plugin behavior.
 
-You can disable automatic capture for a single project while keeping the plugin
-installed:
+You can disable automatic capture for a platform globally while keeping the
+plugin installed:
 
 ```bash
-memsearch config set plugins.codex.summarize.enabled false --project
+memsearch config set plugins.codex.summarize.enabled false
 ```
 
 ## Advanced Plugin Maintenance
@@ -116,21 +123,21 @@ This is disabled by default.
 | `project_review` | `.memsearch/PROJECT.md` | Durable project state: active threads, decisions, risks, next steps |
 | `user_profile` | `.memsearch/USER.md` | Reusable user preferences, working style, recurring goals, background context |
 
-Example project-level setup for Codex:
+Example global setup for Codex:
 
 ```bash
-memsearch config set plugins.codex.project_review.enabled true --project
-memsearch config set plugins.codex.project_review.provider native --project
-memsearch config set plugins.codex.project_review.min_interval_hours 24 --project
-memsearch config set plugins.codex.project_review.input_dir .memsearch/memory --project
-memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md --project
+memsearch config set plugins.codex.project_review.enabled true
+memsearch config set plugins.codex.project_review.provider native
+memsearch config set plugins.codex.project_review.min_interval_hours 24
+memsearch config set plugins.codex.project_review.input_dir .memsearch/memory
+memsearch config set plugins.codex.project_review.output_file .memsearch/PROJECT.md
 
-memsearch config set plugins.codex.user_profile.enabled true --project
-memsearch config set plugins.codex.user_profile.provider native --project
-memsearch config set plugins.codex.user_profile.output_file .memsearch/USER.md --project
+memsearch config set plugins.codex.user_profile.enabled true
+memsearch config set plugins.codex.user_profile.provider native
+memsearch config set plugins.codex.user_profile.output_file .memsearch/USER.md
 ```
 
-Equivalent TOML:
+Equivalent TOML in `~/.memsearch/config.toml`:
 
 ```toml
 [plugins.codex.summarize]
@@ -179,19 +186,20 @@ reference it from the task:
 memsearch config set llm.providers.openai.type openai
 memsearch config set llm.providers.openai.model gpt-5-mini
 memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
-memsearch config set plugins.codex.project_review.provider openai --project
+memsearch config set plugins.codex.project_review.provider openai
 ```
 
-Custom maintenance prompts are configured globally or per project:
+Custom maintenance prompts are configured globally. Prefer absolute paths for
+shared prompt files:
 
 ```bash
-memsearch config set prompts.project_review .memsearch/prompts/project-review.txt --project
-memsearch config set prompts.user_profile .memsearch/prompts/user-profile.txt --project
+memsearch config set prompts.project_review /path/to/project-review.txt
+memsearch config set prompts.user_profile /path/to/user-profile.txt
 ```
 
 The plugin-installed `memory-config` skill can inspect current config, memory
-files, and index health; explain these settings; and make safe project-scoped
-changes from natural-language requests.
+files, and index health; explain these settings; and choose global vs project
+scope from natural-language requests.
 
 ## Skills from Memory (procedural memory)
 
@@ -208,10 +216,14 @@ shares the maintenance tasks' provider/model routing, prompt override
 (`prompts.memory_to_skill`), `input_dir`, and `min_interval_hours` cadence.
 
 ```bash
-memsearch config set plugins.codex.memory_to_skill.enabled true --project
-memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project   # default 3; lower = more eager
-memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --project   # optional; empty = asked at install
+memsearch config set plugins.codex.memory_to_skill.enabled true
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3   # default 3; lower = more eager
+memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]'   # optional; empty = asked at install
 ```
+
+Since v0.4.11, project-local `.memsearch.toml` accepts only allowlisted local
+indexing keys. Keep `plugins.*` settings such as `memory_to_skill.*` in global
+config; do not set them with `--project`.
 
 | Field | Default | Meaning |
 | --- | --- | --- |

--- a/docs/home/embedding-evaluation.md
+++ b/docs/home/embedding-evaluation.md
@@ -118,7 +118,7 @@ The previous Claude Code plugin default was OpenAI `text-embedding-3-small`, whi
   memsearch index .memsearch/memory/ --force
   ```
 
-- **Users with an explicit `embedding.provider` in `.memsearch.toml` or `~/.memsearch/config.toml` are unaffected** — your config still wins.
+- **Users with an explicit `embedding.provider` in `~/.memsearch/config.toml` are unaffected** — your global config still wins.
 
 To pre-download the ONNX model instead of waiting for the first-use download:
 

--- a/plugins/claude-code/skills/memory-config/SKILL.md
+++ b/plugins/claude-code/skills/memory-config/SKILL.md
@@ -17,7 +17,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 
 - Empty request or "check": diagnose current MemSearch setup.
 - "Show/get setting": read the requested resolved/global/project value.
-- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Set/enable/disable/change": choose global vs project scope explicitly; use global config for trusted plugin automation/provider/prompt/endpoint settings and project config only for allowlisted local indexing knobs.
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
@@ -114,14 +114,33 @@ Config is resolved from built-in defaults, global config, project config, env re
 
 Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
 
+Since v0.4.11, project-local `.memsearch.toml` is restricted before it is merged.
+Only these low-risk local indexing keys are honored from project config:
+
+- `milvus.collection`
+- `embedding.batch_size`
+- `chunking.max_chunk_size`
+- `chunking.overlap_lines`
+- `watch.debounce_ms`
+
+Trusted settings are ignored or rejected in project config. Put these in global
+config (`~/.memsearch/config.toml`) or pass explicit CLI flags instead:
+
+- provider/model/API endpoint/API key settings
+- `[llm]` and `[llm.providers.*]`
+- `[prompts]`
+- plugin automation such as `plugins.claude-code.project_review.enabled`,
+  `plugins.claude-code.user_profile.enabled`, and
+  `plugins.claude-code.memory_to_skill.enabled`
+
 Default recommendation:
 
 - Put reusable defaults in global config so users do not repeat setup in every project.
-- Put only project-specific overrides in project config.
-- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
-- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+- Put only allowlisted local indexing overrides in project config.
+- Use global config for named LLM providers, common model choices, plugin enable/disable switches, task intervals, install paths, and shared prompt defaults.
+- If the user wants advanced maintenance enabled for all projects, set the plugin keys globally. The default relative `input_dir` / `output_file` values still resolve inside each current project.
 
-Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime, so a global `output_file = ".memsearch/PROJECT.md"` writes to each project's own `.memsearch/PROJECT.md`. For custom prompt paths, prefer absolute paths in global config; project prompt paths are not trusted.
 
 Claude Code plugin keys:
 
@@ -193,7 +212,7 @@ If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
 `last_failed_at`; background hook errors may not surface in the chat.
 
-Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files, and whether the user wants the enablement global. Do not write plugin automation keys with `--project`; v0.4.11+ project config ignores or rejects them.
 
 Prompt overrides:
 
@@ -207,8 +226,8 @@ memory_to_skill = ""
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
 
-Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+Use `memsearch config set` for changes. For trusted keys such as `plugins.*`, `[llm.providers.*]`, `[prompts]`, `embedding.provider`, or `milvus.uri`, set global config by omitting `--project`. Use `--project` only for allowlisted local indexing keys. After changing anything, show the command, the resolved value, and whether a new session is needed.
 
 MemSearch TOML changes are read lazily by the CLI, hooks, and maintenance runner, so values such as `plugins.claude-code.summarize.*`, `plugins.claude-code.project_review.*`, `plugins.claude-code.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. A fresh Claude Code session is recommended after plugin install/update or hook/skill file changes, because the current session may already have loaded the old plugin state. In final diagnostic/change summaries, make clear that this is MemSearch memory configuration, not Claude Code's own memory/config system.
 
-When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for allowlisted project indexing setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -92,13 +92,18 @@ The background pass mines automatically when enabled, starting from the summarie
 
 ```bash
 memsearch config get plugins.claude-code.memory_to_skill.enabled 2>/dev/null || echo "false"
-# enable the background pass (do not enable silently)
-memsearch config set plugins.claude-code.memory_to_skill.enabled true --project
+# enable the background pass globally (do not enable silently)
+memsearch config set plugins.claude-code.memory_to_skill.enabled true
 # how eagerly history-mining distils (default 3; lower = more eager)
-memsearch config set plugins.claude-code.memory_to_skill.min_occurrences 3 --project
+memsearch config set plugins.claude-code.memory_to_skill.min_occurrences 3
 # pre-set install targets (otherwise you are asked at install time)
-memsearch config set plugins.claude-code.memory_to_skill.paths '[".claude/skills"]' --project
+memsearch config set plugins.claude-code.memory_to_skill.paths '[".claude/skills"]'
 ```
+
+Since v0.4.11, project-local `.memsearch.toml` accepts only allowlisted local
+indexing keys. Do not use `--project` for `plugins.*` settings such as
+`memory_to_skill.enabled`, `min_occurrences`, or `paths`; put them in global
+config instead.
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
 commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.

--- a/plugins/codex/skills/memory-config/SKILL.md
+++ b/plugins/codex/skills/memory-config/SKILL.md
@@ -15,7 +15,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 
 - Empty request or "check": diagnose current MemSearch setup.
 - "Show/get setting": read the requested resolved/global/project value.
-- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Set/enable/disable/change": choose global vs project scope explicitly; use global config for trusted plugin automation/provider/prompt/endpoint settings and project config only for allowlisted local indexing knobs.
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
@@ -112,14 +112,33 @@ Config is resolved from built-in defaults, global config, project config, env re
 
 Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
 
+Since v0.4.11, project-local `.memsearch.toml` is restricted before it is merged.
+Only these low-risk local indexing keys are honored from project config:
+
+- `milvus.collection`
+- `embedding.batch_size`
+- `chunking.max_chunk_size`
+- `chunking.overlap_lines`
+- `watch.debounce_ms`
+
+Trusted settings are ignored or rejected in project config. Put these in global
+config (`~/.memsearch/config.toml`) or pass explicit CLI flags instead:
+
+- provider/model/API endpoint/API key settings
+- `[llm]` and `[llm.providers.*]`
+- `[prompts]`
+- plugin automation such as `plugins.codex.project_review.enabled`,
+  `plugins.codex.user_profile.enabled`, and
+  `plugins.codex.memory_to_skill.enabled`
+
 Default recommendation:
 
 - Put reusable defaults in global config so users do not repeat setup in every project.
-- Put only project-specific overrides in project config.
-- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
-- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+- Put only allowlisted local indexing overrides in project config.
+- Use global config for named LLM providers, common model choices, plugin enable/disable switches, task intervals, install paths, and shared prompt defaults.
+- If the user wants advanced maintenance enabled for all projects, set the plugin keys globally. The default relative `input_dir` / `output_file` values still resolve inside each current project.
 
-Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime, so a global `output_file = ".memsearch/PROJECT.md"` writes to each project's own `.memsearch/PROJECT.md`. For custom prompt paths, prefer absolute paths in global config; project prompt paths are not trusted.
 
 Codex plugin keys:
 
@@ -191,7 +210,7 @@ If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
 `last_failed_at`; background hook errors may not surface in the chat.
 
-Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files, and whether the user wants the enablement global. Do not write plugin automation keys with `--project`; v0.4.11+ project config ignores or rejects them.
 
 Prompt overrides:
 
@@ -205,8 +224,8 @@ memory_to_skill = ""
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
 
-Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+Use `memsearch config set` for changes. For trusted keys such as `plugins.*`, `[llm.providers.*]`, `[prompts]`, `embedding.provider`, or `milvus.uri`, set global config by omitting `--project`. Use `--project` only for allowlisted local indexing keys. After changing anything, show the command, the resolved value, and whether a new session is needed.
 
 MemSearch TOML changes are read lazily by the CLI, hooks, and maintenance runner, so values such as `plugins.codex.summarize.*`, `plugins.codex.project_review.*`, `plugins.codex.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. A fresh Codex session is recommended after `hooks.json`, skill, plugin, or local agent-file changes, because the current session may already have loaded the old hook/skill state. In final diagnostic/change summaries, make clear that this is MemSearch memory configuration, not Codex's own memory/config system.
 
-When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for allowlisted project indexing setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -90,13 +90,18 @@ The background pass mines automatically when enabled, starting from the summarie
 
 ```bash
 memsearch config get plugins.codex.memory_to_skill.enabled 2>/dev/null || echo "false"
-# enable the background pass (do not enable silently)
-memsearch config set plugins.codex.memory_to_skill.enabled true --project
+# enable the background pass globally (do not enable silently)
+memsearch config set plugins.codex.memory_to_skill.enabled true
 # how eagerly history-mining distils (default 3; lower = more eager)
-memsearch config set plugins.codex.memory_to_skill.min_occurrences 3 --project
+memsearch config set plugins.codex.memory_to_skill.min_occurrences 3
 # pre-set install targets (otherwise you are asked at install time)
-memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]' --project
+memsearch config set plugins.codex.memory_to_skill.paths '[".agents/skills"]'
 ```
+
+Since v0.4.11, project-local `.memsearch.toml` accepts only allowlisted local
+indexing keys. Do not use `--project` for `plugins.*` settings such as
+`memory_to_skill.enabled`, `min_occurrences`, or `paths`; put them in global
+config instead.
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
 commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.

--- a/plugins/openclaw/skills/memory-config/SKILL.md
+++ b/plugins/openclaw/skills/memory-config/SKILL.md
@@ -15,7 +15,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 
 - Empty request or "check": diagnose current MemSearch setup.
 - "Show/get setting": read the requested resolved/global/project value.
-- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Set/enable/disable/change": choose global vs project scope explicitly; use global config for trusted plugin automation/provider/prompt/endpoint settings and project config only for allowlisted local indexing knobs.
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
@@ -112,14 +112,33 @@ Config is resolved from built-in defaults, global config, project config, env re
 
 Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for workspace-specific overrides.
 
+Since v0.4.11, project-local `.memsearch.toml` is restricted before it is merged.
+Only these low-risk local indexing keys are honored from project config:
+
+- `milvus.collection`
+- `embedding.batch_size`
+- `chunking.max_chunk_size`
+- `chunking.overlap_lines`
+- `watch.debounce_ms`
+
+Trusted settings are ignored or rejected in project config. Put these in global
+config (`~/.memsearch/config.toml`) or pass explicit CLI flags instead:
+
+- provider/model/API endpoint/API key settings
+- `[llm]` and `[llm.providers.*]`
+- `[prompts]`
+- plugin automation such as `plugins.openclaw.project_review.enabled`,
+  `plugins.openclaw.user_profile.enabled`, and
+  `plugins.openclaw.memory_to_skill.enabled`
+
 Default recommendation:
 
 - Put reusable defaults in global config so users do not repeat setup in every project.
-- Put only project-specific overrides in project config.
-- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
-- Use project config for one workspace's enable/disable switches, unusual output files, special intervals, or workspace-specific providers.
+- Put only allowlisted local indexing overrides in project config.
+- Use global config for named LLM providers, common model choices, plugin enable/disable switches, task intervals, install paths, and shared prompt defaults.
+- If the user wants advanced maintenance enabled for all projects, set the plugin keys globally. The default relative `input_dir` / `output_file` values still resolve inside each current workspace/project.
 
-Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current workspace/project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current workspace/project directory at runtime, so a global `output_file = ".memsearch/PROJECT.md"` writes to each workspace/project's own `.memsearch/PROJECT.md`. For custom prompt paths, prefer absolute paths in global config; project prompt paths are not trusted.
 
 OpenClaw plugin keys:
 
@@ -191,7 +210,7 @@ If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
 `last_failed_at`; background hook errors may not surface in the chat.
 
-Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files, and whether the user wants the enablement global. Do not write plugin automation keys with `--project`; v0.4.11+ project config ignores or rejects them.
 
 Prompt overrides:
 
@@ -205,8 +224,8 @@ memory_to_skill = ""
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
 
-Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+Use `memsearch config set` for changes. For trusted keys such as `plugins.*`, `[llm.providers.*]`, `[prompts]`, `embedding.provider`, or `milvus.uri`, set global config by omitting `--project`. Use `--project` only for allowlisted local indexing keys. After changing anything, show the command, the resolved value, and whether a new session is needed.
 
 MemSearch TOML changes are read lazily by the CLI, OpenClaw plugin hooks/tools, and maintenance runner, so values such as `plugins.openclaw.summarize.*`, `plugins.openclaw.project_review.*`, `plugins.openclaw.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. Run `openclaw gateway restart` after plugin install/update or hook permission changes, because the gateway may already have loaded the old plugin state. In final diagnostic/change summaries, make clear that this is MemSearch memory configuration, not OpenClaw's own memory/config system.
 
-When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for allowlisted project indexing setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -90,13 +90,18 @@ The background pass mines automatically when enabled, starting from the summarie
 
 ```bash
 memsearch config get plugins.openclaw.memory_to_skill.enabled 2>/dev/null || echo "false"
-# enable the background pass (do not enable silently)
-memsearch config set plugins.openclaw.memory_to_skill.enabled true --project
+# enable the background pass globally (do not enable silently)
+memsearch config set plugins.openclaw.memory_to_skill.enabled true
 # how eagerly history-mining distils (default 3; lower = more eager)
-memsearch config set plugins.openclaw.memory_to_skill.min_occurrences 3 --project
+memsearch config set plugins.openclaw.memory_to_skill.min_occurrences 3
 # pre-set install targets (otherwise you are asked at install time)
-memsearch config set plugins.openclaw.memory_to_skill.paths '[".openclaw/skills"]' --project
+memsearch config set plugins.openclaw.memory_to_skill.paths '[".openclaw/skills"]'
 ```
+
+Since v0.4.11, project-local `.memsearch.toml` accepts only allowlisted local
+indexing keys. Do not use `--project` for `plugins.*` settings such as
+`memory_to_skill.enabled`, `min_occurrences`, or `paths`; put them in global
+config instead.
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
 commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.

--- a/plugins/opencode/skills/memory-config/SKILL.md
+++ b/plugins/opencode/skills/memory-config/SKILL.md
@@ -15,7 +15,7 @@ When this skill is triggered, inspect the user's request text. If there is no co
 
 - Empty request or "check": diagnose current MemSearch setup.
 - "Show/get setting": read the requested resolved/global/project value.
-- "Set/enable/disable/change": make a safe project-scoped change after confirming ambiguous choices.
+- "Set/enable/disable/change": choose global vs project scope explicitly; use global config for trusted plugin automation/provider/prompt/endpoint settings and project config only for allowlisted local indexing knobs.
 - "Not capturing/search empty/no memory": troubleshoot files, config, and index health.
 - "Use OpenAI/Gemini/Anthropic/native/model": configure provider routing.
 - "PROJECT.md/USER.md/profile/review": configure advanced maintenance.
@@ -114,14 +114,33 @@ Config is resolved from built-in defaults, global config, project config, env re
 
 Use `memsearch config list --resolved` for effective behavior, `--global` for global overrides, and `--project` for repository-specific overrides.
 
+Since v0.4.11, project-local `.memsearch.toml` is restricted before it is merged.
+Only these low-risk local indexing keys are honored from project config:
+
+- `milvus.collection`
+- `embedding.batch_size`
+- `chunking.max_chunk_size`
+- `chunking.overlap_lines`
+- `watch.debounce_ms`
+
+Trusted settings are ignored or rejected in project config. Put these in global
+config (`~/.memsearch/config.toml`) or pass explicit CLI flags instead:
+
+- provider/model/API endpoint/API key settings
+- `[llm]` and `[llm.providers.*]`
+- `[prompts]`
+- plugin automation such as `plugins.opencode.project_review.enabled`,
+  `plugins.opencode.user_profile.enabled`, and
+  `plugins.opencode.memory_to_skill.enabled`
+
 Default recommendation:
 
 - Put reusable defaults in global config so users do not repeat setup in every project.
-- Put only project-specific overrides in project config.
-- Use global config for named LLM providers, common model choices, normal input/output defaults, and shared prompt defaults.
-- Use project config for one repo's enable/disable switches, unusual output files, special intervals, or repo-specific providers.
+- Put only allowlisted local indexing overrides in project config.
+- Use global config for named LLM providers, common model choices, plugin enable/disable switches, task intervals, install paths, and shared prompt defaults.
+- If the user wants advanced maintenance enabled for all projects, set the plugin keys globally. The default relative `input_dir` / `output_file` values still resolve inside each current project.
 
-Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime. For custom prompt paths, prefer absolute paths in global config and relative paths in project config.
+Maintenance `input_dir` and `output_file` may be relative even when configured globally. They are resolved from the current project directory at runtime, so a global `output_file = ".memsearch/PROJECT.md"` writes to each project's own `.memsearch/PROJECT.md`. For custom prompt paths, prefer absolute paths in global config; project prompt paths are not trusted.
 
 OpenCode plugin keys:
 
@@ -193,7 +212,7 @@ If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and
 `last_failed_at`; background hook errors may not surface in the chat.
 
-Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, and whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files.
+Before enabling advanced maintenance, ask which provider to use, whether the default 24-hour interval is acceptable, whether `.memsearch/PROJECT.md` / `.memsearch/USER.md` are acceptable output files, and whether the user wants the enablement global. Do not write plugin automation keys with `--project`; v0.4.11+ project config ignores or rejects them.
 
 Prompt overrides:
 
@@ -207,8 +226,8 @@ memory_to_skill = ""
 
 Empty prompt paths mean use the built-in MemSearch prompts. Custom prompt files may use `{{AGENT_NAME}}`, `{{TASK_NAME}}`, `{{PROJECT_DIR}}`, `{{INPUT_DIR}}`, and `{{OUTPUT_FILE}}`; the runner appends existing output, recent journals, and digest automatically.
 
-Use `memsearch config set` for changes. After changing anything, show the command, the resolved value, and whether a new session is needed.
+Use `memsearch config set` for changes. For trusted keys such as `plugins.*`, `[llm.providers.*]`, `[prompts]`, `embedding.provider`, or `milvus.uri`, set global config by omitting `--project`. Use `--project` only for allowlisted local indexing keys. After changing anything, show the command, the resolved value, and whether a new session is needed.
 
 MemSearch TOML changes are read lazily by the CLI, capture daemon, and maintenance runner, so values such as `plugins.opencode.summarize.*`, `plugins.opencode.project_review.*`, `plugins.opencode.user_profile.*`, `[llm.providers.*]`, `[prompts]`, `milvus.*`, and `embedding.*` usually apply on the next capture, recall, index, or maintenance invocation. Restart OpenCode after `opencode.json` or plugin package changes; if capture behavior still looks stale after TOML edits, restart OpenCode or the capture daemon. In final diagnostic/change summaries, make clear that this is MemSearch memory configuration, not OpenCode's own memory/config system.
 
-When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for project interactive setup, and `memsearch config set/get/list` for direct CLI changes.
+When useful, remind the user that they can either continue using this `memory-config` skill for guided configuration, or manually run `memsearch config init` for global interactive setup, `memsearch config init --project` for allowlisted project indexing setup, and `memsearch config set/get/list` for direct CLI changes.

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -90,13 +90,18 @@ The background pass mines automatically when enabled, starting from the summarie
 
 ```bash
 memsearch config get plugins.opencode.memory_to_skill.enabled 2>/dev/null || echo "false"
-# enable the background pass (do not enable silently)
-memsearch config set plugins.opencode.memory_to_skill.enabled true --project
+# enable the background pass globally (do not enable silently)
+memsearch config set plugins.opencode.memory_to_skill.enabled true
 # how eagerly history-mining distils (default 3; lower = more eager)
-memsearch config set plugins.opencode.memory_to_skill.min_occurrences 3 --project
+memsearch config set plugins.opencode.memory_to_skill.min_occurrences 3
 # pre-set install targets (otherwise you are asked at install time)
-memsearch config set plugins.opencode.memory_to_skill.paths '[".agents/skills"]' --project
+memsearch config set plugins.opencode.memory_to_skill.paths '[".agents/skills"]'
 ```
+
+Since v0.4.11, project-local `.memsearch.toml` accepts only allowlisted local
+indexing keys. Do not use `--project` for `plugins.*` settings such as
+`memory_to_skill.enabled`, `min_occurrences`, or `paths`; put them in global
+config instead.
 
 Note: `enabled` only gates the **background** (session-end) pass. The explicit
 commands above (`skills add`, `skills install`) always work, and you can mine history (C) directly.

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -770,7 +770,7 @@ def config_group() -> None:
 
 
 @config_group.command("init")
-@click.option("--project", is_flag=True, help="Write to .memsearch.toml (project-level) instead of global.")
+@click.option("--project", is_flag=True, help="Write allowlisted local indexing keys to .memsearch.toml.")
 def config_init(project: bool) -> None:
     """Interactive configuration wizard."""
 
@@ -782,6 +782,46 @@ def config_init(project: bool) -> None:
 
     click.echo("memsearch configuration wizard")
     click.echo(f"Writing to: {target}\n")
+
+    if project:
+        click.echo("Project config is limited to low-risk local indexing keys.")
+        result["milvus"] = {}
+        result["milvus"]["collection"] = click.prompt(
+            "  Collection name",
+            default=current.milvus.collection,
+        )
+
+        result["embedding"] = {}
+        result["embedding"]["batch_size"] = click.prompt(
+            "  Embedding batch size (0 = provider default)",
+            default=current.embedding.batch_size,
+            type=int,
+        )
+
+        click.echo("\n── Chunking ──")
+        result["chunking"] = {}
+        result["chunking"]["max_chunk_size"] = click.prompt(
+            "  Max chunk size (chars)",
+            default=current.chunking.max_chunk_size,
+            type=int,
+        )
+        result["chunking"]["overlap_lines"] = click.prompt(
+            "  Overlap lines",
+            default=current.chunking.overlap_lines,
+            type=int,
+        )
+
+        click.echo("\n── Watch ──")
+        result["watch"] = {}
+        result["watch"]["debounce_ms"] = click.prompt(
+            "  Debounce (ms)",
+            default=current.watch.debounce_ms,
+            type=int,
+        )
+
+        save_config(result, target)
+        click.echo(f"\nConfig saved to {target}")
+        return
 
     # Milvus
     click.echo("── Milvus ──")
@@ -1066,7 +1106,7 @@ def skills_distill(plugin: str, force: bool) -> None:
         click.echo(
             "Standalone 'skills distill' needs an API provider; the default 'native' provider only works "
             "via the background pass. For on-demand mining use the /memory-to-skill skill, or configure a "
-            f"provider, e.g.: memsearch config set plugins.{plugin}.memory_to_skill.provider <name> --project",
+            f"provider, e.g.: memsearch config set plugins.{plugin}.memory_to_skill.provider <name>",
             err=True,
         )
         raise SystemExit(2)

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from click.testing import CliRunner
+
 from memsearch import cli as cli_module
-from memsearch.config import MemSearchConfig
+from memsearch.cli import cli
+from memsearch.config import MemSearchConfig, load_config_file
 
 
 def test_build_cli_overrides_maps_only_non_none_values() -> None:
@@ -84,4 +87,31 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
         "max_chunk_size": 1800,
         "overlap_lines": 4,
         "reranker_model": "",
+    }
+
+
+def test_config_init_project_writes_only_allowlisted_keys(monkeypatch) -> None:
+    cfg = MemSearchConfig()
+    cfg.milvus.collection = "notes"
+    cfg.embedding.batch_size = 16
+    cfg.chunking.max_chunk_size = 2048
+    cfg.chunking.overlap_lines = 4
+    cfg.watch.debounce_ms = 300
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.prompts.project_review = "/tmp/project-review.txt"
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda: cfg)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["config", "init", "--project"], input="\n\n\n\n\n")
+
+        assert result.exit_code == 0
+        data = load_config_file(".memsearch.toml")
+
+    assert data == {
+        "milvus": {"collection": "notes"},
+        "embedding": {"batch_size": 16},
+        "chunking": {"max_chunk_size": 2048, "overlap_lines": 4},
+        "watch": {"debounce_ms": 300},
     }


### PR DESCRIPTION
## Summary
- restrict `memsearch config init --project` to low-risk project-local indexing keys
- update memory-config and memory-to-skill guidance to keep trusted plugin/provider/prompt settings in global config
- document the v0.4.11 project config trust boundary in setup and configuration docs

## Testing
- uv run python -m pytest tests/test_cli_config_helpers.py tests/test_config.py tests/test_skills.py -q
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run python -m pytest -q