### PR TITLE
fix: stop stale OpenCode capture daemons

### DIFF
--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -13,13 +13,15 @@
 
 import type { Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
-import { execSync, exec, spawnSync } from "node:child_process";
+import { execSync, exec, spawn, spawnSync } from "node:child_process";
 import {
   readFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
   realpathSync,
+  unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -153,6 +155,7 @@ function startCaptureDaemon(
   collectionName: string,
   memsearchCmd: string
 ): void {
+  const stateDir = join(projectDir, ".memsearch");
   const pidFile = join(projectDir, ".memsearch", ".capture.pid");
   const daemonScript = join(PLUGIN_DIR, "scripts", "capture-daemon.py");
 
@@ -167,21 +170,40 @@ function startCaptureDaemon(
           return; // Already running
         } catch {
           // Process is dead, clean up stale PID file
+          try { unlinkSync(pidFile); } catch { /* ignore */ }
         }
       }
     } catch { /* ignore */ }
   }
 
-  // Start daemon in background
-  exec(
-    `python3 "${daemonScript}" "${projectDir}" "${collectionName}" ` +
-      `--memsearch-cmd "${shellEscape(memsearchCmd)}" --poll-interval 10 &`,
-    {
-      timeout: 5000,
-      env: { ...process.env, MEMSEARCH_NO_WATCH: "1" },
-    },
-    () => { /* ignore */ }
-  );
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    const child = spawn(
+      "python3",
+      [
+        daemonScript,
+        projectDir,
+        collectionName,
+        "--memsearch-cmd",
+        memsearchCmd,
+        "--poll-interval",
+        "10",
+        "--parent-pid",
+        String(process.pid),
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+        env: { ...process.env, MEMSEARCH_NO_WATCH: "1" },
+      }
+    );
+    child.unref();
+    if (child.pid) {
+      try { writeFileSync(pidFile, String(child.pid), "utf-8"); } catch { /* ignore */ }
+    }
+  } catch {
+    // Capture is best-effort; tools still work without the background daemon.
+  }
 }
 
 /**

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -481,6 +481,21 @@ def wake_maintenance(project_dir: str) -> None:
     )
 
 
+def process_is_alive(pid: int) -> bool:
+    """Return whether a process exists without sending it a signal."""
+    if pid <= 0:
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+    return True
+
+
 def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     """Find OpenCode sessions that belong to the given project directory."""
     sessions = conn.execute(
@@ -764,6 +779,7 @@ def main() -> None:
     parser.add_argument("collection_name", help="Milvus collection name")
     parser.add_argument("--memsearch-cmd", default="memsearch", help="memsearch command")
     parser.add_argument("--poll-interval", type=int, default=10, help="Poll interval in seconds")
+    parser.add_argument("--parent-pid", type=int, default=0, help="Exit when this parent process is gone")
     args = parser.parse_args()
 
     db_path = get_db_path()
@@ -791,6 +807,9 @@ def main() -> None:
     tail_turn_cache: dict[str, TailTurnObservation] = {}
 
     while True:
+        if args.parent_pid and not process_is_alive(args.parent_pid):
+            cleanup()
+
         any_new = False
         conn = None
         try:
@@ -820,6 +839,8 @@ def main() -> None:
             if conn is not None:
                 conn.close()
 
+        if args.parent_pid and not process_is_alive(args.parent_pid):
+            cleanup()
         time.sleep(args.poll_interval)
 
 

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -177,6 +177,37 @@ def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeyp
     assert captured["start_new_session"] is True
 
 
+def test_opencode_plugin_capture_daemon_uses_spawned_child_lifecycle() -> None:
+    source = (SCRIPT_DIR.parent / "index.ts").read_text(encoding="utf-8")
+
+    assert 'exec(\n    `python3 "${daemonScript}"' not in source
+    assert "spawn(" in source
+    assert '"--parent-pid"' in source
+    assert "String(process.pid)" in source
+    assert "writeFileSync(pidFile, String(child.pid)" in source
+
+
+def test_opencode_capture_daemon_parent_process_liveness(monkeypatch) -> None:
+    def alive(pid: int, signal_number: int) -> None:
+        assert pid == 123
+        assert signal_number == 0
+
+    monkeypatch.setattr(capture_daemon.os, "kill", alive)
+    assert capture_daemon.process_is_alive(123) is True
+
+    def missing(pid: int, signal_number: int) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(capture_daemon.os, "kill", missing)
+    assert capture_daemon.process_is_alive(123) is False
+
+    def inaccessible(pid: int, signal_number: int) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(capture_daemon.os, "kill", inaccessible)
+    assert capture_daemon.process_is_alive(123) is True
+
+
 def _make_opencode_db(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row


### PR DESCRIPTION
## Summary
- start the OpenCode capture daemon with `spawn()` instead of a background shell command
- record the daemon PID immediately to avoid duplicate launches during startup races
- pass the OpenCode process PID to the daemon so it exits when the parent process is gone

Closes #621

## Tests
- `python3 -m py_compile plugins/opencode/scripts/capture-daemon.py`
- `node --check plugins/opencode/index.ts`
- `.venv/bin/python -m ruff check tests/test_opencode_turns.py plugins/opencode/scripts/capture-daemon.py`
- `.venv/bin/python -m pytest tests/test_opencode_turns.py`
- `env -u OPENAI_API_KEY .venv/bin/python -m pytest`
- `npm pack --dry-run` from `plugins/opencode`