### PR TITLE
fix(opencode): avoid growing system message array in chat transform hook

### DIFF
--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeSystemMemoryContext, MEMSEARCH_SYSTEM_MARKER } from "./index.ts";
+
+test("appends memory context when no system entry exists yet", () => {
+  const result = mergeSystemMemoryContext(undefined, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  assert.deepEqual(result, [`${MEMSEARCH_SYSTEM_MARKER} ctx-a`]);
+});
+
+test("folds memory context into the first entry without growing the array", () => {
+  const result = mergeSystemMemoryContext(
+    ["You are a helpful assistant."],
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`
+  );
+  assert.equal(result.length, 1);
+  assert.equal(result[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+});
+
+test("repeated calls with the same context stay idempotent", () => {
+  const base = ["You are a helpful assistant."];
+  const memoryText = `${MEMSEARCH_SYSTEM_MARKER} ctx-a`;
+
+  const first = mergeSystemMemoryContext(base, memoryText);
+  const second = mergeSystemMemoryContext(first, memoryText);
+  const third = mergeSystemMemoryContext(second, memoryText);
+
+  assert.equal(third.length, 1);
+  assert.equal(third[0], first[0]);
+  // Only one occurrence of the marker — no duplicated memsearch block.
+  assert.equal(third[0].split(MEMSEARCH_SYSTEM_MARKER).length - 1, 1);
+});
+
+test("repeated calls with updated context replace the previous block", () => {
+  const base = ["You are a helpful assistant."];
+  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+
+  assert.equal(second.length, 1);
+  assert.equal(second[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  assert.ok(!second[0].includes("ctx-a"));
+});
+
+test("does not disturb additional system entries beyond the first", () => {
+  const base = ["Base prompt.", "Second unrelated system entry."];
+  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+
+  assert.equal(second.length, 2);
+  assert.equal(second[1], "Second unrelated system entry.");
+  assert.ok(!second[0].includes("ctx-a"));
+});

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -349,9 +349,16 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
             try {
               const context = getRecentMemories(memoryDir);
               if (context) {
-                output.system.push(
-                  `[memsearch] Memory available. You have access to memory_search, memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`
-                );
+                // Merge into the existing system entry instead of pushing a new
+                // one — some backends (litellm/vllm serving e.g. Qwen models)
+                // require a single system message and reject a multi-entry
+                // output.system array with "system message must be first".
+                const memoryText = `[memsearch] Memory available. You have access to memory_search, memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`;
+                if (Array.isArray(output.system) && output.system.length > 0) {
+                  output.system[0] = `${output.system[0]}\n\n${memoryText}`;
+                } else {
+                  output.system = [memoryText];
+                }
               }
             } catch { /* ignore */ }
           },

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -113,6 +113,34 @@ function shellEscape(s: string): string {
   return s.replace(/'/g, "'\\''");
 }
 
+/** Marks the start of memsearch's injected block within a system message. */
+export const MEMSEARCH_SYSTEM_MARKER = "[memsearch] Memory available.";
+
+/**
+ * Merge memsearch's memory context into an `output.system` array without
+ * growing it. Some backends (litellm/vllm serving e.g. Qwen models) reject a
+ * multi-entry `output.system` array with "system message must be first", so
+ * the memory block is folded into the first entry instead of pushed as a new
+ * one. If a memsearch block from a previous transform call is already present
+ * (identified by MEMSEARCH_SYSTEM_MARKER), it is replaced in place rather than
+ * appended again, so repeated calls against the same output stay idempotent.
+ */
+export function mergeSystemMemoryContext(
+  system: string[] | undefined,
+  memoryText: string
+): string[] {
+  if (!Array.isArray(system) || system.length === 0) {
+    return [memoryText];
+  }
+  const result = [...system];
+  const existing = result[0];
+  const markerIndex = existing.indexOf(MEMSEARCH_SYSTEM_MARKER);
+  const base =
+    markerIndex === -1 ? existing : existing.slice(0, markerIndex).replace(/\n+$/, "");
+  result[0] = base ? `${base}\n\n${memoryText}` : memoryText;
+  return result;
+}
+
 /**
  * Start the capture daemon as a background process.
  * The daemon polls OpenCode's SQLite for completed turns and writes to daily .md files.
@@ -349,16 +377,10 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
             try {
               const context = getRecentMemories(memoryDir);
               if (context) {
-                // Merge into the existing system entry instead of pushing a new
-                // one — some backends (litellm/vllm serving e.g. Qwen models)
-                // require a single system message and reject a multi-entry
-                // output.system array with "system message must be first".
-                const memoryText = `[memsearch] Memory available. You have access to memory_search, memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`;
-                if (Array.isArray(output.system) && output.system.length > 0) {
-                  output.system[0] = `${output.system[0]}\n\n${memoryText}`;
-                } else {
-                  output.system = [memoryText];
-                }
+                const memoryText =
+                  `${MEMSEARCH_SYSTEM_MARKER} You have access to memory_search, ` +
+                  `memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`;
+                output.system = mergeSystemMemoryContext(output.system, memoryText);
               }
             } catch { /* ignore */ }
           },

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -23,6 +23,9 @@
     "semantic-search",
     "milvus"
   ],
+  "scripts": {
+    "test": "node --test"
+  },
   "author": "memsearch contributors",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- `experimental.chat.system.transform` in the OpenCode plugin was pushing a new entry onto `output.system` on every call, producing multiple system messages.
- Some inference backends (litellm/vllm serving Qwen models) reject this with `system message must be first`, since they expect a single system message.
- The memsearch context is now merged into the existing `output.system` entry instead of appending a new one, keeping the array at a single system message.

## Test plan
- [ ] Manually verify with OpenCode + litellm/vllm serving a Qwen model that no "system message must be first" error occurs
- [ ] Confirm memsearch memory context still appears in the system prompt as before