### PR TITLE
fix: scope stale cleanup to indexed directories

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ graph LR
 
 ### Ingest Flow
 
-Markdown files are scanned, chunked by headings, and deduplicated using SHA-256 content hashes. Only new or changed chunks are sent to the embedding API and upserted into Milvus. Chunks from deleted files are automatically cleaned up.
+Markdown files are scanned, chunked by headings, and deduplicated using SHA-256 content hashes. Only new or changed chunks are sent to the embedding API and upserted into Milvus. Chunks from deleted files under indexed directory paths are automatically cleaned up.
 
 ```mermaid
 graph LR

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -302,7 +302,7 @@ provider = "openai"
 
 ## `memsearch index`
 
-Scan one or more directories (or files) and index all markdown files (`.md`, `.markdown`) into the Milvus vector store. Only new or changed chunks are embedded by default -- unchanged chunks are skipped. Chunks belonging to deleted files are automatically removed from the index.
+Scan one or more directories (or files) and index all markdown files (`.md`, `.markdown`) into the Milvus vector store. Only new or changed chunks are embedded by default -- unchanged chunks are skipped. Chunks belonging to deleted files under the indexed directory paths are automatically removed from the index.
 
 ### Options
 
@@ -359,7 +359,7 @@ Indexed 42 chunks.
 ### Notes
 
 - **Incremental by default.** Each chunk is identified by a composite hash of its source file, line range, content hash, and embedding model. Only chunks with new IDs are embedded and stored.
-- **Stale cleanup.** If a file that was previously indexed no longer exists on disk, its chunks are automatically deleted from the index during the next `index` run.
+- **Stale cleanup.** If a file under an indexed directory path no longer exists on disk, its chunks are automatically deleted from the index during the next `index` run. Explicit file paths are treated as partial updates and do not prune other indexed sources.
 - **`--force` re-embeds everything.** Use this when you switch embedding providers or models, since the same content will produce different vectors with a different model.
 
 ---

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -83,7 +83,7 @@ Scan all configured paths and index every markdown file (`.md`, `.markdown`) int
 **Behavior:**
 
 - **Incremental by default.** Only new or changed chunks are embedded. Unchanged chunks are skipped via content-hash dedup.
-- **Stale cleanup.** Chunks from deleted files are automatically removed.
+- **Stale cleanup.** Chunks from deleted files under configured directory paths are automatically removed. Explicit file paths are partial updates and do not prune other indexed sources.
 - **Deleted content.** If a section is removed from a file, its old chunks are cleaned up on the next `index()` call.
 
 ```python

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -104,12 +104,16 @@ class MemSearch:
                 failed += 1
                 logger.exception("Failed to index %s, skipping", f.path)
 
-        # Clean up chunks for files that no longer exist
-        indexed_sources = self._store.indexed_sources()
-        for source in indexed_sources:
-            if source not in active_sources:
-                self._store.delete_by_source(source)
-                logger.info("Removed stale chunks for deleted file: %s", source)
+        # Clean up deleted files only inside directory roots from this run.
+        # Explicit file paths are partial updates and must not prune unrelated
+        # sources from the collection.
+        cleanup_roots = _cleanup_roots_for_paths(self._paths)
+        if cleanup_roots:
+            indexed_sources = self._store.indexed_sources()
+            for source in indexed_sources:
+                if source not in active_sources and _source_under_any_root(source, cleanup_roots):
+                    self._store.delete_by_source(source)
+                    logger.info("Removed stale chunks for deleted file: %s", source)
 
         if failed:
             logger.warning("Indexed %d chunks from %d files (%d files failed)", total, len(files) - failed, failed)
@@ -400,6 +404,26 @@ def _chunk_batches(chunks: list[Chunk], batch_size: int) -> Iterator[list[Chunk]
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
     for i in range(0, len(chunks), batch_size):
         yield chunks[i : i + batch_size]
+
+
+def _cleanup_roots_for_paths(paths: list[str | Path]) -> list[Path]:
+    roots: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path).expanduser().resolve()
+        if path.is_dir():
+            roots.append(path)
+    return roots
+
+
+def _source_under_any_root(source: str, roots: list[Path]) -> bool:
+    source_path = Path(source).expanduser().resolve()
+    for root in roots:
+        try:
+            source_path.relative_to(root)
+        except ValueError:
+            continue
+        return True
+    return False
 
 
 def _records_for_chunks(chunks: list[Chunk], embeddings: list[list[float]], model: str) -> list[dict[str, Any]]:

