### PR TITLE
feat: auto-select ONNX execution providers with CPU-safe fallback

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ $ pip install memsearch
 Each optional extra pulls in the provider SDK you need:
 
 ```bash
-$ pip install "memsearch[onnx]"        # ONNX Runtime — bge-m3 int8, CPU, no API key
+$ pip install "memsearch[onnx]"        # ONNX Runtime — bge-m3 int8, CPU (CUDA auto-detected), no API key
 $ pip install "memsearch[google]"      # Google Gemini embeddings
 $ pip install "memsearch[voyage]"      # Voyage AI embeddings
 $ pip install "memsearch[jina]"        # Jina AI embeddings
@@ -325,7 +325,7 @@ Set the environment variable for your chosen embedding provider. memsearch reads
 | Provider | Env Var | Notes |
 |----------|---------|-------|
 | **OpenAI** (default) | `OPENAI_API_KEY` | Included with base install |
-| **ONNX** (plugin default) | -- | No API key needed. CPU-only, bge-m3 int8. Requires `memsearch[onnx]` |
+| **ONNX** (plugin default) | -- | No API key needed. CPU by default, CUDA auto-selected when available; bge-m3 int8. Requires `memsearch[onnx]` |
 | OpenAI-compatible proxy | `OPENAI_BASE_URL` | For Azure OpenAI, vLLM, LiteLLM, etc. |
 | Google Gemini | `GOOGLE_API_KEY` | Requires `memsearch[google]` |
 | Voyage AI | `VOYAGE_API_KEY` | Requires `memsearch[voyage]` |

--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -1,14 +1,51 @@
-"""ONNX embedding via onnxruntime (runs on CPU, no GPU required).
+"""ONNX embedding via onnxruntime (CPU by default, accelerators when available).
 
 Requires: ``pip install 'memsearch[onnx]'`` or ``uv add 'memsearch[onnx]'``
 No API key needed. Used as the default provider by the Claude Code plugin for zero-config
 memory search. Default model is a pre-quantized int8 bge-m3 ONNX export.
+
+Execution providers are auto-selected from what the installed onnxruntime
+exposes: CUDA is preferred when present, and CPU is always kept as the final
+fallback. CoreML is opt-in only (``providers=`` argument): on the default
+int8 bge-m3 export CoreML places just 1490 of 2384 graph nodes across 220
+partitions, and the resulting CPU<->CoreML copy overhead measured ~60x
+SLOWER than plain CPU. Remote providers (e.g. Azure) are never auto-selected.
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from functools import partial
+
+# Local accelerator providers we are willing to auto-select, in preference
+# order. Deliberately an allowlist: get_available_providers() can include
+# remote providers (e.g. AzureExecutionProvider) that must never be picked
+# implicitly for a local, zero-config embedding path. CoreML is deliberately
+# NOT auto-selected — see the module docstring for the measurement.
+_PREFERRED_ACCELERATORS = ("CUDAExecutionProvider",)
+
+_CPU_PROVIDER = "CPUExecutionProvider"
+
+
+def _select_providers(
+    available: Sequence[str],
+    requested: Sequence[str] | None = None,
+) -> list[str]:
+    """Pick the execution-provider list for an ONNX inference session.
+
+    With *requested*, keeps its order filtered to *available*; otherwise takes
+    known local accelerators from *available* in preference order. CPU is
+    always appended as the final fallback so session creation cannot fail on
+    an accelerator-only list.
+    """
+    if requested:
+        selected = [p for p in requested if p in available]
+    else:
+        selected = [p for p in _PREFERRED_ACCELERATORS if p in available]
+    if _CPU_PROVIDER not in selected:
+        selected.append(_CPU_PROVIDER)
+    return selected
 
 
 class OnnxEmbedding:
@@ -26,6 +63,7 @@ class OnnxEmbedding:
         model: str = "gpahal/bge-m3-onnx-int8",
         *,
         batch_size: int = 0,
+        providers: Sequence[str] | None = None,
     ) -> None:
         try:
             import onnxruntime as ort
@@ -50,7 +88,15 @@ class OnnxEmbedding:
         self._tokenizer.enable_padding(pad_id=1, pad_token="<pad>")
         self._tokenizer.enable_truncation(max_length=8192)
 
-        self._session = ort.InferenceSession(model_path)
+        selected = _select_providers(ort.get_available_providers(), providers)
+        try:
+            self._session = ort.InferenceSession(model_path, providers=selected)
+        except Exception:
+            if selected == [_CPU_PROVIDER]:
+                raise
+            # Accelerator session creation can fail for models the provider
+            # cannot place; retry CPU-only rather than surfacing a hard error.
+            self._session = ort.InferenceSession(model_path, providers=[_CPU_PROVIDER])
         self._output_names = [o.name for o in self._session.get_outputs()]
         self._has_dense_vecs = "dense_vecs" in self._output_names
         self._model = model

--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -15,8 +15,11 @@ SLOWER than plain CPU. Remote providers (e.g. Azure) are never auto-selected.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 from functools import partial
+
+logger = logging.getLogger(__name__)
 
 # Local accelerator providers we are willing to auto-select, in preference
 # order. Deliberately an allowlist: get_available_providers() can include
@@ -41,6 +44,14 @@ def _select_providers(
     """
     if requested:
         selected = [p for p in requested if p in available]
+        dropped = [p for p in requested if p not in available]
+        if dropped:
+            logger.warning(
+                "Requested ONNX execution providers not available in this "
+                "onnxruntime build, ignoring: %s (available: %s)",
+                dropped,
+                list(available),
+            )
     else:
         selected = [p for p in _PREFERRED_ACCELERATORS if p in available]
     if _CPU_PROVIDER not in selected:
@@ -91,11 +102,16 @@ class OnnxEmbedding:
         selected = _select_providers(ort.get_available_providers(), providers)
         try:
             self._session = ort.InferenceSession(model_path, providers=selected)
-        except Exception:
+        except Exception as exc:
             if selected == [_CPU_PROVIDER]:
                 raise
             # Accelerator session creation can fail for models the provider
             # cannot place; retry CPU-only rather than surfacing a hard error.
+            logger.warning(
+                "ONNX session creation failed with providers %s (%s); retrying CPU-only",
+                selected,
+                exc,
+            )
             self._session = ort.InferenceSession(model_path, providers=[_CPU_PROVIDER])
         self._output_names = [o.name for o in self._session.get_outputs()]
         self._has_dense_vecs = "dense_vecs" in self._output_names

--- a/tests/test_embeddings_onnx_providers.py
+++ b/tests/test_embeddings_onnx_providers.py
@@ -1,0 +1,54 @@
+"""Tests for ONNX execution-provider selection.
+
+_select_providers is a pure function, so these run without onnxruntime
+or any model download.
+"""
+
+from __future__ import annotations
+
+from memsearch.embeddings.onnx import _CPU_PROVIDER, _select_providers
+
+_MACOS_PIP_WHEEL = ["CoreMLExecutionProvider", "AzureExecutionProvider", "CPUExecutionProvider"]
+_CUDA_BUILD = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+_CPU_ONLY = ["CPUExecutionProvider"]
+
+
+def test_auto_stays_cpu_on_macos_wheel() -> None:
+    # CoreML is opt-in only: on the default int8 bge-m3 export it measured
+    # ~60x slower than CPU (220 partitions, 1490/2384 nodes placed).
+    assert _select_providers(_MACOS_PIP_WHEEL) == [_CPU_PROVIDER]
+
+
+def test_auto_prefers_cuda_when_available() -> None:
+    assert _select_providers(_CUDA_BUILD) == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_coreml_available_via_explicit_request() -> None:
+    selected = _select_providers(_MACOS_PIP_WHEEL, ["CoreMLExecutionProvider"])
+    assert selected == ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_auto_never_picks_remote_providers() -> None:
+    # AzureExecutionProvider is available on the stock macOS wheel but must
+    # never be selected implicitly.
+    assert "AzureExecutionProvider" not in _select_providers(_MACOS_PIP_WHEEL)
+
+
+def test_cpu_only_runtime_stays_cpu() -> None:
+    assert _select_providers(_CPU_ONLY) == [_CPU_PROVIDER]
+
+
+def test_requested_order_is_kept_and_filtered() -> None:
+    selected = _select_providers(_MACOS_PIP_WHEEL, ["CoreMLExecutionProvider", "CUDAExecutionProvider"])
+    assert selected == ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_requested_unavailable_falls_back_to_cpu() -> None:
+    assert _select_providers(_CPU_ONLY, ["CUDAExecutionProvider"]) == [_CPU_PROVIDER]
+
+
+def test_cpu_always_appended_to_explicit_request() -> None:
+    # An accelerator-only request must not produce an accelerator-only list;
+    # session creation would hard-fail on models the provider cannot place.
+    selected = _select_providers(_CUDA_BUILD, ["CUDAExecutionProvider"])
+    assert selected[-1] == _CPU_PROVIDER

--- a/tests/test_embeddings_onnx_providers.py
+++ b/tests/test_embeddings_onnx_providers.py
@@ -52,3 +52,17 @@ def test_cpu_always_appended_to_explicit_request() -> None:
     # session creation would hard-fail on models the provider cannot place.
     selected = _select_providers(_CUDA_BUILD, ["CUDAExecutionProvider"])
     assert selected[-1] == _CPU_PROVIDER
+
+
+def test_dropped_requested_providers_warn(caplog) -> None:
+    # A user who explicitly requests an unavailable provider should get a
+    # signal that they are not running on it, not a silent CPU fallback.
+    with caplog.at_level("WARNING", logger="memsearch.embeddings.onnx"):
+        _select_providers(_CPU_ONLY, ["CUDAExecutionProvider"])
+    assert any("CUDAExecutionProvider" in r.message for r in caplog.records)
+
+
+def test_no_warning_when_requested_providers_available(caplog) -> None:
+    with caplog.at_level("WARNING", logger="memsearch.embeddings.onnx"):
+        _select_providers(_CUDA_BUILD, ["CUDAExecutionProvider"])
+    assert not caplog.records


### PR DESCRIPTION
## Summary
- `OnnxEmbedding` builds its `InferenceSession` without a `providers` argument, pinning inference to CPU even on CUDA builds of onnxruntime. This selects providers explicitly: CUDA auto-selected when available, CPU always appended as the final fallback, plus a CPU-only retry if accelerator session creation fails.
- Selection is a deliberate allowlist rather than `get_available_providers()` order: the stock macOS wheel exposes `AzureExecutionProvider` (remote), which should never be picked implicitly for a local zero-config embedding path.
- CoreML is **opt-in only** (`providers=` argument), based on measurement rather than assumption: on the default `gpahal/bge-m3-onnx-int8` export, CoreML places only 1490/2384 graph nodes across 220 partitions, and the CPU<->CoreML copy overhead measured **~60x slower than plain CPU** (407.7s vs 6.6s for 64 texts, Apple M-series). Draft in part to surface this trade-off for discussion.

## Test plan
- [x] `tests/test_embeddings_onnx_providers.py`: pure-function coverage for auto-selection (CUDA picked, CoreML/Azure not auto-picked, CPU-only runtime, explicit-request filtering, CPU always appended)
- [x] Full suite: 244 passed, 7 skipped
- [x] `ruff check` / `ruff format --check` clean
- [x] Live session on the default model builds and embeds under both CPU-only and explicit-CoreML provider lists (dim 1024)
- [ ] CUDA-build timing (no NVIDIA hardware here; expected to benefit, needs a CUDA runner)

## Scope notes

- `providers=` is currently reachable only via direct `OnnxEmbedding(...)` construction — deliberate for this PR. Plumbing it through `get_provider()`/config (e.g. an `embedding.onnx_providers` key) is left as a follow-up so CLI/plugin users can opt into CoreML or force a provider list.
- The CPU-retry path in `__init__` (accelerator session creation fails → CPU-only retry) is exercised manually but not unit-tested; a `sys.modules`-stubbed onnxruntime test is a planned follow-up.
