### PR TITLE
fix: limit recent memory previews to daily journals

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -197,7 +197,8 @@ fi
 context=""
 
 # Find the 2 most recent daily log files (sorted by filename descending).
-recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | sort -r | head -2 || true)
+DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md'
+recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name "$DAILY_JOURNAL_PATTERN" -print 2>/dev/null | sort -r | head -2 || true)
 
 if [ -n "$recent_files" ]; then
   context="# Recent Memory\n\n"

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -103,7 +103,8 @@ PROJECT_BASENAME=$(basename "$PROJECT_DIR")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
 # Capture preexisting memory files before writing the new session heading.
-EXISTING_MEMORY_FILES=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort || true)
+DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md'
+EXISTING_MEMORY_FILES=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name "$DAILY_JOURNAL_PATTERN" 2>/dev/null | sort || true)
 EXISTING_MEMORY_COUNT=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | sed '/^$/d' | wc -l | tr -d ' ')
 
 # Write session heading to today's memory file

--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { mergeSystemMemoryContext, MEMSEARCH_SYSTEM_MARKER } from "./index.ts";
+import {
+  getRecentMemories,
+  isDailyJournalFile,
+  mergeSystemMemoryContext,
+  MEMSEARCH_SYSTEM_MARKER,
+} from "./index.ts";
 
 test("appends memory context when no system entry exists yet", () => {
   const result = mergeSystemMemoryContext(undefined, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
@@ -49,4 +57,33 @@ test("does not disturb additional system entries beyond the first", () => {
   assert.equal(second.length, 2);
   assert.equal(second[1], "Second unrelated system entry.");
   assert.ok(!second[0].includes("ctx-a"));
+});
+
+test("recent memories only use dated daily journals", () => {
+  assert.equal(isDailyJournalFile("2026-07-13.md"), true);
+  assert.equal(isDailyJournalFile("notes.md"), false);
+  assert.equal(isDailyJournalFile("recall-staging-123.md"), false);
+
+  const dir = mkdtempSync(join(tmpdir(), "memsearch-opencode-memory-"));
+  try {
+    writeFileSync(
+      join(dir, "2026-07-12.md"),
+      "# 2026-07-12\n\n## Session 09:00\n\n### 09:00\n- Daily journal content.\n",
+      "utf-8"
+    );
+    writeFileSync(
+      join(dir, "zzz-scratch.md"),
+      "# Scratch\n\n## Session 10:00\n\n### 10:00\n- Scratch content should not displace daily journals.\n",
+      "utf-8"
+    );
+
+    const context = getRecentMemories(dir);
+
+    assert.match(context, /2026-07-12\.md/);
+    assert.match(context, /Daily journal content/);
+    assert.doesNotMatch(context, /zzz-scratch/);
+    assert.doesNotMatch(context, /Scratch content/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -109,7 +109,11 @@ function recentMemoryPreviewLines(content: string, maxLines: number): string[] {
   return sections.flat().slice(-maxLines);
 }
 
-function getRecentMemories(
+export function isDailyJournalFile(file: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}\.md$/.test(file);
+}
+
+export function getRecentMemories(
   memDir: string,
   count = 2,
   maxLinesPerFile = 30
@@ -117,7 +121,7 @@ function getRecentMemories(
   if (!existsSync(memDir)) return "";
 
   const files = readdirSync(memDir)
-    .filter((f) => f.endsWith(".md"))
+    .filter(isDailyJournalFile)
     .sort()
     .slice(-count);
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -52,6 +52,16 @@ def test_claude_session_start_recent_memory_skips_empty_sessions(tmp_path: Path)
 """,
         encoding="utf-8",
     )
+    (memory / "zzz-scratch.md").write_text(
+        """# Scratch
+
+## Session 10:00
+
+### 10:00
+- Scratch content should not displace daily journals.
+""",
+        encoding="utf-8",
+    )
 
     fake_memsearch = fake_bin / "memsearch"
     fake_memsearch.write_text(
@@ -101,6 +111,7 @@ exit 0
 
     assert "User discussed a useful migration note." in context
     assert "Session 09:01" in context
+    assert "Scratch content should not displace daily journals." not in context
     assert "Session 09:00" not in context
     assert "Session 09:02" not in context
 
@@ -184,6 +195,17 @@ def test_session_start_upgrade_hints_do_not_clobber_extras() -> None:
         assert "pip install --upgrade 'memsearch[onnx]'" not in source
         assert "uv tool upgrade memsearch" in source
         assert "pip install --upgrade memsearch" in source
+
+
+def test_session_start_recent_memory_selects_daily_journals() -> None:
+    for script in (
+        Path("plugins/claude-code/hooks/session-start.sh"),
+        Path("plugins/codex/hooks/session-start.sh"),
+    ):
+        source = script.read_text(encoding="utf-8")
+
+        assert "DAILY_JOURNAL_PATTERN" in source
+        assert "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md" in source
 
 
 def test_claude_stop_hook_writes_summary_without_safe_mode_flag(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- limit Claude Code and Codex cold-start recent memory selection to dated daily journal files
- make OpenCode recent memory previews use the same `YYYY-MM-DD.md` journal filter
- keep non-journal Markdown files indexable while preventing them from displacing recent journal previews

Closes #601

## Tests
- `bash -n plugins/claude-code/hooks/session-start.sh plugins/codex/hooks/session-start.sh`
- `.venv/bin/python -m ruff check tests/test_claude_hooks.py`
- `.venv/bin/python -m ruff format --check src tests`
- `.venv/bin/python -m pytest tests/test_claude_hooks.py`
- `npm test` from `plugins/opencode`
- `node --check plugins/opencode/index.ts`
- `npm pack --dry-run` from `plugins/opencode`
- `env -u OPENAI_API_KEY .venv/bin/python -m pytest`