--- a/tests/test_index_cleanup.py
+++ b/tests/test_index_cleanup.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memsearch.core import MemSearch
+
+
+class FakeEmbedder:
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def dimension(self) -> int:
+        return 4
+
+    @property
+    def batch_size(self) -> int:
+        return 32
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] * self.dimension for _ in texts]
+
+
+class InMemoryStore:
+    def __init__(self) -> None:
+        self._records_by_source: dict[str, list[dict[str, Any]]] = {}
+        self.deleted_sources: list[str] = []
+
+    def hashes_by_source(self, source: str) -> set[str]:
+        return {record["chunk_hash"] for record in self._records_by_source.get(source, [])}
+
+    def delete_by_hashes(self, hashes: list[str]) -> None:
+        stale = set(hashes)
+        for source, records in list(self._records_by_source.items()):
+            remaining = [record for record in records if record["chunk_hash"] not in stale]
+            if remaining:
+                self._records_by_source[source] = remaining
+            else:
+                self._records_by_source.pop(source, None)
+
+    def upsert(self, records: list[dict[str, Any]]) -> int:
+        for record in records:
+            source = record["source"]
+            existing = [
+                old for old in self._records_by_source.get(source, []) if old["chunk_hash"] != record["chunk_hash"]
+            ]
+            existing.append(record)
+            self._records_by_source[source] = existing
+        return len(records)
+
+    def indexed_sources(self) -> set[str]:
+        return set(self._records_by_source)
+
+    def delete_by_source(self, source: str) -> None:
+        self.deleted_sources.append(source)
+        self._records_by_source.pop(source, None)
+
+
+def make_memsearch(paths: list[str | Path]) -> tuple[MemSearch, InMemoryStore]:
+    ms = MemSearch.__new__(MemSearch)
+    ms._paths = [str(path) for path in paths]
+    ms._max_chunk_size = 1500
+    ms._overlap_lines = 2
+    ms._embedder = FakeEmbedder()
+    store = InMemoryStore()
+    ms._store = store
+    ms._reranker_model = ""
+    return ms, store
+
+
+def write_note(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_file_index_does_not_prune_other_indexed_sources(tmp_path: Path) -> None:
+    a = write_note(tmp_path / "a.md", "# A\n\nalpha\n")
+    b = write_note(tmp_path / "b.md", "# B\n\nbravo\n")
+
+    ms, store = make_memsearch([a, b])
+    await ms.index()
+
+    ms._paths = [str(a)]
+    await ms.index()
+
+    assert str(a) in store.indexed_sources()
+    assert str(b) in store.indexed_sources()
+    assert store.deleted_sources == []
+
+
+@pytest.mark.asyncio
+async def test_directory_index_prunes_deleted_sources_inside_that_directory(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    keep = write_note(docs / "keep.md", "# Keep\n\nalpha\n")
+    stale = write_note(docs / "stale.md", "# Stale\n\nbravo\n")
+
+    ms, store = make_memsearch([docs])
+    await ms.index()
+
+    stale.unlink()
+    await ms.index()
+
+    assert str(keep) in store.indexed_sources()
+    assert str(stale) not in store.indexed_sources()
+    assert store.deleted_sources == [str(stale)]
+
+
+@pytest.mark.asyncio
+async def test_directory_index_does_not_prune_sources_outside_that_directory(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    other = tmp_path / "other"
+    doc = write_note(docs / "a.md", "# A\n\nalpha\n")
+    other_doc = write_note(other / "b.md", "# B\n\nbravo\n")
+
+    ms, store = make_memsearch([docs, other_doc])
+    await ms.index()
+
+    ms._paths = [str(docs)]
+    await ms.index()
+
+    assert str(doc) in store.indexed_sources()
+    assert str(other_doc) in store.indexed_sources()
+    assert store.deleted_sources == []
+
+
+@pytest.mark.asyncio
+async def test_directory_cleanup_uses_path_boundaries_not_string_prefixes(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs2 = tmp_path / "docs2"
+    doc = write_note(docs / "a.md", "# A\n\nalpha\n")
+    similar_prefix_doc = write_note(docs2 / "b.md", "# B\n\nbravo\n")
+
+    ms, store = make_memsearch([docs, docs2])
+    await ms.index()
+
+    ms._paths = [str(docs)]
+    await ms.index()
+
+    assert str(doc) in store.indexed_sources()
+    assert str(similar_prefix_doc) in store.indexed_sources()
+    assert store.deleted_sources == []


### PR DESCRIPTION
## Summary
- restrict stale source cleanup to explicitly indexed directory roots
- treat explicit file paths as partial updates that do not prune unrelated sources
- document the scoped cleanup behavior for CLI and Python API users

## Testing
- uv run python -m pytest tests/test_index_cleanup.py tests/test_core_encoding.py tests/test_embed_batching.py tests/test_scanner.py -q
- uv run python -m pytest -q
- uv run ruff check src tests
- uv run ruff format --check src tests