### PR TITLE
feat: support ONNX models that require token_type_ids

### DIFF
--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -56,8 +56,8 @@ class OnnxEmbedding:
         # BERT-family exports (e.g. Xenova/all-MiniLM-L6-v2) declare a
         # token_type_ids input; XLM-R-family exports (e.g. bge-m3) do not.
         # Session.run() requires every declared input to be fed.
-        self._input_names = {i.name for i in self._session.get_inputs()}
-        self._needs_token_type_ids = "token_type_ids" in self._input_names
+        input_names = {i.name for i in self._session.get_inputs()}
+        self._needs_token_type_ids = "token_type_ids" in input_names
         self._model = model
 
         # Detect dimension from a probe embedding

--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -53,6 +53,11 @@ class OnnxEmbedding:
         self._session = ort.InferenceSession(model_path)
         self._output_names = [o.name for o in self._session.get_outputs()]
         self._has_dense_vecs = "dense_vecs" in self._output_names
+        # BERT-family exports (e.g. Xenova/all-MiniLM-L6-v2) declare a
+        # token_type_ids input; XLM-R-family exports (e.g. bge-m3) do not.
+        # Session.run() requires every declared input to be fed.
+        self._input_names = {i.name for i in self._session.get_inputs()}
+        self._needs_token_type_ids = "token_type_ids" in self._input_names
         self._model = model
 
         # Detect dimension from a probe embedding
@@ -141,6 +146,9 @@ class OnnxEmbedding:
             "input_ids": input_ids,
             "attention_mask": attention_mask,
         }
+        if self._needs_token_type_ids:
+            # Single-sequence embedding: segment ids are all zero.
+            feed["token_type_ids"] = np.zeros_like(input_ids)
         outputs = self._session.run(None, feed)
 
         if self._has_dense_vecs:

--- a/tests/test_embeddings_onnx_inputs.py
+++ b/tests/test_embeddings_onnx_inputs.py
@@ -1,0 +1,59 @@
+"""Tests for ONNX input-feed construction (token_type_ids compatibility).
+
+Uses a stub session so no onnxruntime model download is needed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from memsearch.embeddings.onnx import OnnxEmbedding
+
+
+class _StubTokenizer:
+    def encode_batch(self, texts):
+        class E:
+            ids = [1, 2, 3]
+            attention_mask = [1, 1, 0]
+
+        return [E() for _ in texts]
+
+
+class _StubSession:
+    """Mimics ort.InferenceSession run(); records the feed it was given."""
+
+    def __init__(self) -> None:
+        self.last_feed: dict | None = None
+
+    def run(self, _output_names, feed):
+        self.last_feed = feed
+        batch = len(feed["input_ids"])
+        return [np.ones((batch, 4), dtype=np.float32)]
+
+
+def _make(needs_token_type_ids: bool) -> tuple[OnnxEmbedding, _StubSession]:
+    e = object.__new__(OnnxEmbedding)
+    session = _StubSession()
+    e._tokenizer = _StubTokenizer()
+    e._session = session
+    e._output_names = ["dense_vecs"]
+    e._has_dense_vecs = True
+    e._needs_token_type_ids = needs_token_type_ids
+    return e, session
+
+
+def test_token_type_ids_fed_as_zeros_when_model_requires() -> None:
+    e, session = _make(needs_token_type_ids=True)
+    e._encode(["hello", "world"])
+    assert session.last_feed is not None
+    assert set(session.last_feed) == {"input_ids", "attention_mask", "token_type_ids"}
+    tti = session.last_feed["token_type_ids"]
+    assert tti.shape == session.last_feed["input_ids"].shape
+    assert not tti.any()
+
+
+def test_token_type_ids_omitted_when_model_does_not_declare_it() -> None:
+    e, session = _make(needs_token_type_ids=False)
+    e._encode(["hello"])
+    assert session.last_feed is not None
+    assert set(session.last_feed) == {"input_ids", "attention_mask"}

--- a/tests/test_embeddings_onnx_inputs.py
+++ b/tests/test_embeddings_onnx_inputs.py
@@ -10,13 +10,15 @@ import numpy as np
 from memsearch.embeddings.onnx import OnnxEmbedding
 
 
+class _StubEncoding:
+    def __init__(self) -> None:
+        self.ids = [1, 2, 3]
+        self.attention_mask = [1, 1, 0]
+
+
 class _StubTokenizer:
     def encode_batch(self, texts):
-        class E:
-            ids = [1, 2, 3]
-            attention_mask = [1, 1, 0]
-
-        return [E() for _ in texts]
+        return [_StubEncoding() for _ in texts]
 
 
 class _StubSession:


### PR DESCRIPTION
## Summary
- BERT-family ONNX exports declare a `token_type_ids` input, and `session.run()` requires every declared input in the feed — so models like `Xenova/all-MiniLM-L6-v2` and `Xenova/bge-small-en-v1.5` currently fail with `Required inputs (['token_type_ids']) are missing`. This detects declared inputs once at init and feeds all-zero segment ids when required (correct for single-sequence embedding). XLM-R-family models (the bge-m3 default) are unaffected.
- Why it matters: it unlocks a small-model tier for bulk ingest without touching the default. Verified locally: `Xenova/bge-small-en-v1.5` (33M, CLS-pooling-native — matching this provider's CLS pooling) loads, passes a semantic sanity check, and embeds a 64-text batch in ~0.02s vs ~6.6s for the 568M int8 bge-m3 default on the same CPU. Corpus-scale context: indexing 186K chunks with the default took >4.5h on an M-series CPU; a small-tier model brings that to minutes via `embedding.model` config, no code change.
- Deliberately **not** changing `DEFAULT_MODELS["onnx"]`: a default swap changes embedding dimension (1024 → 384) and would break existing Milvus collections on upgrade. Users opt in per install via `memsearch config set embedding.model`.
- Caveat worth documenting: `Xenova/multilingual-e5-small` now loads but is not recommended — e5 models expect `query:`/`passage:` prefixes and mean pooling, and scored poorly on the sanity check under CLS pooling.

## Test plan
- [x] `tests/test_embeddings_onnx_inputs.py`: stub-session tests that `token_type_ids` is fed as zeros (shape-matched to `input_ids`) when declared, and omitted when not — no model download needed
- [x] Full suite: 238 passed, 7 skipped
- [x] `ruff check` / `ruff format --check` clean
- [x] Live load + embed + semantic sanity for bge-small-en-v1.5, all-MiniLM-L6-v2, multilingual-e5-small; default bge-m3 path unchanged
