### PR TITLE
fix: skip empty sessions in memory previews

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -105,6 +105,43 @@ fi
 PROJECT_BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-.}")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
+_recent_memory_preview() {
+  local file="$1" max_lines="${2:-40}"
+  awk '
+    function flush_section() {
+      if (section_len > 0 && has_body) {
+        for (i = 1; i <= section_len; i++) {
+          print section[i]
+        }
+      }
+      delete section
+      section_len = 0
+      has_body = 0
+    }
+
+    /^##[[:space:]]/ {
+      flush_section()
+      section[++section_len] = $0
+      next
+    }
+
+    /^#{3,4}[[:space:]]/ {
+      section[++section_len] = $0
+      next
+    }
+
+    /^-[[:space:]]/ {
+      section[++section_len] = $0
+      has_body = 1
+      next
+    }
+
+    END {
+      flush_section()
+    }
+  ' "$file" 2>/dev/null | tail -n "$max_lines" || true
+}
+
 # Write session heading to today's memory file
 ensure_memory_dir
 TODAY=$(date +%Y-%m-%d)
@@ -165,11 +202,9 @@ if [ -n "$recent_files" ]; then
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     basename_f=$(basename "$f")
-    # Extract headings (## Session, ### turn timestamps) and bullet content —
-    # higher signal density than a raw tail, so Claude can see the structure
-    # of past days (what sessions existed, what topics came up) rather than
-    # just the last 30 lines of whichever file happened to be newest.
-    content=$(grep -E '^(#{2,4} |- )' "$f" 2>/dev/null | head -40 || true)
+    # Extract recent non-empty session sections. Empty SessionStart headings are
+    # common after short sessions, but they do not carry useful context.
+    content=$(_recent_memory_preview "$f" 40)
     if [ -n "$content" ]; then
       context+="## $basename_f\n$content\n\n"
     fi

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -22,6 +22,36 @@ function ensureDir(dir) {
   }
   return dir;
 }
