### PR TITLE
feat: merge undersized heading sections during chunking (chunking.min_chunk_size)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,8 @@ We use JWT tokens...
 
 When a heading-delimited section exceeds `max_chunk_size` (default: 1500 characters), the chunker splits it further at paragraph boundaries (blank lines). A configurable `overlap_lines` (default: 2 lines) is carried forward between sub-chunks to preserve context continuity.
 
+At the other extreme, heading-dense documents (conversation transcripts, changelogs) can produce many near-empty chunks. Setting `chunking.min_chunk_size` (default: 0, disabled) merges adjacent sections until the combined content reaches that size, without ever exceeding `max_chunk_size`. A merged chunk keeps the heading of its first section and spans the line range of everything merged into it. Because merging changes chunk boundaries, enabling or changing this knob changes chunk IDs — the next index run re-embeds affected files once and cleans up the old chunks.
+
 ### Chunk Metadata
 
 Each chunk carries rich metadata for provenance tracking:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,8 +147,9 @@ Set chunking.max_chunk_size = 2000 in .memsearch.toml
 
 Project config is restricted before it is merged. Use `--project` only for
 allowlisted local indexing keys such as `milvus.collection`,
-`embedding.batch_size`, `chunking.max_chunk_size`, `chunking.overlap_lines`, and
-`indexing.ignore_files`, `indexing.exclude`, and `watch.debounce_ms`. Trusted
+`embedding.batch_size`, `chunking.max_chunk_size`, `chunking.min_chunk_size`,
+`chunking.overlap_lines`, `indexing.ignore_files`, `indexing.exclude`, and
+`watch.debounce_ms`. Trusted
 settings such as provider routing, endpoints, API keys, prompt files, and plugin
 automation must go in global config or explicit CLI flags.
 
@@ -210,6 +211,7 @@ model = ""
 
 [chunking]
 max_chunk_size = 1500
+min_chunk_size = 0
 overlap_lines = 2
 
 [watch]
@@ -282,6 +284,7 @@ provider = "openai"
 | `embedding.base_url` | string | `""` | OpenAI-compatible API base URL (empty = SDK default) |
 | `embedding.api_key` | string | `""` | API key for embedding provider (supports `env:VAR_NAME` syntax) |
 | `chunking.max_chunk_size` | int | `1500` | Maximum chunk size in characters |
+| `chunking.min_chunk_size` | int | `0` | Merge adjacent heading sections smaller than this many characters (0 = no merging) |
 | `chunking.overlap_lines` | int | `2` | Number of overlapping lines between adjacent chunks |
 | `indexing.ignore_files` | list[string] | `[]` | Ignore filenames discovered within each directory index root; new `config init` files write `[".gitignore"]` |
 | `indexing.exclude` | list[string] | `[]` | Additional gitignore-style patterns relative to each index root |
