### PR TITLE
fix: preserve extras in upgrade hints

### DIFF
--- a/docs/platforms/claude-code/troubleshooting.md
+++ b/docs/platforms/claude-code/troubleshooting.md
@@ -20,7 +20,7 @@ The plugin displays a status line at session start:
 
 **Update available:**
 ```
-[memsearch v0.2.9] ... | UPDATE: v0.2.10 available -- run: uv tool upgrade 'memsearch[onnx]'
+[memsearch v0.2.9] ... | UPDATE: v0.2.10 available -- run: uv tool upgrade memsearch
 ```
 
 ### "ERROR: \<KEY\> not set"

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -543,7 +543,7 @@ The SessionStart hook also loads the 2 most recent daily logs as `additionalCont
 **Update available:**
 
 ```
-[memsearch v0.1.11] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db | UPDATE: v0.1.12 available — run: pip install --upgrade 'memsearch[onnx]'
+[memsearch v0.1.11] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db | UPDATE: v0.1.12 available — run: pip install --upgrade memsearch
 ```
 
 #### "ERROR: \<KEY\> not set — memory search disabled"
@@ -576,17 +576,17 @@ To make it permanent, add the export to your `~/.bashrc`, `~/.zshrc`, or equival
 The plugin checks PyPI at session start (2s timeout) and shows this hint when a newer version exists. The hint now includes the exact upgrade command, auto-detected from your installation method:
 
 ```
