### PR TITLE
fix: keep Claude stop hook portable on macOS

### DIFF
--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -140,12 +140,12 @@ elif command -v claude &>/dev/null; then
 
 Transcript:
 ${PARSED}"
-  CLAUDE_SAFE_MODE_ARGS=()
+  CLAUDE_SAFE_MODE_ARG=""
   if claude --help 2>/dev/null | grep -q -- '--safe-mode'; then
-    CLAUDE_SAFE_MODE_ARGS=(--safe-mode)
+    CLAUDE_SAFE_MODE_ARG="--safe-mode"
   fi
   SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_DISABLE=1 CLAUDECODE= claude -p \
-    "${CLAUDE_SAFE_MODE_ARGS[@]}" \
+    ${CLAUDE_SAFE_MODE_ARG:+"$CLAUDE_SAFE_MODE_ARG"} \
     --strict-mcp-config \
     --tools "" \
     --model "$SUMMARIZE_MODEL" \

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -69,7 +69,6 @@ if [ "$1" = "config" ] && [ "$2" = "set" ]; then
   exit 0
 fi
 if [ "$1" = "index" ]; then
-  echo "Indexed 0 chunks."
   exit 0
 fi
 if [ "$1" = "--version" ]; then
@@ -104,3 +103,105 @@ exit 0
     assert "Session 09:01" in context
     assert "Session 09:00" not in context
     assert "Session 09:02" not in context
+
+
+def test_claude_stop_hook_writes_summary_without_safe_mode_flag(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    plugin_root = Path("plugins/claude-code").resolve()
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    transcript = tmp_path / "session-123.jsonl"
+    claude_args = tmp_path / "claude-args.txt"
+    home.mkdir()
+    fake_bin.mkdir()
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "system", "message": {"content": "start"}}),
+                json.dumps({"type": "user", "uuid": "turn-1", "message": {"content": "Summarize this session"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "I explained the macOS hook issue."}]},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    plugins.claude-code.summarize.enabled) echo "true" ;;
+    plugins.claude-code.summarize.model) echo "" ;;
+    plugins.claude-code.summarize.provider) echo "" ;;
+    prompts.summarize) echo "" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "index" ]; then
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+
+    fake_claude = fake_bin / "claude"
+    fake_claude.write_text(
+        """#!/usr/bin/env bash
+if [ "${1:-}" = "--help" ]; then
+  echo "Usage: claude"
+  exit 0
+fi
+printf '%s\n' "$@" > "$CLAUDE_ARGS_FILE"
+echo "- User discussed a macOS stop hook regression."
+""",
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "CLAUDE_ARGS_FILE": str(claude_args),
+    }
+    result = subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    memory_files = list((memsearch_dir / "memory").glob("*.md"))
+    assert result.stdout.strip() == "{}"
+    assert len(memory_files) == 1
+    memory_text = memory_files[0].read_text(encoding="utf-8")
+    assert "macOS stop hook regression" in memory_text
+
+    captured_args = claude_args.read_text(encoding="utf-8").splitlines()
+    assert captured_args[:4] == ["-p", "--strict-mcp-config", "--tools", ""]
+    assert "--safe-mode" not in captured_args
+    assert captured_args[captured_args.index("--model") + 1] == "haiku"
+
+
+def test_claude_stop_hook_avoids_empty_array_expansion_under_nounset() -> None:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    source = script.read_text(encoding="utf-8")
+
+    assert '"${CLAUDE_SAFE_MODE_ARGS[@]}"' not in source
+    assert "CLAUDE_SAFE_MODE_ARG" in source


### PR DESCRIPTION
## Summary
- avoid empty Bash array expansion in the Claude Code Stop hook under `set -u`
- keep optional `--safe-mode` support when the installed CLI advertises it
- add regression coverage for the Stop hook path when `--safe-mode` is unavailable

Closes #618

## Tests
- `bash -n plugins/claude-code/hooks/stop.sh plugins/claude-code/hooks/session-start.sh plugins/claude-code/hooks/common.sh`
- `.venv/bin/python -m ruff check tests/test_claude_hooks.py`
- `.venv/bin/python -m pytest tests/test_claude_hooks.py tests/test_claude_parse_transcript.py`
- `env -u OPENAI_API_KEY .venv/bin/python -m pytest`