+function recentMemoryPreviewLines(content, maxLines) {
+  const sections = [];
+  let current = [];
+  let hasBody = false;
+  const flush = () => {
+    if (current.length > 0 && hasBody) {
+      sections.push(current);
+    }
+    current = [];
+    hasBody = false;
+  };
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (/^##\s/.test(line)) {
+      flush();
+      current = [line];
+      continue;
+    }
+    if (/^#{3,4}\s/.test(line)) {
+      current.push(line);
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      current.push(line);
+      hasBody = true;
+    }
+  }
+  flush();
+  return sections.flat().slice(-maxLines);
+}
 function getRecentMemories(memDir, count = 2, maxLinesPerFile = 30) {
   if (!existsSync(memDir)) return "";
   const files = readdirSync(memDir).filter((f) => f.endsWith(".md")).sort().slice(-count);
@@ -30,7 +60,7 @@ function getRecentMemories(memDir, count = 2, maxLinesPerFile = 30) {
   for (const file of files) {
     try {
       const content = readFileSync(join(memDir, file), "utf-8");
-      const lines = content.split("\n").filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- ")).slice(0, maxLinesPerFile);
+      const lines = recentMemoryPreviewLines(content, maxLinesPerFile);
       if (lines.length > 0) {
         summary.push(`[${file}]`, ...lines);
       }

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -45,10 +45,43 @@ function ensureDir(dir: string): string {
 
 /**
  * Summarize the N most recent daily .md files for cold-start context.
- * Extracts headings (## Session, ### turns) and bullet content so the
- * agent sees the structure of past days rather than just the tail of
- * whichever file happened to be newest.
+ * Extracts recent non-empty session sections so empty SessionStart headings
+ * do not crowd out useful context.
  */
+function recentMemoryPreviewLines(content: string, maxLines: number): string[] {
+  const sections: string[][] = [];
+  let current: string[] = [];
+  let hasBody = false;
+
+  const flush = () => {
+    if (current.length > 0 && hasBody) {
+      sections.push(current);
+    }
+    current = [];
+    hasBody = false;
+  };
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (/^##\s/.test(line)) {
+      flush();
+      current = [line];
+      continue;
+    }
+    if (/^#{3,4}\s/.test(line)) {
+      current.push(line);
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      current.push(line);
+      hasBody = true;
+    }
+  }
+
+  flush();
+  return sections.flat().slice(-maxLines);
+}
+
 function getRecentMemories(
   memDir: string,
   count = 2,
@@ -67,9 +100,7 @@ function getRecentMemories(
   for (const file of files) {
     try {
       const content = readFileSync(join(memDir, file), "utf-8");
-      const lines = content.split("\n")
-        .filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- "))
-        .slice(0, maxLinesPerFile);
+      const lines = recentMemoryPreviewLines(content, maxLinesPerFile);
       if (lines.length > 0) {
         summary.push(`[${file}]`, ...lines);
       }

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -70,10 +70,43 @@ function deriveCollectionName(projectDir: string): string {
 
 /**
  * Summarize the N most recent daily .md files for cold-start context.
- * Extracts headings (## Session, ### turns) and bullet content from each
- * file so the agent sees the structure of past days (what sessions existed,
- * what topics came up), not just the tail of whichever file is newest.
+ * Extracts recent non-empty session sections so empty SessionStart headings
+ * do not crowd out useful context.
  */
+function recentMemoryPreviewLines(content: string, maxLines: number): string[] {
+  const sections: string[][] = [];
+  let current: string[] = [];
+  let hasBody = false;
+
+  const flush = () => {
+    if (current.length > 0 && hasBody) {
+      sections.push(current);
+    }
+    current = [];
+    hasBody = false;
+  };
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (/^##\s/.test(line)) {
+      flush();
+      current = [line];
+      continue;
+    }
+    if (/^#{3,4}\s/.test(line)) {
+      current.push(line);
+      continue;
+    }
+    if (line.startsWith("- ") || line.startsWith("[User]") || line.startsWith("[Assistant]")) {
+      current.push(line);
+      hasBody = true;
+    }
+  }
+
+  flush();
+  return sections.flat().slice(-maxLines);
+}
+
 function getRecentMemories(
   memDir: string,
   count = 2,
@@ -92,9 +125,7 @@ function getRecentMemories(
   for (const file of files) {
     try {
       const content = readFileSync(join(memDir, file), "utf-8");
-      const lines = content.split("\n")
-        .filter((l) => /^#{2,4}\s/.test(l) || l.startsWith("- ") || l.startsWith("[User]") || l.startsWith("[Assistant]"))
-        .slice(0, maxLinesPerFile);
+      const lines = recentMemoryPreviewLines(content, maxLinesPerFile);
       if (lines.length > 0) {
         summary.push(`[${file}]`, ...lines);
       }

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -25,3 +26,81 @@ def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Pat
 
     assert result.stdout.strip() == "{}"
     assert not (tmp_path / ".memsearch").exists()
+
+
+def test_claude_session_start_recent_memory_skips_empty_sessions(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memory = tmp_path / ".memsearch" / "memory"
+    home.mkdir()
+    fake_bin.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    memory.mkdir(parents=True)
+    (memory / "2026-01-01.md").write_text(
+        """# 2026-01-01
+
+## Session 09:00
+
+## Session 09:01
+
+### 09:01
+- User discussed a useful migration note.
+
+## Session 09:02
+""",
+        encoding="utf-8",
+    )
+
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    embedding.model) echo "" ;;
+    milvus.uri) echo "~/.memsearch/milvus.db" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "config" ] && [ "$2" = "set" ]; then
+  exit 0
+fi
+if [ "$1" = "index" ]; then
+  echo "Indexed 0 chunks."
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(tmp_path / ".memsearch"),
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+
+    assert "User discussed a useful migration note." in context
+    assert "Session 09:01" in context
+    assert "Session 09:00" not in context
+    assert "Session 09:02" not in context


### PR DESCRIPTION
Summary:
- Skip empty session sections when building cold-start memory previews.
- Keep recent non-empty section lines so useful context is not crowded out by empty headings.
- Apply the same preview behavior across shell, OpenCode, and OpenClaw integrations.

Tests:
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check tests/test_claude_hooks.py`
- `bash -n plugins/claude-code/hooks/session-start.sh`
- `node --check plugins/openclaw/index.js`
- `git diff --check`

Related to #598.