-UPDATE: v0.1.15 available — run: pip install --upgrade 'memsearch[onnx]'
-UPDATE: v0.1.15 available — run: uv tool upgrade 'memsearch[onnx]'
+UPDATE: v0.1.15 available — run: pip install --upgrade memsearch
+UPDATE: v0.1.15 available — run: uv tool upgrade memsearch
 ```
 
 | Install method | Upgrade command shown |
 |---|---|
-| `pip install memsearch[onnx]` | `pip install --upgrade 'memsearch[onnx]'` |
-| `uv tool install memsearch[onnx]` | `uv tool upgrade 'memsearch[onnx]'` |
+| `pip install memsearch[onnx]` | `pip install --upgrade memsearch` |
+| `uv tool install memsearch[onnx]` | `uv tool upgrade memsearch` |
 | `uvx` (auto) | `uvx --upgrade --from 'memsearch[onnx]' memsearch --version` |
 
-> **Note:** `uvx` users get automatic upgrades — the plugin runs `uvx --upgrade` on every bootstrap with the `[onnx]` extra. The `UPDATE` hint primarily helps `pip`/`uv tool` users who have no automatic update mechanism.
+> **Note:** The `pip` and `uv tool` commands upgrade the installed package without replacing the optional extras already present in that environment. `uvx` users get automatic upgrades — the plugin runs `uvx --upgrade` on every bootstrap with the `[onnx]` extra.
 
 ---
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -78,12 +78,14 @@ if [ -n "$VERSION" ]; then
     if [ -n "$_MS_BIN" ]; then
       _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
     fi
-    if [[ "$MEMSEARCH_CMD" == *"uvx"* ]] || [[ "$_MS_REAL" == *"uv/tools"* ]]; then
-      UPGRADE_CMD="uv tool install -U 'memsearch[onnx]'"
+    if [[ "$MEMSEARCH_CMD" == *"uvx"* ]]; then
+      UPGRADE_CMD="uvx --upgrade --from 'memsearch[onnx]' memsearch --version"
+    elif [[ "$_MS_REAL" == *"uv/tools"* ]]; then
+      UPGRADE_CMD="uv tool upgrade memsearch"
     elif [[ "$_MS_REAL" == *"/pipx/venvs/memsearch/"* ]] || { command -v pipx &>/dev/null && pipx list 2>/dev/null | grep -Eq "package memsearch([ ,]|$)"; }; then
       UPGRADE_CMD="pipx upgrade memsearch"
     else
-      UPGRADE_CMD="pip install --upgrade 'memsearch[onnx]'"
+      UPGRADE_CMD="pip install --upgrade memsearch"
     fi
     UPDATE_HINT=" | UPDATE: v${LATEST} available — run: ${UPGRADE_CMD}"
   fi

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -73,12 +73,14 @@ if [ -n "$VERSION" ]; then
     if [ -n "$_MS_BIN" ]; then
       _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
     fi
-    if [ "${MEMSEARCH_CMD[0]:-}" = "uvx" ] || [[ "$_MS_REAL" == *"uv/tools"* ]]; then
-      UPGRADE_CMD="uv tool install -U 'memsearch[onnx]'"
+    if [ "${MEMSEARCH_CMD[0]:-}" = "uvx" ]; then
+      UPGRADE_CMD="uvx --upgrade --from 'memsearch[onnx]' memsearch --version"
+    elif [[ "$_MS_REAL" == *"uv/tools"* ]]; then
+      UPGRADE_CMD="uv tool upgrade memsearch"
     elif [[ "$_MS_REAL" == *"/pipx/venvs/memsearch/"* ]] || { command -v pipx &>/dev/null && pipx list 2>/dev/null | grep -Eq "package memsearch([ ,]|$)"; }; then
       UPGRADE_CMD="pipx upgrade memsearch"
     else
-      UPGRADE_CMD="pip install --upgrade 'memsearch[onnx]'"
+      UPGRADE_CMD="pip install --upgrade memsearch"
     fi
     UPDATE_HINT=" | UPDATE: v${LATEST} available — run: ${UPGRADE_CMD}"
   fi

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -105,6 +105,87 @@ exit 0
     assert "Session 09:02" not in context
 
 
+def test_claude_session_start_uv_tool_upgrade_hint_preserves_extras(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    uv_tool_bin = home / ".local" / "share" / "uv" / "tools" / "memsearch" / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    home.mkdir()
+    fake_bin.mkdir()
+    uv_tool_bin.mkdir(parents=True)
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+
+    fake_memsearch = uv_tool_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "voyage" ;;
+    embedding.model) echo "voyage-3-lite" ;;
+    milvus.uri) echo "http://localhost:19530" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.12"
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+    (fake_bin / "memsearch").symlink_to(fake_memsearch)
+
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+echo '{"info":{"version":"0.4.13"}}'
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+        "VOYAGE_API_KEY": "test-key",
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    assert "UPDATE: v0.4.13 available" in status
+    assert "uv tool upgrade memsearch" in status
+    assert "uv tool install -U 'memsearch[onnx]'" not in status
+
+
+def test_session_start_upgrade_hints_do_not_clobber_extras() -> None:
+    for script in (
+        Path("plugins/claude-code/hooks/session-start.sh"),
+        Path("plugins/codex/hooks/session-start.sh"),
+    ):
+        source = script.read_text(encoding="utf-8")
+
+        assert "uv tool install -U 'memsearch[onnx]'" not in source
+        assert "pip install --upgrade 'memsearch[onnx]'" not in source
+        assert "uv tool upgrade memsearch" in source
+        assert "pip install --upgrade memsearch" in source
+
+
 def test_claude_stop_hook_writes_summary_without_safe_mode_flag(tmp_path: Path) -> None:
     script = Path("plugins/claude-code/hooks/stop.sh")
     plugin_root = Path("plugins/claude-code").resolve()


### PR DESCRIPTION
## Summary
- use `uv tool upgrade memsearch` for uv tool installs so the existing tool receipt controls installed extras
- use `pip install --upgrade memsearch` for pip installs instead of adding the ONNX extra during upgrades
- keep the uvx hint separate from persistent uv tool installs and update Claude Code docs

Closes #619

## Tests
- `bash -n plugins/claude-code/hooks/session-start.sh plugins/codex/hooks/session-start.sh plugins/claude-code/hooks/common.sh plugins/codex/hooks/common.sh`
- `.venv/bin/python -m ruff check tests/test_claude_hooks.py`
- `.venv/bin/python -m pytest tests/test_claude_hooks.py`
- `env -u OPENAI_API_KEY .venv/bin/python -m pytest`