### PR TITLE
perf: raise ONNX default batch size to 64

### DIFF
--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -62,7 +62,12 @@ class OnnxEmbedding:
         # Detect dimension from a probe embedding
         probe = self._encode(["hello"])
         self._dimension = len(probe[0])
-        self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE
+        self._batch_size = self._resolve_batch_size(batch_size)
+
+    @classmethod
+    def _resolve_batch_size(cls, batch_size: int) -> int:
+        """An explicit positive ``batch_size`` wins; 0 means provider default."""
+        return batch_size if batch_size > 0 else cls._DEFAULT_BATCH_SIZE
 
     @staticmethod
     def _download_model_files(model, hf_hub_download, list_repo_files):

--- a/src/memsearch/embeddings/onnx.py
+++ b/src/memsearch/embeddings/onnx.py
@@ -19,7 +19,11 @@ class OnnxEmbedding:
     - Models with ``last_hidden_state`` output — CLS pooling + L2 normalize applied
     """
 
-    _DEFAULT_BATCH_SIZE = 32
+    # 64 measured ~11% faster than 32 on the default int8 bge-m3 model
+    # (CPU, Apple M-series; 128 texts: 13.2s @ 32 -> 11.7s @ 64 -> 10.6s @ 128).
+    # 128 is not the default because worst-case padded batches (8192-token
+    # inputs) materialize multi-GB activation tensors; 64 keeps that bounded.
+    _DEFAULT_BATCH_SIZE = 64
 
     def __init__(
         self,

--- a/tests/test_embeddings_onnx_batch_size.py
+++ b/tests/test_embeddings_onnx_batch_size.py
@@ -1,0 +1,22 @@
+"""ONNX provider batch-size default and override resolution.
+
+Pure-function tests only: constructing OnnxEmbedding loads a real model,
+so the resolution logic is tested through ``_resolve_batch_size``.
+"""
+
+import pytest
+
+onnx_module = pytest.importorskip("memsearch.embeddings.onnx")
+
+
+def test_default_batch_size_is_64():
+    assert onnx_module.OnnxEmbedding._DEFAULT_BATCH_SIZE == 64
+
+
+def test_zero_batch_size_resolves_to_provider_default():
+    assert onnx_module.OnnxEmbedding._resolve_batch_size(0) == 64
+
+
+def test_explicit_batch_size_overrides_default():
+    assert onnx_module.OnnxEmbedding._resolve_batch_size(128) == 128
+    assert onnx_module.OnnxEmbedding._resolve_batch_size(16) == 16

--- a/tests/test_embeddings_onnx_batch_size.py
+++ b/tests/test_embeddings_onnx_batch_size.py
@@ -13,8 +13,9 @@ def test_default_batch_size_is_64():
     assert onnx_module.OnnxEmbedding._DEFAULT_BATCH_SIZE == 64
 
 
-def test_zero_batch_size_resolves_to_provider_default():
+def test_non_positive_batch_size_resolves_to_provider_default():
     assert onnx_module.OnnxEmbedding._resolve_batch_size(0) == 64
+    assert onnx_module.OnnxEmbedding._resolve_batch_size(-1) == 64
 
 
 def test_explicit_batch_size_overrides_default():


### PR DESCRIPTION
## Summary
- Raises `OnnxEmbedding._DEFAULT_BATCH_SIZE` from 32 to 64. Measured on the default `gpahal/bge-m3-onnx-int8` (CPU, Apple M-series, 128 texts x ~230 tokens): 14.1s @ batch 16, 13.2s @ 32, 11.7s @ 64, 10.6s @ 128 — so 64 is ~11% faster than the current default. On corpus-scale indexing (observed >4.5h for 186K chunks with this model) that's tens of minutes.
- 128 is deliberately **not** the default: the tokenizer pads to the longest text in a batch with `max_length=8192`, so a worst-case batch of long texts at 128-wide materializes multi-GB activation tensors. 64 keeps the worst case bounded while capturing most of the win; users can still set `embedding.batch_size = 128` in config where memory allows.
- `embedding.batch_size` config continues to override; `0` still means "provider default".

## Test plan
- [x] Full suite passes (no test pins the ONNX default batch size)
- [x] `ruff check` / `ruff format --check` clean
- [x] Timing measurements above reproduce with a 4-text warmup + `time.perf_counter` around `embed()`