### PR TITLE
docs: explain the indexing cost model (cold vs incremental vs model swap)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,6 +152,32 @@ graph TD
 
 ---
 
+## Indexing Cost Model
+
+Deduplication makes indexing cost *event-driven*, not size-driven: what you pay depends on which of three events you are in, not on how big the knowledge base is.
+
+### Cold vs Incremental vs Model Swap
+
+| Event | What gets embedded | Typical cost |
+|-------|--------------------|--------------|
+| Steady state (watch / re-index) | Only new or edited sections | Seconds -- most runs embed nothing |
+| Cold index (new machine, wiped collection) | Everything | Minutes to hours, scales with chunk count x model size |
+| **Embedding model change** | **Everything** | Same as a cold index, plus collection implications below |
+
+The model name is part of every composite chunk ID (`hash(source:lines:contentHash:model)`), so changing `embedding.model` or `embedding.provider` invalidates every existing ID at once: the next index run re-embeds the entire corpus. If the new model also has a different vector dimension, the existing collection cannot hold the new vectors -- expect a [dimension mismatch](faq.md#what-does-dimension-mismatch-mean-and-how-do-i-fix-it) and plan to rebuild the collection. Treat a model swap as a scheduled migration, not a config tweak.
+
+### What Governs Cold-Index Throughput
+
+For local providers (`onnx`, `local`), embedding compute dominates cold-index time. Three knobs control it:
+
+1. **Model size.** The default `onnx` model (bge-m3, ~568M parameters) prioritizes multilingual quality; on CPU it embeds on the order of ~10 texts/second. Smaller models are 10-100x faster at some quality cost.
+2. **Chunk count.** Cost scales linearly with the number of chunks, and heading-dense documents (conversation transcripts) can chunk to many small pieces. `chunking.max_chunk_size` controls the split ceiling.
+3. **Batch size.** `embedding.batch_size` trades memory for throughput; measured on the default onnx model (CPU, Apple M-series, 128 texts), batch 64 was ~11% faster than batch 32 and batch 128 ~20% faster.
+
+A useful rule of thumb before a cold index: `chunks x (seconds per chunk for your model)`. If the projection is hours, either accept it as a one-time migration cost or pick a smaller model for that collection.
+
+---
+
 ## Storage Architecture
 
 ### Collection Schema

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,13 @@
 # FAQ
 
+## Why is my first index slow, when re-indexing is instant?
+
+That asymmetry is by design. Chunk IDs are content-addressable, so a re-index only embeds sections that are new or changed -- on an unchanged knowledge base it embeds nothing. A **cold** index (new machine, wiped collection, or an embedding model change) embeds everything, and with a local provider that cost is dominated by model compute: chunk count x model size.
+
+If a cold index projects to hours, pick a smaller model for that collection, raise `embedding.batch_size`, or accept it as a one-time migration cost. Note that changing `embedding.model` later re-triggers the full cost: the model name is part of every chunk ID.
+
+See [Architecture — Indexing Cost Model](architecture.md#indexing-cost-model) for the full breakdown.
+
 ## Does memsearch work on Windows?
 
 Yes, but **Milvus Lite** (the default local `.db` backend) does not provide Windows binaries.


### PR DESCRIPTION
## Summary
- Adds an "Indexing Cost Model" section to `docs/architecture.md`, directly after Deduplication: indexing cost is event-driven, and the three tiers (steady-state incremental, cold index, embedding model change) have very different costs. The non-obvious one for users: the model name is part of every composite chunk ID, so changing `embedding.model`/`provider` re-embeds the entire corpus and, on a dimension change, requires a collection rebuild — worth treating as a scheduled migration.
- Documents the three throughput knobs for local-provider cold indexes (model size, chunk count, `embedding.batch_size`) with hardware-qualified reference measurements (default onnx model on an Apple M-series CPU: ~10 texts/s; batch 64 ~11% faster than 32).
- Adds a FAQ entry ("Why is my first index slow, when re-indexing is instant?") linking to the new section, matching the existing FAQ answer style.

## Test plan
- [x] `mkdocs build --strict` clean (anchors/links resolve, including the FAQ dimension-mismatch cross-reference)
- [x] Full test suite unaffected (docs-only)