@@ -329,6 +332,7 @@ Scan one or more directories (or files) and index all markdown files (`.md`, `.m
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token (for server or Zilliz Cloud) |
 | `--max-chunk-size` | | config value | Override `chunking.max_chunk_size` for this run |
+| `--min-chunk-size` | | config value | Override `chunking.min_chunk_size` for this run |
 | `--ignore-file NAME` | | *(none)* | Append an ignore filename to discover within each directory index root; repeatable |
 | `--exclude PATTERN` | | *(none)* | Append a gitignore-style pattern relative to each index root; repeatable |
 | `--force` | | `false` | Re-embed and re-index all chunks, even if unchanged |
@@ -488,6 +492,7 @@ Start a long-running file watcher that monitors directories for markdown file ch
 | `--milvus-uri` | | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `--milvus-token` | | *(none)* | Milvus auth token |
 | `--max-chunk-size` | | config value | Override `chunking.max_chunk_size` for this run |
+| `--min-chunk-size` | | config value | Override `chunking.min_chunk_size` for this run |
 | `--ignore-file NAME` | | *(none)* | Append an ignore filename to discover within each watched root; repeatable |
 | `--exclude PATTERN` | | *(none)* | Append a gitignore-style exclusion pattern; repeatable |
 

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -11,8 +11,8 @@ memsearch uses a layered TOML config system. Most users don't need to configure 
 Since v0.4.11, project-level `.memsearch.toml` is intentionally restricted
 before it is merged. It can only set low-risk local indexing keys:
 `milvus.collection`, `embedding.batch_size`, `chunking.max_chunk_size`,
-`chunking.overlap_lines`, `indexing.ignore_files`, `indexing.exclude`, and
-`watch.debounce_ms`. Put trusted settings such as provider routing, API
+`chunking.min_chunk_size`, `chunking.overlap_lines`, `indexing.ignore_files`,
+`indexing.exclude`, and `watch.debounce_ms`. Put trusted settings such as provider routing, API
 endpoints, API keys, prompt files, and `plugins.*` automation in global config
 or pass them as explicit CLI flags.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -33,6 +33,7 @@ MemSearch(
     milvus_token=None,
     collection="memsearch_chunks",
     max_chunk_size=1500,
+    min_chunk_size=0,
     overlap_lines=2,
     ignore_files=None,
     exclude=None,
@@ -51,6 +52,7 @@ MemSearch(
 | `milvus_token` | `str \| None` | `None` | Auth token for Milvus Server or Zilliz Cloud |
 | `collection` | `str` | `"memsearch_chunks"` | Milvus collection name. Use different names to isolate agents sharing the same backend |
 | `max_chunk_size` | `int` | `1500` | Maximum chunk size in characters |
+| `min_chunk_size` | `int` | `0` | Merge adjacent heading sections smaller than this many characters (0 = no merging). Changing it changes chunk IDs, so the next index run re-embeds affected files |
 | `overlap_lines` | `int` | `2` | Overlapping lines between adjacent chunks |
 | `ignore_files` | `list[str] \| None` | `None` | Ignore filenames discovered within each directory index root, for example `[".gitignore"]` |
 | `exclude` | `list[str] \| None` | `None` | Additional gitignore-style patterns relative to each directory index root |

--- a/src/memsearch/chunker.py
+++ b/src/memsearch/chunker.py
@@ -83,12 +83,19 @@ def chunk_markdown(
     *,
     max_chunk_size: int = 1500,
     overlap_lines: int = 2,
+    min_chunk_size: int = 0,
 ) -> list[Chunk]:
     """Split markdown *text* into chunks, breaking on headings.
 
     Chunks that exceed *max_chunk_size* characters are split further at
     paragraph boundaries.  A small *overlap_lines* context is carried
     forward to preserve continuity.
+
+    When *min_chunk_size* is positive, consecutive sections smaller than it
+    are merged (up to *max_chunk_size*) into a single chunk that carries the
+    first section's heading.  Heading-dense documents such as conversation
+    transcripts otherwise produce one tiny chunk per heading, multiplying
+    embedding cost.  ``0`` (the default) keeps one chunk per section.
     """
     lines = text.split("\n")
     # Find all heading positions
@@ -109,23 +116,43 @@ def chunk_markdown(
         sections.append((line_idx, next_start, title, level))
 
     chunks: list[Chunk] = []
+    # Sections accumulated toward min_chunk_size: (text, start, end, heading, level)
+    pending: list[tuple[str, int, int, str, int]] = []
+
+    def _pending_len() -> int:
+        return sum(len(p[0]) for p in pending) + 2 * (len(pending) - 1)
+
+    def _flush_pending() -> None:
+        if not pending:
+            return
+        content = "\n\n".join(p[0] for p in pending)
+        chunks.append(
+            Chunk(
+                content=content,
+                source=source,
+                heading=pending[0][3],
+                heading_level=pending[0][4],
+                start_line=pending[0][1] + 1,
+                end_line=pending[-1][2],
+            )
+        )
+        pending.clear()
+
     for start, end, heading, level in sections:
         section_text = "\n".join(lines[start:end]).strip()
         if not section_text or not _has_meaningful_content(section_text):
             continue
 
         if len(section_text) <= max_chunk_size:
-            chunks.append(
-                Chunk(
-                    content=section_text,
-                    source=source,
-                    heading=heading,
-                    heading_level=level,
-                    start_line=start + 1,
-                    end_line=end,
-                )
-            )
+            # Merging this section would push the pending chunk past
+            # max_chunk_size — flush what we have first.
+            if pending and _pending_len() + len(section_text) + 2 > max_chunk_size:
+                _flush_pending()
+            pending.append((section_text, start, end, heading, level))
+            if _pending_len() >= min_chunk_size:
+                _flush_pending()
         else:
+            _flush_pending()
             # Split large sections at paragraph boundaries
             chunks.extend(
                 _split_large_section(
@@ -138,6 +165,9 @@ def chunk_markdown(
                     overlap=overlap_lines,
                 )
             )
+
+    # Trailing accumulation below min_chunk_size still becomes a chunk.
+    _flush_pending()
 
     return chunks
 

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -60,6 +60,7 @@ _PARAM_MAP = {
     "llm_api_key": "compact.api_key",
     "max_chunk_size": "chunking.max_chunk_size",
     "overlap_lines": "chunking.overlap_lines",
+    "min_chunk_size": "chunking.min_chunk_size",
     "debounce_ms": "watch.debounce_ms",
     "reranker_model": "reranker.model",
 }
@@ -93,6 +94,7 @@ def _cfg_to_memsearch_kwargs(cfg: MemSearchConfig) -> dict:
         "collection": cfg.milvus.collection,
         "max_chunk_size": cfg.chunking.max_chunk_size,
         "overlap_lines": cfg.chunking.overlap_lines,
+        "min_chunk_size": cfg.chunking.min_chunk_size,
         "reranker_model": cfg.reranker.model,
     }
 

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -216,6 +216,12 @@ def cli() -> None:
 @click.option(
     "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
 )
+@click.option(
+    "--min-chunk-size",
+    default=None,
+    type=click.IntRange(min=0),
+    help="Merge heading sections smaller than this many characters (0 disables merging).",
+)
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def index(
     paths: tuple[str, ...],
@@ -231,6 +237,7 @@ def index(
     exclude_patterns: tuple[str, ...],
     force: bool,
     max_chunk_size: int | None,
+    min_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Index markdown files from PATHS."""
@@ -248,6 +255,7 @@ def index(
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
             max_chunk_size=max_chunk_size,
+            min_chunk_size=min_chunk_size,
         )
     )
     ms = None
@@ -563,6 +571,12 @@ def _extract_section(
 @click.option(
     "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
 )
+@click.option(
+    "--min-chunk-size",
+    default=None,
+    type=click.IntRange(min=0),
+    help="Merge heading sections smaller than this many characters (0 disables merging).",
+)
 @click.option("--description", default=None, help="Collection description (written on creation only).")
 def watch(
     paths: tuple[str, ...],
@@ -578,6 +592,7 @@ def watch(
     exclude_patterns: tuple[str, ...],
     debounce_ms: int | None,
     max_chunk_size: int | None,
+    min_chunk_size: int | None,
     description: str | None,
 ) -> None:
     """Watch PATHS for markdown changes and auto-index."""
@@ -596,6 +611,7 @@ def watch(
             milvus_token=milvus_token,
             debounce_ms=debounce_ms,
             max_chunk_size=max_chunk_size,
+            min_chunk_size=min_chunk_size,
         )
     )
     ms = None

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -26,7 +26,15 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
+_INT_FIELDS = {
+    "max_chunk_size",
+    "overlap_lines",
+    "min_chunk_size",
+    "debounce_ms",
+    "batch_size",
+    "min_interval_hours",
+    "min_occurrences",
+}
 _BOOL_FIELDS = {"enabled"}
 _LIST_FIELDS = {"paths"}
 
@@ -39,6 +47,7 @@ _PROJECT_CONFIG_ALLOWED_PATHS = {
     ("embedding", "batch_size"),
     ("chunking", "max_chunk_size"),
     ("chunking", "overlap_lines"),
+    ("chunking", "min_chunk_size"),
     ("watch", "debounce_ms"),
 }
 
@@ -72,6 +81,7 @@ class CompactConfig:
 class ChunkingConfig:
     max_chunk_size: int = 1500
     overlap_lines: int = 2
+    min_chunk_size: int = 0  # 0 = one chunk per heading section (no merging)
 
 
 @dataclass

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -60,11 +60,13 @@ class MemSearch:
         description: str = "",
         max_chunk_size: int = 1500,
         overlap_lines: int = 2,
+        min_chunk_size: int = 0,
         reranker_model: str = "",
     ) -> None:
         self._paths = [str(p) for p in (paths or [])]
         self._max_chunk_size = max_chunk_size
         self._overlap_lines = overlap_lines
+        self._min_chunk_size = min_chunk_size
         self._embedder: EmbeddingProvider = get_provider(
             embedding_provider,
             model=embedding_model,
@@ -132,6 +134,7 @@ class MemSearch:
             source=source,
             max_chunk_size=self._max_chunk_size,
             overlap_lines=self._overlap_lines,
+            min_chunk_size=self._min_chunk_size,
         )
         model = self._embedder.model_name
 

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -251,3 +251,50 @@ def test_long_cjk_text_splits_on_fullwidth_semicolon() -> None:
     assert len(chunks) > 1
     assert all(len(chunk.content) <= 24 for chunk in chunks)
     assert all(chunk.content.endswith(semicolon) for chunk in chunks[:-1])
+
+
+def test_min_chunk_size_default_keeps_per_section_chunks():
+    md = "## user\n\nok sounds good\n\n## assistant\n\ndone, pushed the fix\n\n## user\n\nthanks"
+    chunks = chunk_markdown(md, source="t.md")
+    assert len(chunks) == 3
+
+
+def test_min_chunk_size_merges_tiny_sections():
+    md = "## user\n\nok sounds good\n\n## assistant\n\ndone, pushed the fix\n\n## user\n\nthanks"
+    chunks = chunk_markdown(md, source="t.md", min_chunk_size=200)
+    assert len(chunks) == 1
+    c = chunks[0]
+    # Merged chunk carries the first section's heading and spans all lines.
+    assert c.heading == "user"
+    assert c.start_line == 1
+    assert c.end_line == 11
+    # All section bodies preserved in order.
+    assert c.content.index("ok sounds good") < c.content.index("pushed the fix") < c.content.index("thanks")
+
+
+def test_min_chunk_size_merge_respects_max_chunk_size():
+    sections = [f"## turn {i}\n\n" + "x" * 120 for i in range(10)]
+    md = "\n\n".join(sections)
+    chunks = chunk_markdown(md, source="t.md", min_chunk_size=10_000, max_chunk_size=400)
+    assert len(chunks) > 1
+    for c in chunks:
+        assert len(c.content) <= 400
+
+
+def test_min_chunk_size_flush_before_oversized_section():
+    md = "## tiny\n\nshort body\n\n## big\n\n" + "y" * 900
+    chunks = chunk_markdown(md, source="t.md", min_chunk_size=5_000, max_chunk_size=300)
+    # The tiny section is flushed on its own; the big one goes through
+    # the large-section splitter with its own heading.
+    assert chunks[0].heading == "tiny"
+    assert all(c.heading == "big" for c in chunks[1:])
+    assert len(chunks) >= 3
+
+
+def test_min_chunk_size_stops_merging_once_reached():
+    md = "## a\n\n" + "a" * 150 + "\n\n## b\n\n" + "b" * 150 + "\n\n## c\n\n" + "c" * 150
+    chunks = chunk_markdown(md, source="t.md", min_chunk_size=200, max_chunk_size=1500)
+    # a+b reach 200 and flush together; c stands alone.
+    assert len(chunks) == 2
+    assert chunks[0].heading == "a"
+    assert chunks[1].heading == "c"

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -71,6 +71,7 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
     cfg.milvus.collection = "team_notes"
     cfg.chunking.max_chunk_size = 1800
     cfg.chunking.overlap_lines = 4
+    cfg.chunking.min_chunk_size = 200
     cfg.reranker.model = ""
 
     kwargs = cli_module._cfg_to_memsearch_kwargs(cfg)
@@ -86,6 +87,7 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
         "collection": "team_notes",
         "max_chunk_size": 1800,
         "overlap_lines": 4,
+        "min_chunk_size": 200,
         "reranker_model": "",
     }
 

--- a/tests/test_core_encoding.py
+++ b/tests/test_core_encoding.py
@@ -45,6 +45,7 @@ def make_memsearch() -> tuple[MemSearch, RecordingStore]:
     ms._paths = []
     ms._max_chunk_size = 1500
     ms._overlap_lines = 2
+    ms._min_chunk_size = 0
     ms._embedder = FakeEmbedder()
     store = RecordingStore()
     ms._store = store

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -112,6 +112,7 @@ def mem_with_fake(tmp_path: Path):
     ms._paths = []
     ms._max_chunk_size = 1500
     ms._overlap_lines = 2
+    ms._min_chunk_size = 0
     ms._embedder = fake
     ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
     yield ms, fake
@@ -140,6 +141,7 @@ def mem_with_recording_store():
     ms._paths = []
     ms._max_chunk_size = 1500
     ms._overlap_lines = 2
+    ms._min_chunk_size = 0
     ms._embedder = fake
     ms._store = store
     return ms, fake, store
@@ -214,6 +216,7 @@ async def test_index_continues_after_file_failure(tmp_path: Path):
     ms._paths = [str(docs)]
     ms._max_chunk_size = 1500
     ms._overlap_lines = 2
+    ms._min_chunk_size = 0
     ms._embedder = fake
     ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
 


### PR DESCRIPTION
## Summary
- Heading-dense markdown (conversation transcripts, session logs — memsearch's primary memory shape) currently produces one chunk per heading section no matter how tiny; a 19,195-session corpus chunked into 186,192 pieces (~10x expansion), and embedding cost scales linearly with chunk count. This adds `chunking.min_chunk_size`: consecutive sections below the threshold are accumulated into one chunk (never exceeding `max_chunk_size`), carrying the first section's heading and the full merged line span.
- **Default `0` = exactly today's behavior** (every section flushes immediately); the merge path only activates when opted in. Oversized sections still route through the existing paragraph splitter unchanged.
- Plumbing: `ChunkingConfig.min_chunk_size` (TOML + `config set`), allowed in project-local `.memsearch.toml` (same trust tier as the existing `chunking.max_chunk_size`/`overlap_lines`), passed through `MemSearch.__init__` and the CLI override map.
- Trade-off note for review: merging changes chunk identity (chunk IDs hash content + line span), so enabling it on an existing collection re-embeds affected files once. Retrieval-quality impact is corpus-dependent; on a LongMemEval-S bench harness, coarser session-level granularity scored slightly better than per-turn chunks with the same embedder, but a maintainer-side eval would be worth running before recommending a non-zero default.

## Test plan
- [x] New tests: default keeps per-section behavior; tiny sections merge (heading/line-span/order assertions); merge respects `max_chunk_size`; pending chunks flush before an oversized section; accumulation stops once the threshold is reached
- [x] Updated `_cfg_to_memsearch_kwargs` translation test and manual-construction test stubs for the new attribute
- [x] Full suite: 241 passed, 7 skipped
- [x] `ruff check` / `ruff format --check` clean

## Design notes

- **Merging is heading-level-blind by design.** Accumulation crosses heading levels (a small `###` tail can merge into the following `##` section). For the transcript shape that motivates this feature, levels carry no hierarchy (every turn is the same level), and stopping at level boundaries would reintroduce the tiny-chunk problem exactly where it bites. If level-aware merging turns out to matter for prose docs, it can be layered on later without changing the config surface.
- **Merged chunks keep the first section's heading in metadata only.** All subsequent headings survive verbatim inside `content` (sections include their heading lines), so no text is lost to search; the metadata heading is used for display/filtering and the first section's heading is the least surprising representative for a run of consecutive tiny sections.
