### PR TITLE
fix(opencode,openclaw): honor MEMSEARCH_DIR env var for storage scope

### DIFF
--- a/plugins/claude-code/transcript.py
+++ b/plugins/claude-code/transcript.py
@@ -229,13 +229,10 @@ def _summarize_tool_input(name: str, tool_input: dict) -> str:
 
 
 if __name__ == "__main__":
+    import argparse
     import sys
 
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="View conversation turns from a Claude Code JSONL transcript."
-    )
+    parser = argparse.ArgumentParser(description="View conversation turns from a Claude Code JSONL transcript.")
     parser.add_argument("jsonl_path", help="Path to the JSONL transcript file.")
     parser.add_argument("--turn", "-t", default=None, help="Target turn UUID (prefix match).")
     parser.add_argument("--context", "-c", default=3, type=int, help="Number of turns before/after target.")

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -18,8 +18,9 @@ function getMemoryDir(projectDir) {
   return join(getMemsearchDir(projectDir), "memory");
 }
 function getCollectionScopeDir(projectDir) {
+  const memsearchDir = getMemsearchDir(projectDir);
   const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit || projectDir;
+  return explicit ? memsearchDir : projectDir;
 }
 function ensureDir(dir) {
   if (!existsSync(dir)) {

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -1,21 +1,19 @@
 import {
-  readFileSync,
   appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
-  writeFileSync,
-  unlinkSync
+  readFileSync,
+  unlinkSync,
+  writeFileSync
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
-function getMemsearchDir(projectDir) {
-  const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit || join(projectDir, ".memsearch");
-}
 function getMemoryDir(projectDir) {
-  return join(getMemsearchDir(projectDir), "memory");
+  let memsearchDir2 = process.env.MEMSEARCH_DIR?.trim();
+  memsearchDir2 = memsearchDir2 || join(projectDir, ".memsearch");
+  return join(memsearchDir2, "memory");
 }
 function getCollectionScopeDir(projectDir) {
   return process.env.MEMSEARCH_DIR?.trim() || projectDir;
@@ -129,8 +127,14 @@ function tailTruncate(text, maxChars) {
 ${text.slice(-maxChars)}`;
 }
 function stripInjectedContext(text) {
-  let cleaned = text.replace(/Recent memories \(use memory_search for full search\):[\s\S]*?(?=\n\n(?!\s|-)|\n*$)/g, "");
-  cleaned = cleaned.replace(/Conversation info \(untrusted metadata\):[\s\S]*?(?=\n\n(?!\s|")|\n*$)/g, "");
+  let cleaned = text.replace(
+    /Recent memories \(use memory_search for full search\):[\s\S]*?(?=\n\n(?!\s|-)|\n*$)/g,
+    ""
+  );
+  cleaned = cleaned.replace(
+    /Conversation info \(untrusted metadata\):[\s\S]*?(?=\n\n(?!\s|")|\n*$)/g,
+    ""
+  );
   cleaned = cleaned.replace(/\[message_id:.*?\]\n/g, "");
   return cleaned.trim();
 }
@@ -236,7 +240,10 @@ var index_default = {
           ],
           {
             timeoutMs: 12e4,
-            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" })
+            env: envWithOverrides({
+              MEMSEARCH_NO_WATCH: "1",
+              MEMSEARCH_DISABLE: "1"
+            })
           }
         ).catch(() => {
         });
@@ -264,16 +271,14 @@ var index_default = {
     }
     let agentId = "main";
     let projectDir = join(home, ".openclaw", "workspace");
-    let memsearchDir = getMemsearchDir(projectDir);
-    let memoryDir = join(memsearchDir, "memory");
+    let memoryDir = getMemoryDir(projectDir);
     function updateAgentContext(ctx) {
       const newId = ctx?.agentId;
       const newWorkspace = ctx?.workspaceDir;
       if (newId && (newId !== agentId || newWorkspace && newWorkspace !== projectDir)) {
         agentId = newId;
         projectDir = newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
-        memsearchDir = getMemsearchDir(projectDir);
-        memoryDir = join(memsearchDir, "memory");
+        memoryDir = getMemoryDir(projectDir);
         _collectionNameFor = "";
         logger?.info?.(
           `[memsearch] Agent context updated: ${agentId}, dir: ${projectDir}`
@@ -319,7 +324,10 @@ var index_default = {
             } catch (e) {
               return {
                 content: [
-                  { type: "text", text: `Search failed: ${e.message}` }
+                  {
+                    type: "text",
+                    text: `Search failed: ${e.message}`
+                  }
                 ]
               };
             }
@@ -362,7 +370,10 @@ var index_default = {
             } catch (e) {
               return {
                 content: [
-                  { type: "text", text: `Expand failed: ${e.message}` }
+                  {
+                    type: "text",
+                    text: `Expand failed: ${e.message}`
+                  }
                 ]
               };
             }
@@ -390,7 +401,11 @@ var index_default = {
           },
           async execute(_toolCallId, params) {
             try {
-              const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.sh");
+              const scriptPath = join(
+                PLUGIN_DIR,
+                "scripts",
+                "parse-transcript.sh"
+              );
               const result = await runCmd(
                 ["bash", scriptPath, params.transcript_path],
                 { timeoutMs: 15e3 }
@@ -400,7 +415,10 @@ var index_default = {
             } catch (e) {
               return {
                 content: [
-                  { type: "text", text: `Transcript parse failed: ${e.message}` }
+                  {
+                    type: "text",
+                    text: `Transcript parse failed: ${e.message}`
+                  }
                 ]
               };
             }
@@ -417,9 +435,7 @@ var index_default = {
             return { prependContext: context };
           }
         } catch (e) {
-          logger?.warn?.(
-            `[memsearch] Failed to inject memories: ${e.message}`
-          );
+          logger?.warn?.(`[memsearch] Failed to inject memories: ${e.message}`);
         }
         return {};
       });
@@ -434,23 +450,33 @@ var index_default = {
         } catch {
         }
         if (customPromptFile && existsSync(customPromptFile)) {
-          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(
+            /\{\{AGENT_NAME\}\}/g,
+            agentName
+          );
         } else {
           const builtinPath = join(PLUGIN_DIR, "prompts", "summarize.txt");
           if (existsSync(builtinPath)) {
-            systemPrompt = readFileSync(builtinPath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+            systemPrompt = readFileSync(builtinPath, "utf-8").replace(
+              /\{\{AGENT_NAME\}\}/g,
+              agentName
+            );
           } else {
             systemPrompt = "You are a third-person note-taker. Summarize the transcript as 2-10 bullet points. Write in third person. Mandatory language rule: write every bullet in the same primary language as the [User] text. If User mixes languages, use the dominant user-facing language. Do NOT answer User's question. Output ONLY bullet points.";
           }
         }
         let summarizeModel = "";
         try {
-          summarizeModel = await getMemsearchConfigValue("plugins.openclaw.summarize.model");
+          summarizeModel = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.model"
+          );
         } catch {
         }
         let summarizeProvider = "";
         try {
-          summarizeProvider = await getMemsearchConfigValue("plugins.openclaw.summarize.provider");
+          summarizeProvider = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.provider"
+          );
         } catch {
         }
         if (summarizeProvider && summarizeProvider !== "native") {
@@ -461,7 +487,10 @@ var index_default = {
             const shellCmd = `cat ${JSON.stringify(tmpInput)} | ${cmd} summarize --plugin openclaw --agent-name OpenClaw`;
             const result = await runCmd(["bash", "-c", shellCmd], {
               timeoutMs: 6e4,
-              env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" })
+              env: envWithOverrides({
+                MEMSEARCH_NO_WATCH: "1",
+                MEMSEARCH_DISABLE: "1"
+              })
             });
             try {
               unlinkSync(tmpInput);
@@ -484,7 +513,10 @@ ${turnText}`;
           const shellCmd = `openclaw agent --local --session-id memsearch-summarize${modelArg} -m ${JSON.stringify(msgText)} > ${JSON.stringify(tmpFile)} 2>/dev/null`;
           await runCmd(["bash", "-c", shellCmd], {
             timeoutMs: 6e4,
-            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" })
+            env: envWithOverrides({
+              MEMSEARCH_NO_WATCH: "1",
+              MEMSEARCH_DISABLE: "1"
+            })
           });
           if (existsSync(tmpFile)) {
             const raw = readFileSync(tmpFile, "utf-8");
@@ -492,7 +524,9 @@ ${turnText}`;
               unlinkSync(tmpFile);
             } catch {
             }
-            const output = raw.split("\n").filter((line) => !line.startsWith("[plugins]") && !line.startsWith("[agents]")).join("\n").trim();
+            const output = raw.split("\n").filter(
+              (line) => !line.startsWith("[plugins]") && !line.startsWith("[agents]")
+            ).join("\n").trim();
             if (output && output.includes("- ")) {
               return output;
             }
@@ -560,7 +594,9 @@ ${anchor}${cleanSummary}
         if (messages.length < 2) return;
         let summarizeEnabled = "true";
         try {
-          summarizeEnabled = await getMemsearchConfigValue("plugins.openclaw.summarize.enabled");
+          summarizeEnabled = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.enabled"
+          );
         } catch {
         }
         if (summarizeEnabled === "false") {
@@ -600,81 +636,86 @@ ${anchor}${cleanSummary}
             ],
             { timeoutMs: 12e4 }
           ).catch((err) => {
-            logger?.warn?.(
-              `[memsearch] Initial index failed: ${err.message}`
-            );
+            logger?.warn?.(`[memsearch] Initial index failed: ${err.message}`);
           });
         }
       } catch (e) {
         logger?.warn?.(`[memsearch] session_start failed: ${e.message}`);
       }
     });
-    api.registerCli(({ program }) => {
-      const cmd = program.command("memsearch").description("Semantic memory search and management");
-      cmd.command("search <query>").description("Search past memories").option("-k, --top-k <n>", "Number of results", "5").action(async (query, opts) => {
-        try {
+    api.registerCli(
+      ({ program }) => {
+        const cmd = program.command("memsearch").description("Semantic memory search and management");
+        cmd.command("search <query>").description("Search past memories").option("-k, --top-k <n>", "Number of results", "5").action(async (query, opts) => {
+          try {
+            const memsearch = await getMemsearchCmd();
+            const collection = await getCollectionName();
+            const result = await runCmd(
+              [
+                "bash",
+                "-c",
+                `${memsearch} search '${shellEscape(query)}' --top-k ${opts.topK || 5} --collection ${collection}`
+              ],
+              { timeoutMs: 3e4 }
+            );
+            if (result.stdout) process.stdout.write(result.stdout);
+            if (result.stderr) process.stderr.write(result.stderr);
+          } catch (e) {
+            console.error(`Search failed: ${e.message}`);
+          }
+        });
+        cmd.command("index [directory]").description("Index memory files").action(async (directory) => {
+          const dir = directory || memoryDir;
+          try {
+            const memsearch = await getMemsearchCmd();
+            const collection = await getCollectionName();
+            const result = await runCmd(
+              [
+                "bash",
+                "-c",
+                `${memsearch} index '${shellEscape(dir)}' --collection ${collection}`
+              ],
+              { timeoutMs: 12e4 }
+            );
+            if (result.stdout) process.stdout.write(result.stdout);
+            if (result.stderr) process.stderr.write(result.stderr);
+          } catch (e) {
+            console.error(`Index failed: ${e.message}`);
+          }
+        });
+        cmd.command("status").description("Show memsearch status").action(async () => {
           const memsearch = await getMemsearchCmd();
           const collection = await getCollectionName();
-          const result = await runCmd(
-            [
-              "bash",
-              "-c",
-              `${memsearch} search '${shellEscape(query)}' --top-k ${opts.topK || 5} --collection ${collection}`
-            ],
-            { timeoutMs: 3e4 }
-          );
-          if (result.stdout) process.stdout.write(result.stdout);
-          if (result.stderr) process.stderr.write(result.stderr);
-        } catch (e) {
-          console.error(`Search failed: ${e.message}`);
-        }
-      });
-      cmd.command("index [directory]").description("Index memory files").action(async (directory) => {
-        const dir = directory || memoryDir;
-        try {
-          const memsearch = await getMemsearchCmd();
-          const collection = await getCollectionName();
-          const result = await runCmd(
-            [
-              "bash",
-              "-c",
-              `${memsearch} index '${shellEscape(dir)}' --collection ${collection}`
-            ],
-            { timeoutMs: 12e4 }
-          );
-          if (result.stdout) process.stdout.write(result.stdout);
-          if (result.stderr) process.stderr.write(result.stderr);
-        } catch (e) {
-          console.error(`Index failed: ${e.message}`);
-        }
-      });
-      cmd.command("status").description("Show memsearch status").action(async () => {
-        const memsearch = await getMemsearchCmd();
-        const collection = await getCollectionName();
-        console.log(`Agent:       ${agentId}`);
-        console.log(`Collection:  ${collection}`);
-        console.log(`Memory dir:  ${memoryDir}`);
-        console.log(`Provider:    ${pluginConfig.provider || "onnx"}`);
-        console.log(`CLI:         ${memsearch}`);
-        console.log(`AutoCapture: ${autoCapture}`);
-        console.log(`AutoRecall:  ${autoRecall}`);
-        try {
-          const result = await runCmd(
-            ["bash", "-c", `${memsearch} stats --collection ${collection}`],
-            { timeoutMs: 1e4 }
-          );
-          if (result.stdout) process.stdout.write(result.stdout);
-        } catch {
-          console.log("Stats: (unavailable \u2014 collection may not exist yet)");
-        }
-      });
-    }, {
-      descriptors: [{
-        name: "memsearch",
-        description: "Semantic memory search and management",
-        hasSubcommands: true
-      }]
-    });
+          console.log(`Agent:       ${agentId}`);
+          console.log(`Collection:  ${collection}`);
+          console.log(`Memory dir:  ${memoryDir}`);
+          console.log(`Provider:    ${pluginConfig.provider || "onnx"}`);
+          console.log(`CLI:         ${memsearch}`);
+          console.log(`AutoCapture: ${autoCapture}`);
+          console.log(`AutoRecall:  ${autoRecall}`);
+          try {
+            const result = await runCmd(
+              ["bash", "-c", `${memsearch} stats --collection ${collection}`],
+              { timeoutMs: 1e4 }
+            );
+            if (result.stdout) process.stdout.write(result.stdout);
+          } catch {
+            console.log(
+              "Stats: (unavailable \u2014 collection may not exist yet)"
+            );
+          }
+        });
+      },
+      {
+        descriptors: [
+          {
+            name: "memsearch",
+            description: "Semantic memory search and management",
+            hasSubcommands: true
+          }
+        ]
+      }
+    );
     getCollectionName().then((name) => {
       logger?.info?.(
         `[memsearch] Plugin loaded. Collection: ${name}, autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -19,8 +19,8 @@ function getMemoryDir(projectDir) {
 }
 function getCollectionScopeDir(projectDir) {
   const memsearchDir = getMemsearchDir(projectDir);
-  const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit ? memsearchDir : projectDir;
+  const isGlobalScope = memsearchDir !== join(projectDir, ".memsearch");
+  return isGlobalScope ? memsearchDir : projectDir;
 }
 function ensureDir(dir) {
   if (!existsSync(dir)) {

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -18,9 +18,7 @@ function getMemoryDir(projectDir) {
   return join(getMemsearchDir(projectDir), "memory");
 }
 function getCollectionScopeDir(projectDir) {
-  const memsearchDir = getMemsearchDir(projectDir);
-  const isGlobalScope = memsearchDir !== join(projectDir, ".memsearch");
-  return isGlobalScope ? memsearchDir : projectDir;
+  return process.env.MEMSEARCH_DIR?.trim() || projectDir;
 }
 function ensureDir(dir) {
   if (!existsSync(dir)) {

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -7,16 +7,17 @@ import {
   unlinkSync,
   writeFileSync
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 function getMemoryDir(projectDir) {
-  let memsearchDir2 = process.env.MEMSEARCH_DIR?.trim();
-  memsearchDir2 = memsearchDir2 || join(projectDir, ".memsearch");
-  return join(memsearchDir2, "memory");
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  const memsearchDir = explicit ? resolve(explicit) : join(projectDir, ".memsearch");
+  return join(memsearchDir, "memory");
 }
 function getCollectionScopeDir(projectDir) {
-  return process.env.MEMSEARCH_DIR?.trim() || projectDir;
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit ? resolve(explicit) : projectDir;
 }
 function ensureDir(dir) {
   if (!existsSync(dir)) {
@@ -232,11 +233,12 @@ var index_default = {
     async function wakeMaintenance() {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
+        const wakeMemsearchDir = process.env.MEMSEARCH_DIR?.trim() ? resolve(process.env.MEMSEARCH_DIR.trim()) : join(projectDir, ".memsearch");
         runCmd(
           [
             "bash",
             "-c",
-            `python3 '${shellEscape(runner)}' --platform openclaw --project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(memsearchDir)}'`
+            `python3 '${shellEscape(runner)}' --platform openclaw --project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(wakeMemsearchDir)}'`
           ],
           {
             timeoutMs: 12e4,

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -11,10 +11,15 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 function getMemsearchDir(projectDir) {
-  return join(projectDir, ".memsearch");
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit || join(projectDir, ".memsearch");
 }
 function getMemoryDir(projectDir) {
   return join(getMemsearchDir(projectDir), "memory");
+}
+function getCollectionScopeDir(projectDir) {
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit || projectDir;
 }
 function ensureDir(dir) {
   if (!existsSync(dir)) {
@@ -242,10 +247,11 @@ var index_default = {
     let _collectionNameFor = "";
     let _collectionName = "ms_openclaw_default";
     async function getCollectionName() {
-      if (_collectionNameFor === projectDir) return _collectionName;
+      const scopeDir = getCollectionScopeDir(projectDir);
+      if (_collectionNameFor === scopeDir) return _collectionName;
       const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
       try {
-        const r = await runCmd(["bash", script, projectDir], { timeoutMs: 5e3 });
+        const r = await runCmd(["bash", script, scopeDir], { timeoutMs: 5e3 });
         if (r.code === 0 && r.stdout?.trim()) {
           _collectionName = r.stdout.trim();
         } else {
@@ -254,12 +260,12 @@ var index_default = {
       } catch {
         _collectionName = "ms_openclaw_default";
       }
-      _collectionNameFor = projectDir;
+      _collectionNameFor = scopeDir;
       return _collectionName;
     }
     let agentId = "main";
     let projectDir = join(home, ".openclaw", "workspace");
-    let memsearchDir = join(projectDir, ".memsearch");
+    let memsearchDir = getMemsearchDir(projectDir);
     let memoryDir = join(memsearchDir, "memory");
     function updateAgentContext(ctx) {
       const newId = ctx?.agentId;
@@ -267,7 +273,7 @@ var index_default = {
       if (newId && (newId !== agentId || newWorkspace && newWorkspace !== projectDir)) {
         agentId = newId;
         projectDir = newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
-        memsearchDir = join(projectDir, ".memsearch");
+        memsearchDir = getMemsearchDir(projectDir);
         memoryDir = join(memsearchDir, "memory");
         _collectionNameFor = "";
         logger?.info?.(

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -10,10 +10,12 @@ import {
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
-function getMemoryDir(projectDir) {
+function getMemsearchDir(projectDir) {
   const explicit = process.env.MEMSEARCH_DIR?.trim();
-  const memsearchDir = explicit ? resolve(explicit) : join(projectDir, ".memsearch");
-  return join(memsearchDir, "memory");
+  return explicit ? resolve(explicit) : join(projectDir, ".memsearch");
+}
+function getMemoryDir(projectDir) {
+  return join(getMemsearchDir(projectDir), "memory");
 }
 function getCollectionScopeDir(projectDir) {
   const explicit = process.env.MEMSEARCH_DIR?.trim();
@@ -233,7 +235,7 @@ var index_default = {
     async function wakeMaintenance() {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
-        const wakeMemsearchDir = process.env.MEMSEARCH_DIR?.trim() ? resolve(process.env.MEMSEARCH_DIR.trim()) : join(projectDir, ".memsearch");
+        const wakeMemsearchDir = getMemsearchDir(projectDir);
         runCmd(
           [
             "bash",

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -235,12 +235,12 @@ var index_default = {
     async function wakeMaintenance() {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
-        const wakeMemsearchDir = getMemsearchDir(projectDir);
+        const memsearchDir = getMemsearchDir(projectDir);
         runCmd(
           [
             "bash",
             "-c",
-            `python3 '${shellEscape(runner)}' --platform openclaw --project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(wakeMemsearchDir)}'`
+            `python3 '${shellEscape(runner)}' --platform openclaw --project-dir '${shellEscape(projectDir)}' --memsearch-dir '${shellEscape(memsearchDir)}'`
           ],
           {
             timeoutMs: 12e4,

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -28,11 +28,14 @@ const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 // Helpers (no external process calls — those live inside register())
 // ---------------------------------------------------------------------------
 
-function getMemoryDir(projectDir: string): string {
-  // Honor MEMSEARCH_DIR for shared/global scope
+function getMemsearchDir(projectDir: string): string {
+  // Honor MEMSEARCH_DIR for shared/global scope — matches claude-code/codex behavior.
   const explicit = process.env.MEMSEARCH_DIR?.trim();
-  const memsearchDir = explicit ? resolve(explicit) : join(projectDir, ".memsearch");
-  return join(memsearchDir, "memory");
+  return explicit ? resolve(explicit) : join(projectDir, ".memsearch");
+}
+
+function getMemoryDir(projectDir: string): string {
+  return join(getMemsearchDir(projectDir), "memory");
 }
 
 /**
@@ -358,9 +361,7 @@ export default {
     async function wakeMaintenance(): Promise<void> {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
-        const wakeMemsearchDir = process.env.MEMSEARCH_DIR?.trim()
-          ? resolve(process.env.MEMSEARCH_DIR.trim())
-          : join(projectDir, ".memsearch");
+        const wakeMemsearchDir = getMemsearchDir(projectDir);
         runCmd(
           [
             "bash",

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -39,16 +39,13 @@ function getMemoryDir(projectDir: string): string {
 }
 
 /**
- * When MEMSEARCH_DIR is set, collection derives from that shared dir (global scope).
- * Otherwise collection derives from projectDir (per-project isolation).
- * Uses getMemsearchDir so both paths always share the same root.
+ * Directory to derive the collection name from.
+ * When MEMSEARCH_DIR is set, collection keys off that shared dir (global scope).
+ * Otherwise collection keys off projectDir (per-project isolation).
+ * Matches claude-code/codex common.sh behavior exactly.
  */
 function getCollectionScopeDir(projectDir: string): string {
-  const memsearchDir = getMemsearchDir(projectDir);
-  // When MEMSEARCH_DIR is set, memsearchDir IS that value; use it as the collection key.
-  // Otherwise memsearchDir is <projectDir>/.memsearch — collection still keys off projectDir.
-  const isGlobalScope = memsearchDir !== join(projectDir, ".memsearch");
-  return isGlobalScope ? memsearchDir : projectDir;
+  return process.env.MEMSEARCH_DIR?.trim() || projectDir;
 }
 
 function ensureDir(dir: string): string {

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -361,14 +361,14 @@ export default {
     async function wakeMaintenance(): Promise<void> {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
-        const wakeMemsearchDir = getMemsearchDir(projectDir);
+        const memsearchDir = getMemsearchDir(projectDir);
         runCmd(
           [
             "bash",
             "-c",
             `python3 '${shellEscape(runner)}' --platform openclaw ` +
               `--project-dir '${shellEscape(projectDir)}' ` +
-              `--memsearch-dir '${shellEscape(wakeMemsearchDir)}'`,
+              `--memsearch-dir '${shellEscape(memsearchDir)}'`,
           ],
           {
             timeoutMs: 120000,

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -39,16 +39,16 @@ function getMemoryDir(projectDir: string): string {
 }
 
 /**
- * When MEMSEARCH_DIR is set, the collection derives from that shared dir
- * (global scope); otherwise it derives from the project dir (per-project).
- * Derives from getMemsearchDir to guarantee they always share the same root.
+ * When MEMSEARCH_DIR is set, collection derives from that shared dir (global scope).
+ * Otherwise collection derives from projectDir (per-project isolation).
+ * Uses getMemsearchDir so both paths always share the same root.
  */
 function getCollectionScopeDir(projectDir: string): string {
   const memsearchDir = getMemsearchDir(projectDir);
-  // MEMSEARCH_DIR set → storage is memsearchDir itself (e.g. /shared/.memsearch)
-  // Per-project → storage is <projectDir>/.memsearch, but collection keys off projectDir
-  const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit ? memsearchDir : projectDir;
+  // When MEMSEARCH_DIR is set, memsearchDir IS that value; use it as the collection key.
+  // Otherwise memsearchDir is <projectDir>/.memsearch — collection still keys off projectDir.
+  const isGlobalScope = memsearchDir !== join(projectDir, ".memsearch");
+  return isGlobalScope ? memsearchDir : projectDir;
 }
 
 function ensureDir(dir: string): string {

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -19,7 +19,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
@@ -30,8 +30,8 @@ const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 
 function getMemoryDir(projectDir: string): string {
   // Honor MEMSEARCH_DIR for shared/global scope
-  let memsearchDir = process.env.MEMSEARCH_DIR?.trim();
-  memsearchDir = memsearchDir || join(projectDir, ".memsearch");
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  const memsearchDir = explicit ? resolve(explicit) : join(projectDir, ".memsearch");
   return join(memsearchDir, "memory");
 }
 
@@ -42,7 +42,8 @@ function getMemoryDir(projectDir: string): string {
  * Matches claude-code/codex common.sh behavior exactly.
  */
 function getCollectionScopeDir(projectDir: string): string {
-  return process.env.MEMSEARCH_DIR?.trim() || projectDir;
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit ? resolve(explicit) : projectDir;
 }
 
 function ensureDir(dir: string): string {
@@ -357,13 +358,16 @@ export default {
     async function wakeMaintenance(): Promise<void> {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
+        const wakeMemsearchDir = process.env.MEMSEARCH_DIR?.trim()
+          ? resolve(process.env.MEMSEARCH_DIR.trim())
+          : join(projectDir, ".memsearch");
         runCmd(
           [
             "bash",
             "-c",
             `python3 '${shellEscape(runner)}' --platform openclaw ` +
               `--project-dir '${shellEscape(projectDir)}' ` +
-              `--memsearch-dir '${shellEscape(memsearchDir)}'`,
+              `--memsearch-dir '${shellEscape(wakeMemsearchDir)}'`,
           ],
           {
             timeoutMs: 120000,

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -29,11 +29,22 @@ const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 // ---------------------------------------------------------------------------
 
 function getMemsearchDir(projectDir: string): string {
-  return join(projectDir, ".memsearch");
+  // Honor MEMSEARCH_DIR for shared/global scope — matches claude-code/codex behavior.
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit || join(projectDir, ".memsearch");
 }
 
 function getMemoryDir(projectDir: string): string {
   return join(getMemsearchDir(projectDir), "memory");
+}
+
+/**
+ * When MEMSEARCH_DIR is set, the collection derives from that shared dir
+ * (global scope); otherwise it derives from the project dir (per-project).
+ */
+function getCollectionScopeDir(projectDir: string): string {
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  return explicit || projectDir;
 }
 
 function ensureDir(dir: string): string {
@@ -362,10 +373,11 @@ export default {
     let _collectionName = "ms_openclaw_default";
 
     async function getCollectionName(): Promise<string> {
-      if (_collectionNameFor === projectDir) return _collectionName;
+      const scopeDir = getCollectionScopeDir(projectDir);
+      if (_collectionNameFor === scopeDir) return _collectionName;
       const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
       try {
-        const r = await runCmd(["bash", script, projectDir], { timeoutMs: 5000 });
+        const r = await runCmd(["bash", script, scopeDir], { timeoutMs: 5000 });
         if (r.code === 0 && r.stdout?.trim()) {
           _collectionName = r.stdout.trim();
         } else {
@@ -374,7 +386,7 @@ export default {
       } catch {
         _collectionName = "ms_openclaw_default";
       }
-      _collectionNameFor = projectDir;
+      _collectionNameFor = scopeDir;
       return _collectionName;
     }
 
@@ -386,7 +398,7 @@ export default {
     // same project directory.
     let agentId = "main";
     let projectDir = join(home, ".openclaw", "workspace");  // default main workspace
-    let memsearchDir = join(projectDir, ".memsearch");
+    let memsearchDir = getMemsearchDir(projectDir);
     let memoryDir = join(memsearchDir, "memory");
 
     /** Update agent context from tool factory ctx. Called on each tool invocation. */
@@ -396,7 +408,7 @@ export default {
       if (newId && (newId !== agentId || (newWorkspace && newWorkspace !== projectDir))) {
         agentId = newId;
         projectDir = newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
-        memsearchDir = join(projectDir, ".memsearch");
+        memsearchDir = getMemsearchDir(projectDir);
         memoryDir = join(memsearchDir, "memory");
         // Invalidate cached collection name — will be re-derived on next getCollectionName()
         _collectionNameFor = "";

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -11,15 +11,15 @@
  */
 
 import {
-  readFileSync,
   appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
-  writeFileSync,
+  readFileSync,
   unlinkSync,
+  writeFileSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
@@ -28,14 +28,11 @@ const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
 // Helpers (no external process calls — those live inside register())
 // ---------------------------------------------------------------------------
 
-function getMemsearchDir(projectDir: string): string {
-  // Honor MEMSEARCH_DIR for shared/global scope — matches claude-code/codex behavior.
-  const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit || join(projectDir, ".memsearch");
-}
-
 function getMemoryDir(projectDir: string): string {
-  return join(getMemsearchDir(projectDir), "memory");
+  // Honor MEMSEARCH_DIR for shared/global scope
+  let memsearchDir = process.env.MEMSEARCH_DIR?.trim();
+  memsearchDir = memsearchDir || join(projectDir, ".memsearch");
+  return join(memsearchDir, "memory");
 }
 
 /**
@@ -97,7 +94,7 @@ function recentMemoryPreviewLines(content: string, maxLines: number): string[] {
 function getRecentMemories(
   memDir: string,
   count = 2,
-  maxLinesPerFile = 30
+  maxLinesPerFile = 30,
 ): string {
   if (!existsSync(memDir)) return "";
 
@@ -210,9 +207,15 @@ function tailTruncate(text: string, maxChars: number): string {
  */
 function stripInjectedContext(text: string): string {
   // Remove "Recent memories ..." block (goes until a blank line followed by non-indented text, or end)
-  let cleaned = text.replace(/Recent memories \(use memory_search for full search\):[\s\S]*?(?=\n\n(?!\s|-)|\n*$)/g, "");
+  let cleaned = text.replace(
+    /Recent memories \(use memory_search for full search\):[\s\S]*?(?=\n\n(?!\s|-)|\n*$)/g,
+    "",
+  );
   // Remove "Conversation info (untrusted metadata):" block
-  cleaned = cleaned.replace(/Conversation info \(untrusted metadata\):[\s\S]*?(?=\n\n(?!\s|")|\n*$)/g, "");
+  cleaned = cleaned.replace(
+    /Conversation info \(untrusted metadata\):[\s\S]*?(?=\n\n(?!\s|")|\n*$)/g,
+    "",
+  );
   // Remove "[message_id: ...]" lines
   cleaned = cleaned.replace(/\[message_id:.*?\]\n/g, "");
   return cleaned.trim();
@@ -263,7 +266,9 @@ function extractLastTurn(messages: any[]): string | null {
  * Build a full env object with overrides (needed because runCommandWithTimeout
  * replaces the env entirely when the env option is specified).
  */
-function envWithOverrides(overrides: Record<string, string>): Record<string, string> {
+function envWithOverrides(
+  overrides: Record<string, string>,
+): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [k, v] of Object.entries(process.env)) {
     if (v !== undefined) env[k] = v;
@@ -294,7 +299,7 @@ export default {
     // Convenience wrapper for api.runtime.system.runCommandWithTimeout
     async function runCmd(
       argv: string[],
-      opts?: { timeoutMs?: number; cwd?: string; env?: Record<string, string> }
+      opts?: { timeoutMs?: number; cwd?: string; env?: Record<string, string> },
     ): Promise<{ stdout: string; stderr: string; code: number | null }> {
       return api.runtime.system.runCommandWithTimeout(argv, opts || {});
     }
@@ -344,7 +349,7 @@ export default {
       const cmd = await getMemsearchCmd();
       const r = await runCmd(
         ["bash", "-c", `${cmd} config get '${shellEscape(key)}'`],
-        { timeoutMs: 5000 }
+        { timeoutMs: 5000 },
       );
       return r.stdout?.trim() || "";
     }
@@ -354,16 +359,22 @@ export default {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
         runCmd(
           [
-            "bash", "-c",
+            "bash",
+            "-c",
             `python3 '${shellEscape(runner)}' --platform openclaw ` +
               `--project-dir '${shellEscape(projectDir)}' ` +
               `--memsearch-dir '${shellEscape(memsearchDir)}'`,
           ],
           {
             timeoutMs: 120000,
-            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" }),
-          }
-        ).catch(() => { /* ignore */ });
+            env: envWithOverrides({
+              MEMSEARCH_NO_WATCH: "1",
+              MEMSEARCH_DISABLE: "1",
+            }),
+          },
+        ).catch(() => {
+          /* ignore */
+        });
       } catch {
         /* ignore */
       }
@@ -398,23 +409,25 @@ export default {
     // memories are automatically shared when multiple platforms work on the
     // same project directory.
     let agentId = "main";
-    let projectDir = join(home, ".openclaw", "workspace");  // default main workspace
-    let memsearchDir = getMemsearchDir(projectDir);
-    let memoryDir = join(memsearchDir, "memory");
+    let projectDir = join(home, ".openclaw", "workspace"); // default main workspace
+    let memoryDir = getMemoryDir(projectDir);
 
     /** Update agent context from tool factory ctx. Called on each tool invocation. */
     function updateAgentContext(ctx: any): void {
       const newId = ctx?.agentId;
       const newWorkspace = ctx?.workspaceDir;
-      if (newId && (newId !== agentId || (newWorkspace && newWorkspace !== projectDir))) {
+      if (
+        newId &&
+        (newId !== agentId || (newWorkspace && newWorkspace !== projectDir))
+      ) {
         agentId = newId;
-        projectDir = newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
-        memsearchDir = getMemsearchDir(projectDir);
-        memoryDir = join(memsearchDir, "memory");
+        projectDir =
+          newWorkspace || join(home, ".openclaw", `workspace-${agentId}`);
+        memoryDir = getMemoryDir(projectDir);
         // Invalidate cached collection name — will be re-derived on next getCollectionName()
         _collectionNameFor = "";
         logger?.info?.(
-          `[memsearch] Agent context updated: ${agentId}, dir: ${projectDir}`
+          `[memsearch] Agent context updated: ${agentId}, dir: ${projectDir}`,
         );
       }
     }
@@ -449,7 +462,7 @@ export default {
           },
           async execute(
             _toolCallId: string,
-            params: { query: string; top_k?: number }
+            params: { query: string; top_k?: number },
           ) {
             const topK = params.top_k || 5;
             try {
@@ -457,25 +470,29 @@ export default {
               const collection = await getCollectionName();
               const result = await runCmd(
                 [
-                  "bash", "-c",
+                  "bash",
+                  "-c",
                   `${cmd} search '${shellEscape(params.query)}' ` +
                     `--top-k ${topK} --json-output --collection ${collection}`,
                 ],
-                { timeoutMs: 30000 }
+                { timeoutMs: 30000 },
               );
               const output = result.stdout || result.stderr || "No results";
               return { content: [{ type: "text" as const, text: output }] };
             } catch (e: any) {
               return {
                 content: [
-                  { type: "text" as const, text: `Search failed: ${e.message}` },
+                  {
+                    type: "text" as const,
+                    text: `Search failed: ${e.message}`,
+                  },
                 ],
               };
             }
           },
         };
       },
-      { name: "memory_search" }
+      { name: "memory_search" },
     );
 
     // ----- Tool: memory_get -----
@@ -501,34 +518,35 @@ export default {
             },
             required: ["chunk_hash"],
           },
-          async execute(
-            _toolCallId: string,
-            params: { chunk_hash: string }
-          ) {
+          async execute(_toolCallId: string, params: { chunk_hash: string }) {
             try {
               const cmd = await getMemsearchCmd();
               const collection = await getCollectionName();
               const result = await runCmd(
                 [
-                  "bash", "-c",
+                  "bash",
+                  "-c",
                   `${cmd} expand '${shellEscape(params.chunk_hash)}' ` +
                     `--collection ${collection}`,
                 ],
-                { timeoutMs: 15000 }
+                { timeoutMs: 15000 },
               );
               const output = result.stdout || result.stderr || "No content";
               return { content: [{ type: "text" as const, text: output }] };
             } catch (e: any) {
               return {
                 content: [
-                  { type: "text" as const, text: `Expand failed: ${e.message}` },
+                  {
+                    type: "text" as const,
+                    text: `Expand failed: ${e.message}`,
+                  },
                 ],
               };
             }
           },
         };
       },
-      { name: "memory_get" }
+      { name: "memory_get" },
     );
 
     // ----- Tool: memory_transcript (L3) -----
@@ -550,34 +568,45 @@ export default {
             properties: {
               transcript_path: {
                 type: "string" as const,
-                description: "Path to the .jsonl transcript file (from the anchor comment)",
+                description:
+                  "Path to the .jsonl transcript file (from the anchor comment)",
               },
             },
             required: ["transcript_path"],
           },
           async execute(
             _toolCallId: string,
-            params: { transcript_path: string }
+            params: { transcript_path: string },
           ) {
             try {
-              const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.sh");
+              const scriptPath = join(
+                PLUGIN_DIR,
+                "scripts",
+                "parse-transcript.sh",
+              );
               const result = await runCmd(
                 ["bash", scriptPath, params.transcript_path],
-                { timeoutMs: 15000 }
+                { timeoutMs: 15000 },
               );
-              const output = result.stdout?.trim() || result.stderr || "No transcript content";
+              const output =
+                result.stdout?.trim() ||
+                result.stderr ||
+                "No transcript content";
               return { content: [{ type: "text" as const, text: output }] };
             } catch (e: any) {
               return {
                 content: [
-                  { type: "text" as const, text: `Transcript parse failed: ${e.message}` },
+                  {
+                    type: "text" as const,
+                    text: `Transcript parse failed: ${e.message}`,
+                  },
                 ],
               };
             }
           },
         };
       },
-      { name: "memory_transcript" }
+      { name: "memory_transcript" },
     );
 
     // ----- Hook: before_agent_start — inject recent memories -----
@@ -589,9 +618,7 @@ export default {
             return { prependContext: context };
           }
         } catch (e: any) {
-          logger?.warn?.(
-            `[memsearch] Failed to inject memories: ${e.message}`
-          );
+          logger?.warn?.(`[memsearch] Failed to inject memories: ${e.message}`);
         }
         return {};
       });
@@ -622,15 +649,23 @@ export default {
         let customPromptFile = "";
         try {
           customPromptFile = await getMemsearchConfigValue("prompts.summarize");
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
 
         if (customPromptFile && existsSync(customPromptFile)) {
-          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+          systemPrompt = readFileSync(customPromptFile, "utf-8").replace(
+            /\{\{AGENT_NAME\}\}/g,
+            agentName,
+          );
         } else {
           // Fall back to plugin built-in template
           const builtinPath = join(PLUGIN_DIR, "prompts", "summarize.txt");
           if (existsSync(builtinPath)) {
-            systemPrompt = readFileSync(builtinPath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, agentName);
+            systemPrompt = readFileSync(builtinPath, "utf-8").replace(
+              /\{\{AGENT_NAME\}\}/g,
+              agentName,
+            );
           } else {
             systemPrompt =
               "You are a third-person note-taker. Summarize the transcript as 2-10 bullet points. " +
@@ -642,13 +677,21 @@ export default {
 
         let summarizeModel = "";
         try {
-          summarizeModel = await getMemsearchConfigValue("plugins.openclaw.summarize.model");
-        } catch { /* ignore */ }
+          summarizeModel = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.model",
+          );
+        } catch {
+          /* ignore */
+        }
 
         let summarizeProvider = "";
         try {
-          summarizeProvider = await getMemsearchConfigValue("plugins.openclaw.summarize.provider");
-        } catch { /* ignore */ }
+          summarizeProvider = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.provider",
+          );
+        } catch {
+          /* ignore */
+        }
 
         if (summarizeProvider && summarizeProvider !== "native") {
           try {
@@ -660,9 +703,16 @@ export default {
               `--plugin openclaw --agent-name OpenClaw`;
             const result = await runCmd(["bash", "-c", shellCmd], {
               timeoutMs: 60000,
-              env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" }),
+              env: envWithOverrides({
+                MEMSEARCH_NO_WATCH: "1",
+                MEMSEARCH_DISABLE: "1",
+              }),
             });
-            try { unlinkSync(tmpInput); } catch { /* ignore cleanup errors */ }
+            try {
+              unlinkSync(tmpInput);
+            } catch {
+              /* ignore cleanup errors */
+            }
             const output = (result.stdout || "").trim();
             if (output) {
               return output;
@@ -678,19 +728,31 @@ export default {
         try {
           const msgText = `${systemPrompt}\n\nTranscript:\n${turnText}`;
           const tmpFile = `/tmp/memsearch-summarize-${Date.now()}.txt`;
-          const modelArg = summarizeModel ? ` --model ${JSON.stringify(summarizeModel)}` : "";
+          const modelArg = summarizeModel
+            ? ` --model ${JSON.stringify(summarizeModel)}`
+            : "";
           const shellCmd = `openclaw agent --local --session-id memsearch-summarize${modelArg} -m ${JSON.stringify(msgText)} > ${JSON.stringify(tmpFile)} 2>/dev/null`;
           await runCmd(["bash", "-c", shellCmd], {
             timeoutMs: 60000,
-            env: envWithOverrides({ MEMSEARCH_NO_WATCH: "1", MEMSEARCH_DISABLE: "1" }),
+            env: envWithOverrides({
+              MEMSEARCH_NO_WATCH: "1",
+              MEMSEARCH_DISABLE: "1",
+            }),
           });
           if (existsSync(tmpFile)) {
             const raw = readFileSync(tmpFile, "utf-8");
-            try { unlinkSync(tmpFile); } catch { /* ignore cleanup errors */ }
+            try {
+              unlinkSync(tmpFile);
+            } catch {
+              /* ignore cleanup errors */
+            }
             // Filter out plugin loading logs polluting stdout (openclaw/openclaw#51076)
             const output = raw
               .split("\n")
-              .filter((line: string) => !line.startsWith("[plugins]") && !line.startsWith("[agents]"))
+              .filter(
+                (line: string) =>
+                  !line.startsWith("[plugins]") && !line.startsWith("[agents]"),
+              )
               .join("\n")
               .trim();
             if (output && output.includes("- ")) {
@@ -706,7 +768,10 @@ export default {
       }
 
       /** Write a turn summary to the daily memory file and re-index. */
-      async function writeTurnCapture(turnText: string, sessionId?: string): Promise<void> {
+      async function writeTurnCapture(
+        turnText: string,
+        sessionId?: string,
+      ): Promise<void> {
         try {
           if (turnText.length < 1) return;
 
@@ -720,7 +785,7 @@ export default {
             writeFileSync(
               memoryFile,
               `# ${today}\n\n## Session ${now}\n\n`,
-              "utf-8"
+              "utf-8",
             );
           }
 
@@ -754,10 +819,11 @@ export default {
           const collection = await getCollectionName();
           runCmd(
             [
-              "bash", "-c",
+              "bash",
+              "-c",
               `${cmd} index '${shellEscape(memoryDir)}' --collection ${collection}`,
             ],
-            { timeoutMs: 60000 }
+            { timeoutMs: 60000 },
           ).catch((err: any) => {
             logger?.warn?.(`[memsearch] Index failed: ${err.message}`);
           });
@@ -775,10 +841,16 @@ export default {
 
         let summarizeEnabled = "true";
         try {
-          summarizeEnabled = await getMemsearchConfigValue("plugins.openclaw.summarize.enabled");
-        } catch { /* ignore */ }
+          summarizeEnabled = await getMemsearchConfigValue(
+            "plugins.openclaw.summarize.enabled",
+          );
+        } catch {
+          /* ignore */
+        }
         if (summarizeEnabled === "false") {
-          wakeMaintenance().catch(() => { /* ignore */ });
+          wakeMaintenance().catch(() => {
+            /* ignore */
+          });
           return;
         }
 
@@ -787,7 +859,9 @@ export default {
 
         const sessionId = event.sessionId || "";
         await writeTurnCapture(lastTurn, sessionId);
-        wakeMaintenance().catch(() => { /* ignore */ });
+        wakeMaintenance().catch(() => {
+          /* ignore */
+        });
       });
     }
 
@@ -804,7 +878,7 @@ export default {
           try {
             await runCmd(
               ["bash", "-c", `${cmd} config set embedding.provider onnx`],
-              { timeoutMs: 5000 }
+              { timeoutMs: 5000 },
             );
           } catch {
             /* ignore */
@@ -815,14 +889,13 @@ export default {
         if (existsSync(memoryDir)) {
           runCmd(
             [
-              "bash", "-c",
+              "bash",
+              "-c",
               `${cmd} index '${shellEscape(memoryDir)}' --collection ${collection}`,
             ],
-            { timeoutMs: 120000 }
+            { timeoutMs: 120000 },
           ).catch((err: any) => {
-            logger?.warn?.(
-              `[memsearch] Initial index failed: ${err.message}`
-            );
+            logger?.warn?.(`[memsearch] Initial index failed: ${err.message}`);
           });
         }
       } catch (e: any) {
@@ -831,98 +904,107 @@ export default {
     });
 
     // ----- CLI: memsearch subcommand -----
-    api.registerCli(({ program }: any) => {
-      const cmd = program
-        .command("memsearch")
-        .description("Semantic memory search and management");
+    api.registerCli(
+      ({ program }: any) => {
+        const cmd = program
+          .command("memsearch")
+          .description("Semantic memory search and management");
 
-      cmd
-        .command("search <query>")
-        .description("Search past memories")
-        .option("-k, --top-k <n>", "Number of results", "5")
-        .action(async (query: string, opts: any) => {
-          try {
+        cmd
+          .command("search <query>")
+          .description("Search past memories")
+          .option("-k, --top-k <n>", "Number of results", "5")
+          .action(async (query: string, opts: any) => {
+            try {
+              const memsearch = await getMemsearchCmd();
+              const collection = await getCollectionName();
+              const result = await runCmd(
+                [
+                  "bash",
+                  "-c",
+                  `${memsearch} search '${shellEscape(query)}' ` +
+                    `--top-k ${opts.topK || 5} --collection ${collection}`,
+                ],
+                { timeoutMs: 30000 },
+              );
+              if (result.stdout) process.stdout.write(result.stdout);
+              if (result.stderr) process.stderr.write(result.stderr);
+            } catch (e: any) {
+              console.error(`Search failed: ${e.message}`);
+            }
+          });
+
+        cmd
+          .command("index [directory]")
+          .description("Index memory files")
+          .action(async (directory?: string) => {
+            const dir = directory || memoryDir;
+            try {
+              const memsearch = await getMemsearchCmd();
+              const collection = await getCollectionName();
+              const result = await runCmd(
+                [
+                  "bash",
+                  "-c",
+                  `${memsearch} index '${shellEscape(dir)}' --collection ${collection}`,
+                ],
+                { timeoutMs: 120000 },
+              );
+              if (result.stdout) process.stdout.write(result.stdout);
+              if (result.stderr) process.stderr.write(result.stderr);
+            } catch (e: any) {
+              console.error(`Index failed: ${e.message}`);
+            }
+          });
+
+        cmd
+          .command("status")
+          .description("Show memsearch status")
+          .action(async () => {
             const memsearch = await getMemsearchCmd();
             const collection = await getCollectionName();
-            const result = await runCmd(
-              [
-                "bash", "-c",
-                `${memsearch} search '${shellEscape(query)}' ` +
-                  `--top-k ${opts.topK || 5} --collection ${collection}`,
-              ],
-              { timeoutMs: 30000 }
-            );
-            if (result.stdout) process.stdout.write(result.stdout);
-            if (result.stderr) process.stderr.write(result.stderr);
-          } catch (e: any) {
-            console.error(`Search failed: ${e.message}`);
-          }
-        });
-
-      cmd
-        .command("index [directory]")
-        .description("Index memory files")
-        .action(async (directory?: string) => {
-          const dir = directory || memoryDir;
-          try {
-            const memsearch = await getMemsearchCmd();
-            const collection = await getCollectionName();
-            const result = await runCmd(
-              [
-                "bash", "-c",
-                `${memsearch} index '${shellEscape(dir)}' --collection ${collection}`,
-              ],
-              { timeoutMs: 120000 }
-            );
-            if (result.stdout) process.stdout.write(result.stdout);
-            if (result.stderr) process.stderr.write(result.stderr);
-          } catch (e: any) {
-            console.error(`Index failed: ${e.message}`);
-          }
-        });
-
-      cmd
-        .command("status")
-        .description("Show memsearch status")
-        .action(async () => {
-          const memsearch = await getMemsearchCmd();
-          const collection = await getCollectionName();
-          console.log(`Agent:       ${agentId}`);
-          console.log(`Collection:  ${collection}`);
-          console.log(`Memory dir:  ${memoryDir}`);
-          console.log(`Provider:    ${pluginConfig.provider || "onnx"}`);
-          console.log(`CLI:         ${memsearch}`);
-          console.log(`AutoCapture: ${autoCapture}`);
-          console.log(`AutoRecall:  ${autoRecall}`);
-          try {
-            const result = await runCmd(
-              ["bash", "-c", `${memsearch} stats --collection ${collection}`],
-              { timeoutMs: 10000 }
-            );
-            if (result.stdout) process.stdout.write(result.stdout);
-          } catch {
-            console.log("Stats: (unavailable — collection may not exist yet)");
-          }
-        });
-    }, {
-      descriptors: [{
-        name: "memsearch",
-        description: "Semantic memory search and management",
-        hasSubcommands: true,
-      }],
-    });
+            console.log(`Agent:       ${agentId}`);
+            console.log(`Collection:  ${collection}`);
+            console.log(`Memory dir:  ${memoryDir}`);
+            console.log(`Provider:    ${pluginConfig.provider || "onnx"}`);
+            console.log(`CLI:         ${memsearch}`);
+            console.log(`AutoCapture: ${autoCapture}`);
+            console.log(`AutoRecall:  ${autoRecall}`);
+            try {
+              const result = await runCmd(
+                ["bash", "-c", `${memsearch} stats --collection ${collection}`],
+                { timeoutMs: 10000 },
+              );
+              if (result.stdout) process.stdout.write(result.stdout);
+            } catch {
+              console.log(
+                "Stats: (unavailable — collection may not exist yet)",
+              );
+            }
+          });
+      },
+      {
+        descriptors: [
+          {
+            name: "memsearch",
+            description: "Semantic memory search and management",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
 
     // Eager init (non-blocking) — log when ready
     getCollectionName()
       .then((name) => {
         logger?.info?.(
           `[memsearch] Plugin loaded. Collection: ${name}, ` +
-            `autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`
+            `autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`,
         );
       })
       .catch(() => {
         logger?.info?.(
-          `[memsearch] Plugin loaded. autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`
+          `[memsearch] Plugin loaded. autoCapture: ${autoCapture}, autoRecall: ${autoRecall}`,
         );
       });
   },

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -41,10 +41,14 @@ function getMemoryDir(projectDir: string): string {
 /**
  * When MEMSEARCH_DIR is set, the collection derives from that shared dir
  * (global scope); otherwise it derives from the project dir (per-project).
+ * Derives from getMemsearchDir to guarantee they always share the same root.
  */
 function getCollectionScopeDir(projectDir: string): string {
+  const memsearchDir = getMemsearchDir(projectDir);
+  // MEMSEARCH_DIR set → storage is memsearchDir itself (e.g. /shared/.memsearch)
+  // Per-project → storage is <projectDir>/.memsearch, but collection keys off projectDir
   const explicit = process.env.MEMSEARCH_DIR?.trim();
-  return explicit || projectDir;
+  return explicit ? memsearchDir : projectDir;
 }
 
 function ensureDir(dir: string): string {

--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -1,29 +1,35 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import test from "node:test";
 
 import {
   getRecentMemories,
   isDailyJournalFile,
+  MEMSEARCH_SYSTEM_MARKER,
   mergeSystemMemoryContext,
   resolveScope,
-  MEMSEARCH_SYSTEM_MARKER,
 } from "./index.ts";
 
 test("appends memory context when no system entry exists yet", () => {
-  const result = mergeSystemMemoryContext(undefined, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  const result = mergeSystemMemoryContext(
+    undefined,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
   assert.deepEqual(result, [`${MEMSEARCH_SYSTEM_MARKER} ctx-a`]);
 });
 
 test("folds memory context into the first entry without growing the array", () => {
   const result = mergeSystemMemoryContext(
     ["You are a helpful assistant."],
-    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
   );
   assert.equal(result.length, 1);
-  assert.equal(result[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  assert.equal(
+    result[0],
+    `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
 });
 
 test("repeated calls with the same context stay idempotent", () => {
@@ -42,18 +48,33 @@ test("repeated calls with the same context stay idempotent", () => {
 
 test("repeated calls with updated context replace the previous block", () => {
   const base = ["You are a helpful assistant."];
-  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
-  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  const first = mergeSystemMemoryContext(
+    base,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
+  const second = mergeSystemMemoryContext(
+    first,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
 
   assert.equal(second.length, 1);
-  assert.equal(second[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  assert.equal(
+    second[0],
+    `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
   assert.ok(!second[0].includes("ctx-a"));
 });
 
 test("does not disturb additional system entries beyond the first", () => {
   const base = ["Base prompt.", "Second unrelated system entry."];
-  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
-  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  const first = mergeSystemMemoryContext(
+    base,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
+  const second = mergeSystemMemoryContext(
+    first,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
 
   assert.equal(second.length, 2);
   assert.equal(second[1], "Second unrelated system entry.");
@@ -66,7 +87,10 @@ test("resolveScope defaults to per-project isolation when MEMSEARCH_DIR is unset
   try {
     const scope = resolveScope("/tmp/my-project");
     assert.equal(scope.memsearchDir, join("/tmp/my-project", ".memsearch"));
-    assert.equal(scope.memoryDir, join("/tmp/my-project", ".memsearch", "memory"));
+    assert.equal(
+      scope.memoryDir,
+      join("/tmp/my-project", ".memsearch", "memory"),
+    );
     // Collection derives from the project dir in per-project scope.
     assert.match(scope.collection, /^ms_.+_[0-9a-f]{8}$/);
   } finally {
@@ -105,12 +129,12 @@ test("recent memories only use dated daily journals", () => {
     writeFileSync(
       join(dir, "2026-07-12.md"),
       "# 2026-07-12\n\n## Session 09:00\n\n### 09:00\n- Daily journal content.\n",
-      "utf-8"
+      "utf-8",
     );
     writeFileSync(
       join(dir, "zzz-scratch.md"),
       "# Scratch\n\n## Session 10:00\n\n### 10:00\n- Scratch content should not displace daily journals.\n",
-      "utf-8"
+      "utf-8",
     );
 
     const context = getRecentMemories(dir);

--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -8,6 +8,7 @@ import {
   getRecentMemories,
   isDailyJournalFile,
   mergeSystemMemoryContext,
+  resolveScope,
   MEMSEARCH_SYSTEM_MARKER,
 } from "./index.ts";
 
@@ -57,6 +58,41 @@ test("does not disturb additional system entries beyond the first", () => {
   assert.equal(second.length, 2);
   assert.equal(second[1], "Second unrelated system entry.");
   assert.ok(!second[0].includes("ctx-a"));
+});
+
+test("resolveScope defaults to per-project isolation when MEMSEARCH_DIR is unset", () => {
+  const prev = process.env.MEMSEARCH_DIR;
+  delete process.env.MEMSEARCH_DIR;
+  try {
+    const scope = resolveScope("/tmp/my-project");
+    assert.equal(scope.memsearchDir, join("/tmp/my-project", ".memsearch"));
+    assert.equal(scope.memoryDir, join("/tmp/my-project", ".memsearch", "memory"));
+    // Collection derives from the project dir in per-project scope.
+    assert.match(scope.collection, /^ms_.+_[0-9a-f]{8}$/);
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR;
+    else process.env.MEMSEARCH_DIR = prev;
+  }
+});
+
+test("resolveScope honors MEMSEARCH_DIR for shared/global scope", () => {
+  const prev = process.env.MEMSEARCH_DIR;
+  const shared = mkdtempSync(join(tmpdir(), "memsearch-shared-"));
+  process.env.MEMSEARCH_DIR = shared;
+  try {
+    const a = resolveScope("/tmp/project-a");
+    const b = resolveScope("/tmp/project-b");
+    // Shared storage dir regardless of the working directory.
+    assert.equal(a.memsearchDir, shared);
+    assert.equal(b.memsearchDir, shared);
+    assert.equal(a.memoryDir, join(shared, "memory"));
+    // Same collection across projects — global scope is shared.
+    assert.equal(a.collection, b.collection);
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR;
+    else process.env.MEMSEARCH_DIR = prev;
+    rmSync(shared, { recursive: true, force: true });
+  }
 });
 
 test("recent memories only use dated daily journals", () => {

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -220,7 +220,8 @@ function startCaptureDaemon(
   memsearchCmd: string,
   memsearchDir: string
 ): void {
-  const pidFile = join(memsearchDir, ".capture.pid");
+  // PID file is per-project so each project has its own daemon even when sharing memsearchDir.
+  const pidFile = join(projectDir, ".memsearch", ".capture.pid");
   const daemonScript = join(PLUGIN_DIR, "scripts", "capture-daemon.py");
 
   // Check if daemon is already running
@@ -242,6 +243,7 @@ function startCaptureDaemon(
 
   try {
     mkdirSync(memsearchDir, { recursive: true });
+    mkdirSync(join(projectDir, ".memsearch"), { recursive: true });
     const child = spawn(
       "python3",
       [
@@ -275,8 +277,8 @@ function startCaptureDaemon(
 /**
  * Stop the capture daemon.
  */
-function stopCaptureDaemon(memsearchDir: string): void {
-  const pidFile = join(memsearchDir, ".capture.pid");
+function stopCaptureDaemon(projectDir: string): void {
+  const pidFile = join(projectDir, ".memsearch", ".capture.pid");
   if (existsSync(pidFile)) {
     try {
       const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -70,6 +70,40 @@ function deriveCollectionName(projectDir: string): string {
   }
 }
 
+/** True when MEMSEARCH_DIR is explicitly set (global/shared scope). */
+function memsearchDirExplicit(): boolean {
+  return !!(process.env.MEMSEARCH_DIR && process.env.MEMSEARCH_DIR.trim());
+}
+
+/**
+ * Resolve the memsearch storage scope for a working directory.
+ *
+ * When MEMSEARCH_DIR is set, use it as the shared storage dir and derive the
+ * collection from it (global scope, shared across projects) — matching the
+ * claude-code/codex `common.sh` behavior. Otherwise fall back to per-project
+ * isolation under `<projectDir>/.memsearch`.
+ */
+export function resolveScope(dir: string): {
+  memsearchDir: string;
+  memoryDir: string;
+  collection: string;
+} {
+  if (memsearchDirExplicit()) {
+    const memsearchDir = process.env.MEMSEARCH_DIR as string;
+    return {
+      memsearchDir,
+      memoryDir: join(memsearchDir, "memory"),
+      collection: deriveCollectionName(memsearchDir),
+    };
+  }
+  const memsearchDir = join(dir, ".memsearch");
+  return {
+    memsearchDir,
+    memoryDir: join(memsearchDir, "memory"),
+    collection: deriveCollectionName(dir),
+  };
+}
+
 /**
  * Summarize the N most recent daily .md files for cold-start context.
  * Extracts recent non-empty session sections so empty SessionStart headings
@@ -185,10 +219,11 @@ export function mergeSystemMemoryContext(
 function startCaptureDaemon(
   projectDir: string,
   collectionName: string,
-  memsearchCmd: string
+  memsearchCmd: string,
+  memsearchDir: string
 ): void {
-  const stateDir = join(projectDir, ".memsearch");
-  const pidFile = join(projectDir, ".memsearch", ".capture.pid");
+  const stateDir = memsearchDir;
+  const pidFile = join(memsearchDir, ".capture.pid");
   const daemonScript = join(PLUGIN_DIR, "scripts", "capture-daemon.py");
 
   // Check if daemon is already running
@@ -218,6 +253,8 @@ function startCaptureDaemon(
         collectionName,
         "--memsearch-cmd",
         memsearchCmd,
+        "--memsearch-dir",
+        memsearchDir,
         "--poll-interval",
         "10",
         "--parent-pid",
@@ -241,8 +278,8 @@ function startCaptureDaemon(
 /**
  * Stop the capture daemon.
  */
-function stopCaptureDaemon(projectDir: string): void {
-  const pidFile = join(projectDir, ".memsearch", ".capture.pid");
+function stopCaptureDaemon(memsearchDir: string): void {
+  const pidFile = join(memsearchDir, ".capture.pid");
   if (existsSync(pidFile)) {
     try {
       const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
@@ -274,9 +311,8 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
   // worktree can be "/" for global projects — use directory instead
   const projectDir = (worktree && worktree !== "/") ? worktree : (directory || process.cwd());
   const memsearchCmd = detectMemsearchCmd();
-  const collectionName = deriveCollectionName(projectDir);
-  const memsearchDir = join(projectDir, ".memsearch");
-  const memoryDir = join(memsearchDir, "memory");
+  // Honor MEMSEARCH_DIR (shared/global scope) when set, else per-project scope.
+  const { memsearchDir, memoryDir, collection: collectionName } = resolveScope(projectDir);
   const home = process.env.HOME || "~";
 
   // Skip capture/recall in child processes to prevent recursion
@@ -310,7 +346,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
 
   // Start capture daemon for auto-capture
   if (autoCapture) {
-    startCaptureDaemon(projectDir, collectionName, memsearchCmd);
+    startCaptureDaemon(projectDir, collectionName, memsearchCmd, memsearchDir);
     wakeMaintenance(projectDir, memsearchDir);
   }
 
@@ -330,10 +366,12 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         async execute(args, context) {
           // Use context.directory for the actual session directory (may differ from init)
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          const memDir = join(dir, ".memsearch", "memory");
+          const scope = dir !== projectDir
+            ? resolveScope(dir)
+            : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
           // Ensure daemon is running for current directory
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           const topK = args.top_k || 5;
           try {
             const result = spawnSync(
@@ -362,8 +400,11 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          const scope = dir !== projectDir
+            ? resolveScope(dir)
+            : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
             const result = spawnSync(
               "bash",
@@ -396,8 +437,11 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          const scope = dir !== projectDir
+            ? resolveScope(dir)
+            : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
             const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.py");
             const scriptArgs = [

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -83,6 +83,7 @@ function memsearchDirExplicit(): boolean {
  * claude-code/codex `common.sh` behavior. Otherwise fall back to per-project
  * isolation under `<projectDir>/.memsearch`.
  */
+// exported for unit-testing only
 export function resolveScope(dir: string): {
   memsearchDir: string;
   memoryDir: string;

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -65,10 +65,12 @@ function detectMemsearchCmd(): string {
 function deriveCollectionName(projectDir: string): string {
   const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
   try {
-    return execSync(`bash "${script}" "${projectDir}"`, {
+    const r = spawnSync("bash", [script, projectDir], {
       encoding: "utf-8",
       timeout: 5000,
-    }).trim();
+    });
+    if (r.status === 0 && r.stdout?.trim()) return r.stdout.trim();
+    return "ms_opencode_default";
   } catch {
     return "ms_opencode_default";
   }

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -70,11 +70,6 @@ function deriveCollectionName(projectDir: string): string {
   }
 }
 
-/** True when MEMSEARCH_DIR is explicitly set (global/shared scope). */
-function memsearchDirExplicit(): boolean {
-  return !!(process.env.MEMSEARCH_DIR && process.env.MEMSEARCH_DIR.trim());
-}
-
 /**
  * Resolve the memsearch storage scope for a working directory.
  *
@@ -89,12 +84,12 @@ export function resolveScope(dir: string): {
   memoryDir: string;
   collection: string;
 } {
-  if (memsearchDirExplicit()) {
-    const memsearchDir = process.env.MEMSEARCH_DIR as string;
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  if (explicit) {
     return {
-      memsearchDir,
-      memoryDir: join(memsearchDir, "memory"),
-      collection: deriveCollectionName(memsearchDir),
+      memsearchDir: explicit,
+      memoryDir: join(explicit, "memory"),
+      collection: deriveCollectionName(explicit),
     };
   }
   const memsearchDir = join(dir, ".memsearch");

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -23,7 +23,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_DIR = dirname(realpathSync(fileURLToPath(import.meta.url)));
@@ -86,10 +86,12 @@ export function resolveScope(dir: string): {
 } {
   const explicit = process.env.MEMSEARCH_DIR?.trim();
   if (explicit) {
+    // Resolve to absolute path so relative values behave consistently regardless of cwd.
+    const memsearchDir = resolve(explicit);
     return {
-      memsearchDir: explicit,
-      memoryDir: join(explicit, "memory"),
-      collection: deriveCollectionName(explicit),
+      memsearchDir,
+      memoryDir: join(memsearchDir, "memory"),
+      collection: deriveCollectionName(memsearchDir),
     };
   }
   const memsearchDir = join(dir, ".memsearch");
@@ -218,7 +220,6 @@ function startCaptureDaemon(
   memsearchCmd: string,
   memsearchDir: string
 ): void {
-  const stateDir = memsearchDir;
   const pidFile = join(memsearchDir, ".capture.pid");
   const daemonScript = join(PLUGIN_DIR, "scripts", "capture-daemon.py");
 
@@ -240,7 +241,7 @@ function startCaptureDaemon(
   }
 
   try {
-    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(memsearchDir, { recursive: true });
     const child = spawn(
       "python3",
       [

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -13,17 +13,17 @@
 
 import type { Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
-import { execSync, exec, spawn, spawnSync } from "node:child_process";
+import { exec, execSync, spawn, spawnSync } from "node:child_process";
 import {
-  readFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join, dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_DIR = dirname(realpathSync(fileURLToPath(import.meta.url)));
@@ -42,7 +42,9 @@ function detectMemsearchCmd(): string {
   try {
     const r = spawnSync("which", ["memsearch"], { stdio: "pipe" });
     if (r.status === 0) return "memsearch";
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 
   const uvxPath = join(home, ".local", "bin", "uvx");
   if (existsSync(uvxPath)) {
@@ -52,7 +54,9 @@ function detectMemsearchCmd(): string {
   try {
     const r = spawnSync("which", ["uvx"], { stdio: "pipe" });
     if (r.status === 0) return "uvx --from 'memsearch[onnx]' memsearch";
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 
   return "memsearch";
 }
@@ -131,7 +135,11 @@ function recentMemoryPreviewLines(content: string, maxLines: number): string[] {
       current.push(line);
       continue;
     }
-    if (line.startsWith("- ") || line.startsWith("[User]") || line.startsWith("[Assistant]")) {
+    if (
+      line.startsWith("- ") ||
+      line.startsWith("[User]") ||
+      line.startsWith("[Assistant]")
+    ) {
       current.push(line);
       hasBody = true;
     }
@@ -148,7 +156,7 @@ export function isDailyJournalFile(file: string): boolean {
 export function getRecentMemories(
   memDir: string,
   count = 2,
-  maxLinesPerFile = 30
+  maxLinesPerFile = 30,
 ): string {
   if (!existsSync(memDir)) return "";
 
@@ -167,7 +175,9 @@ export function getRecentMemories(
       if (lines.length > 0) {
         summary.push(`[${file}]`, ...lines);
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
 
   if (summary.length === 0) {
@@ -196,7 +206,7 @@ export const MEMSEARCH_SYSTEM_MARKER = "[memsearch] Memory available.";
  */
 export function mergeSystemMemoryContext(
   system: string[] | undefined,
-  memoryText: string
+  memoryText: string,
 ): string[] {
   if (!Array.isArray(system) || system.length === 0) {
     return [memoryText];
@@ -205,7 +215,9 @@ export function mergeSystemMemoryContext(
   const existing = result[0];
   const markerIndex = existing.indexOf(MEMSEARCH_SYSTEM_MARKER);
   const base =
-    markerIndex === -1 ? existing : existing.slice(0, markerIndex).replace(/\n+$/, "");
+    markerIndex === -1
+      ? existing
+      : existing.slice(0, markerIndex).replace(/\n+$/, "");
   result[0] = base ? `${base}\n\n${memoryText}` : memoryText;
   return result;
 }
@@ -218,7 +230,7 @@ function startCaptureDaemon(
   projectDir: string,
   collectionName: string,
   memsearchCmd: string,
-  memsearchDir: string
+  memsearchDir: string,
 ): void {
   // PID file is per-project so each project has its own daemon even when sharing memsearchDir.
   const pidFile = join(projectDir, ".memsearch", ".capture.pid");
@@ -235,10 +247,16 @@ function startCaptureDaemon(
           return; // Already running
         } catch {
           // Process is dead, clean up stale PID file
-          try { unlinkSync(pidFile); } catch { /* ignore */ }
+          try {
+            unlinkSync(pidFile);
+          } catch {
+            /* ignore */
+          }
         }
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   try {
@@ -263,11 +281,15 @@ function startCaptureDaemon(
         detached: true,
         stdio: "ignore",
         env: { ...process.env, MEMSEARCH_NO_WATCH: "1" },
-      }
+      },
     );
     child.unref();
     if (child.pid) {
-      try { writeFileSync(pidFile, String(child.pid), "utf-8"); } catch { /* ignore */ }
+      try {
+        writeFileSync(pidFile, String(child.pid), "utf-8");
+      } catch {
+        /* ignore */
+      }
     }
   } catch {
     // Capture is best-effort; tools still work without the background daemon.
@@ -283,9 +305,15 @@ function stopCaptureDaemon(projectDir: string): void {
     try {
       const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
       if (pid > 0) {
-        try { process.kill(pid, "SIGTERM"); } catch { /* ignore */ }
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          /* ignore */
+        }
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -298,7 +326,9 @@ function wakeMaintenance(projectDir: string, memsearchDir: string): void {
       timeout: 5000,
       env: { ...process.env, MEMSEARCH_NO_WATCH: "1" },
     },
-    () => { /* ignore */ }
+    () => {
+      /* ignore */
+    },
   );
 }
 
@@ -308,10 +338,15 @@ function wakeMaintenance(projectDir: string, memsearchDir: string): void {
 
 const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
   // worktree can be "/" for global projects — use directory instead
-  const projectDir = (worktree && worktree !== "/") ? worktree : (directory || process.cwd());
+  const projectDir =
+    worktree && worktree !== "/" ? worktree : directory || process.cwd();
   const memsearchCmd = detectMemsearchCmd();
   // Honor MEMSEARCH_DIR (shared/global scope) when set, else per-project scope.
-  const { memsearchDir, memoryDir, collection: collectionName } = resolveScope(projectDir);
+  const {
+    memsearchDir,
+    memoryDir,
+    collection: collectionName,
+  } = resolveScope(projectDir);
   const home = process.env.HOME || "~";
 
   // Skip capture/recall in child processes to prevent recursion
@@ -329,9 +364,13 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           timeout: 5000,
           stdio: "ignore",
         });
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 
   // Run initial index in background
   if (existsSync(memoryDir)) {
@@ -339,7 +378,9 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
       `${memsearchCmd} index '${shellEscape(memoryDir)}' ` +
         `--collection ${collectionName}`,
       { timeout: 120000 },
-      () => { /* ignore */ }
+      () => {
+        /* ignore */
+      },
     );
   }
 
@@ -359,18 +400,25 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           "topics discussed, and code referenced. Powered by Milvus hybrid " +
           "search (BM25 + dense vectors + RRF reranking).",
         args: {
-          query: tool.schema.string().describe("Search query — describe what you want to find"),
-          top_k: tool.schema.number().optional().describe("Number of results to return (default: 5)"),
+          query: tool.schema
+            .string()
+            .describe("Search query — describe what you want to find"),
+          top_k: tool.schema
+            .number()
+            .optional()
+            .describe("Number of results to return (default: 5)"),
         },
         async execute(args, context) {
           // Use context.directory for the actual session directory (may differ from init)
           const dir = context?.directory || projectDir;
-          const scope = dir !== projectDir
-            ? resolveScope(dir)
-            : { memsearchDir, memoryDir, collection: collectionName };
+          const scope =
+            dir !== projectDir
+              ? resolveScope(dir)
+              : { memsearchDir, memoryDir, collection: collectionName };
           const col = scope.collection;
           // Ensure daemon is running for current directory
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
+          if (autoCapture)
+            startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           const topK = args.top_k || 5;
           try {
             const result = spawnSync(
@@ -380,7 +428,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
                 `${memsearchCmd} search '${shellEscape(args.query)}' ` +
                   `--top-k ${topK} --json-output --collection ${col}`,
               ],
-              { encoding: "utf-8", timeout: 30000 }
+              { encoding: "utf-8", timeout: 30000 },
             );
             return result.stdout || result.stderr || "No results found.";
           } catch (e: any) {
@@ -395,15 +443,19 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           "surrounding context. Use after memory_search to get details " +
           "about a specific result.",
         args: {
-          chunk_hash: tool.schema.string().describe("The chunk_hash from a search result to expand"),
+          chunk_hash: tool.schema
+            .string()
+            .describe("The chunk_hash from a search result to expand"),
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const scope = dir !== projectDir
-            ? resolveScope(dir)
-            : { memsearchDir, memoryDir, collection: collectionName };
+          const scope =
+            dir !== projectDir
+              ? resolveScope(dir)
+              : { memsearchDir, memoryDir, collection: collectionName };
           const col = scope.collection;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
+          if (autoCapture)
+            startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
             const result = spawnSync(
               "bash",
@@ -412,7 +464,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
                 `${memsearchCmd} expand '${shellEscape(args.chunk_hash)}' ` +
                   `--collection ${col}`,
               ],
-              { encoding: "utf-8", timeout: 15000 }
+              { encoding: "utf-8", timeout: 15000 },
             );
             return result.stdout || result.stderr || "No content found.";
           } catch (e: any) {
@@ -429,20 +481,39 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           "dialogue with [User] and [Assistant] labels. When turn_id is present, " +
           "the tool returns the target turn plus surrounding context.",
         args: {
-          session_id: tool.schema.string().describe("The session ID from the anchor comment"),
-          turn_id: tool.schema.string().optional().describe("Optional turn ID from the anchor comment"),
-          context: tool.schema.number().optional().describe("Turns before/after the target turn (default: 3)"),
-          limit: tool.schema.number().optional().describe("Max number of turns to return when no turn_id is provided (default: 20)"),
+          session_id: tool.schema
+            .string()
+            .describe("The session ID from the anchor comment"),
+          turn_id: tool.schema
+            .string()
+            .optional()
+            .describe("Optional turn ID from the anchor comment"),
+          context: tool.schema
+            .number()
+            .optional()
+            .describe("Turns before/after the target turn (default: 3)"),
+          limit: tool.schema
+            .number()
+            .optional()
+            .describe(
+              "Max number of turns to return when no turn_id is provided (default: 20)",
+            ),
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const scope = dir !== projectDir
-            ? resolveScope(dir)
-            : { memsearchDir, memoryDir, collection: collectionName };
+          const scope =
+            dir !== projectDir
+              ? resolveScope(dir)
+              : { memsearchDir, memoryDir, collection: collectionName };
           const col = scope.collection;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
+          if (autoCapture)
+            startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
-            const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.py");
+            const scriptPath = join(
+              PLUGIN_DIR,
+              "scripts",
+              "parse-transcript.py",
+            );
             const scriptArgs = [
               scriptPath,
               args.session_id,
@@ -462,7 +533,11 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
               encoding: "utf-8",
               timeout: 15000,
             });
-            return result.stdout?.trim() || result.stderr || "No transcript content found.";
+            return (
+              result.stdout?.trim() ||
+              result.stderr ||
+              "No transcript content found."
+            );
           } catch (e: any) {
             return `Transcript parse failed: ${e.message}`;
           }
@@ -473,16 +548,24 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
     // ----- Hook: system prompt transform — inject recent memories -----
     ...(autoRecall
       ? {
-          "experimental.chat.system.transform": async (_input: any, output: any) => {
+          "experimental.chat.system.transform": async (
+            _input: any,
+            output: any,
+          ) => {
             try {
               const context = getRecentMemories(memoryDir);
               if (context) {
                 const memoryText =
                   `${MEMSEARCH_SYSTEM_MARKER} You have access to memory_search, ` +
                   `memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`;
-                output.system = mergeSystemMemoryContext(output.system, memoryText);
+                output.system = mergeSystemMemoryContext(
+                  output.system,
+                  memoryText,
+                );
               }
-            } catch { /* ignore */ }
+            } catch {
+              /* ignore */
+            }
           },
         }
       : {}),

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -810,9 +810,11 @@ def main() -> None:
     # OpenCode session/config lookups still key off the real project_dir.
     memsearch_dir = Path(args.memsearch_dir) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
     memory_dir = memsearch_dir / "memory"
-    pid_file = memsearch_dir / ".capture.pid"
+    # PID file is per-project so each project has its own daemon even when sharing memsearch_dir.
+    pid_file = Path(args.project_dir) / ".memsearch" / ".capture.pid"
 
     memsearch_dir.mkdir(parents=True, exist_ok=True)
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
     def cleanup(signum=None, frame=None) -> None:

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -709,7 +709,7 @@ def capture_session_turns(
     memsearch_cmd: str,
     db_path: str,
     tail_turn_cache: dict[str, TailTurnObservation] | None = None,
-    project_dir: str | os.PathLike[str] | None = None,
+    project_dir: str | os.PathLike[str] = "",
 ) -> bool:
     """Capture all newly completed turns for a single session."""
     state = load_turn_state(turn_db, session_id)
@@ -755,10 +755,7 @@ def capture_session_turns(
         if not capture_exists(memory_dir, session_id, turn.turn_id):
             if not get_plugin_summarize_enabled(memsearch_cmd):
                 continue
-            # OpenCode config/isolation keys off the real project dir; only fall
-            # back to the memsearch-dir-derived path when no project_dir is given.
-            summarize_project_dir = project_dir if project_dir is not None else memsearch_dir.parent
-            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, summarize_project_dir)
+            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, project_dir)
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -729,7 +729,7 @@ def capture_session_turns(
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(str(memsearch_dir))
+        legacy_after_time = _load_legacy_last_msg_time(memsearch_dir.as_posix())
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None
@@ -804,11 +804,12 @@ def main() -> None:
 
     # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
     # OpenCode session/config lookups still key off the real project_dir.
-    memsearch_dir = args.memsearch_dir or os.path.join(args.project_dir, ".memsearch")
-    memory_dir = os.path.join(memsearch_dir, "memory")
-    pid_file = os.path.join(memsearch_dir, ".capture.pid")
+    _memsearch_path = Path(args.memsearch_dir) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
+    memsearch_dir = _memsearch_path.as_posix()
+    memory_dir = (_memsearch_path / "memory").as_posix()
+    pid_file = (_memsearch_path / ".capture.pid").as_posix()
 
-    os.makedirs(os.path.dirname(pid_file), exist_ok=True)
+    _memsearch_path.mkdir(parents=True, exist_ok=True)
     with open(pid_file, "w", encoding="utf-8") as f:
         f.write(str(os.getpid()))
 
@@ -821,7 +822,7 @@ def main() -> None:
     signal.signal(signal.SIGINT, cleanup)
 
     small_model = get_small_model(args.project_dir)
-    turn_db = open_turn_db(args.project_dir, memsearch_dir)
+    turn_db = open_turn_db(memsearch_dir)
     tail_turn_cache: dict[str, TailTurnObservation] = {}
 
     while True:

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -763,12 +763,8 @@ def capture_session_turns(
                 continue
             # OpenCode config/isolation keys off the real project dir; only fall
             # back to the memsearch-dir-derived path when no project_dir is given.
-            summarize_project_dir = (
-                project_dir if project_dir is not None else memsearch_dir.parent
-            )
-            summary = summarize_with_llm(
-                turn_text, small_model, memsearch_cmd, summarize_project_dir
-            )
+            summarize_project_dir = project_dir if project_dir is not None else memsearch_dir.parent
+            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, summarize_project_dir)
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -543,9 +543,11 @@ def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     return [row[0] for row in sessions]
 
 
-def _load_legacy_last_msg_time(memsearch_dir: Path) -> int:
+def _load_legacy_last_msg_time(project_dir: Path) -> int:
     """Read the pre-sidecar capture checkpoint for upgrade compatibility."""
-    path = memsearch_dir / ".last_msg_time"
+    # Always reads from project_dir/.memsearch regardless of MEMSEARCH_DIR so
+    # existing checkpoints are found after users migrate to a shared storage dir.
+    path = project_dir / ".memsearch" / ".last_msg_time"
     try:
         value = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
@@ -735,7 +737,7 @@ def capture_session_turns(
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(memory_dir.resolve().parent)
+        legacy_after_time = _load_legacy_last_msg_time(Path(project_dir).resolve())
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -858,7 +858,13 @@ def main() -> None:
 
             if any_new:
                 subprocess.Popen(
-                    [*split_memsearch_cmd(args.memsearch_cmd), "index", memory_dir.as_posix(), "--collection", args.collection_name],
+                    [
+                        *split_memsearch_cmd(args.memsearch_cmd),
+                        "index",
+                        memory_dir.as_posix(),
+                        "--collection",
+                        args.collection_name,
+                    ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -3,13 +3,17 @@
 
 Usage:
   capture-daemon.py <project_dir> <collection_name> [--memsearch-cmd CMD]
+                    [--memsearch-dir DIR]
 
 The daemon polls the OpenCode SQLite database for completed turns, extracts
 the latest completed turn, summarizes it as bullet points, and writes to
-<project_dir>/.memsearch/memory/YYYY-MM-DD.md.
+<memsearch_dir>/memory/YYYY-MM-DD.md.
 
-It also persists derived turn metadata in <project_dir>/.memsearch/opencode-turns.db
-and triggers memsearch indexing after writing.
+It also persists derived turn metadata in <memsearch_dir>/opencode-turns.db
+and triggers memsearch indexing after writing. <memsearch_dir> defaults to
+<project_dir>/.memsearch but honors MEMSEARCH_DIR (shared/global scope) when
+the plugin passes --memsearch-dir. OpenCode session and config lookups still
+key off the real <project_dir>.
 """
 
 from __future__ import annotations
@@ -459,9 +463,10 @@ def summarize_with_llm(
     return None
 
 
-def wake_maintenance(project_dir: str) -> None:
+def wake_maintenance(project_dir: str, memsearch_dir: str | None = None) -> None:
     """Start maintenance in a hook-disabled child environment."""
     runner = Path(__file__).resolve().parent / "maintenance-runner.py"
+    resolved_memsearch_dir = memsearch_dir or os.path.join(project_dir, ".memsearch")
     subprocess.Popen(
         [
             "python3",
@@ -471,7 +476,7 @@ def wake_maintenance(project_dir: str) -> None:
             "--project-dir",
             project_dir,
             "--memsearch-dir",
-            os.path.join(project_dir, ".memsearch"),
+            resolved_memsearch_dir,
         ],
         env={**os.environ, "MEMSEARCH_NO_WATCH": "1", "MEMSEARCH_DISABLE": "1"},
         stdin=subprocess.DEVNULL,
@@ -524,9 +529,9 @@ def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     return [row[0] for row in sessions]
 
 
-def _load_legacy_last_msg_time(project_dir: str) -> int:
+def _load_legacy_last_msg_time(memsearch_dir: str) -> int:
     """Read the pre-sidecar capture checkpoint for upgrade compatibility."""
-    path = Path(project_dir) / ".memsearch" / ".last_msg_time"
+    path = Path(memsearch_dir) / ".last_msg_time"
     try:
         value = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
@@ -711,6 +716,7 @@ def capture_session_turns(
     memsearch_cmd: str,
     db_path: str,
     tail_turn_cache: dict[str, TailTurnObservation] | None = None,
+    project_dir: str | os.PathLike[str] | None = None,
 ) -> bool:
     """Capture all newly completed turns for a single session."""
     state = load_turn_state(turn_db, session_id)
@@ -719,9 +725,12 @@ def capture_session_turns(
     if tail_turn_cache is None:
         tail_turn_cache = {}
 
+    # The memsearch storage dir holds the memory/ folder and the legacy checkpoint.
+    memsearch_dir = Path(memory_dir).resolve().parent
+
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(str(Path(memory_dir).resolve().parent.parent))
+        legacy_after_time = _load_legacy_last_msg_time(str(memsearch_dir))
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None
@@ -753,8 +762,14 @@ def capture_session_turns(
         if not capture_exists(memory_dir, session_id, turn.turn_id):
             if not get_plugin_summarize_enabled(memsearch_cmd):
                 continue
-            project_dir = Path(memory_dir).resolve().parent.parent
-            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, project_dir)
+            # OpenCode config/isolation keys off the real project dir; only fall
+            # back to the memsearch-dir-derived path when no project_dir is given.
+            summarize_project_dir = (
+                project_dir if project_dir is not None else memsearch_dir.parent
+            )
+            summary = summarize_with_llm(
+                turn_text, small_model, memsearch_cmd, summarize_project_dir
+            )
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,
@@ -778,6 +793,11 @@ def main() -> None:
     parser.add_argument("project_dir", help="Project directory")
     parser.add_argument("collection_name", help="Milvus collection name")
     parser.add_argument("--memsearch-cmd", default="memsearch", help="memsearch command")
+    parser.add_argument(
+        "--memsearch-dir",
+        default=None,
+        help="MemSearch storage dir (defaults to <project_dir>/.memsearch)",
+    )
     parser.add_argument("--poll-interval", type=int, default=10, help="Poll interval in seconds")
     parser.add_argument("--parent-pid", type=int, default=0, help="Exit when this parent process is gone")
     args = parser.parse_args()
@@ -787,8 +807,11 @@ def main() -> None:
         sys.stderr.write(f"OpenCode database not found at {db_path}\n")
         sys.exit(1)
 
-    memory_dir = os.path.join(args.project_dir, ".memsearch", "memory")
-    pid_file = os.path.join(args.project_dir, ".memsearch", ".capture.pid")
+    # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
+    # OpenCode session/config lookups still key off the real project_dir.
+    memsearch_dir = args.memsearch_dir or os.path.join(args.project_dir, ".memsearch")
+    memory_dir = os.path.join(memsearch_dir, "memory")
+    pid_file = os.path.join(memsearch_dir, ".capture.pid")
 
     os.makedirs(os.path.dirname(pid_file), exist_ok=True)
     with open(pid_file, "w", encoding="utf-8") as f:
@@ -803,7 +826,7 @@ def main() -> None:
     signal.signal(signal.SIGINT, cleanup)
 
     small_model = get_small_model(args.project_dir)
-    turn_db = open_turn_db(args.project_dir)
+    turn_db = open_turn_db(args.project_dir, memsearch_dir)
     tail_turn_cache: dict[str, TailTurnObservation] = {}
 
     while True:
@@ -826,13 +849,14 @@ def main() -> None:
                         args.memsearch_cmd,
                         db_path,
                         tail_turn_cache,
+                        args.project_dir,
                     )
                     or any_new
                 )
 
             if any_new:
                 os.system(f"{args.memsearch_cmd} index '{memory_dir}' --collection {args.collection_name} &")
-                wake_maintenance(args.project_dir)
+                wake_maintenance(args.project_dir, memsearch_dir)
         except Exception:
             pass
         finally:

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -810,7 +810,9 @@ def main() -> None:
 
     # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
     # OpenCode session/config lookups still key off the real project_dir.
-    memsearch_dir = Path(os.path.abspath(args.memsearch_dir)) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
+    memsearch_dir = (
+        Path(os.path.abspath(args.memsearch_dir)) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
+    )
     memory_dir = memsearch_dir / "memory"
     # PID file is per-project so each project has its own daemon even when sharing memsearch_dir.
     pid_file = Path(args.project_dir) / ".memsearch" / ".capture.pid"

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -718,12 +718,9 @@ def capture_session_turns(
     if tail_turn_cache is None:
         tail_turn_cache = {}
 
-    # The memsearch storage dir holds the memory/ folder and the legacy checkpoint.
-    memsearch_dir = memory_dir.resolve().parent
-
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(memsearch_dir)
+        legacy_after_time = _load_legacy_last_msg_time(memory_dir.resolve().parent)
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -463,7 +463,7 @@ def summarize_with_llm(
     return None
 
 
-def wake_maintenance(project_dir: str, memsearch_dir: str) -> None:
+def wake_maintenance(project_dir: str, memsearch_dir: Path) -> None:
     """Start maintenance in a hook-disabled child environment."""
     runner = Path(__file__).resolve().parent / "maintenance-runner.py"
     subprocess.Popen(
@@ -475,7 +475,7 @@ def wake_maintenance(project_dir: str, memsearch_dir: str) -> None:
             "--project-dir",
             project_dir,
             "--memsearch-dir",
-            memsearch_dir,
+            memsearch_dir.as_posix(),
         ],
         env={**os.environ, "MEMSEARCH_NO_WATCH": "1", "MEMSEARCH_DISABLE": "1"},
         stdin=subprocess.DEVNULL,
@@ -528,9 +528,9 @@ def get_session_ids(conn: sqlite3.Connection, project_dir: str) -> list[str]:
     return [row[0] for row in sessions]
 
 
-def _load_legacy_last_msg_time(memsearch_dir: str) -> int:
+def _load_legacy_last_msg_time(memsearch_dir: Path) -> int:
     """Read the pre-sidecar capture checkpoint for upgrade compatibility."""
-    path = Path(memsearch_dir) / ".last_msg_time"
+    path = memsearch_dir / ".last_msg_time"
     try:
         value = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
@@ -542,21 +542,18 @@ def _make_capture_anchor_key(session_id: str, turn_id: str) -> tuple[str, str]:
     return (session_id, turn_id)
 
 
-def load_capture_anchor_cache(memory_dir: str) -> set[tuple[str, str]]:
-    if not os.path.isdir(memory_dir):
+def load_capture_anchor_cache(memory_dir: Path) -> set[tuple[str, str]]:
+    if not memory_dir.is_dir():
         return set()
 
     anchor_cache: set[tuple[str, str]] = set()
-    for name in os.listdir(memory_dir):
-        if not name.endswith(".md"):
+    for path in memory_dir.iterdir():
+        if not path.name.endswith(".md"):
             continue
-
-        path = os.path.join(memory_dir, name)
         try:
-            text = Path(path).read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8")
         except OSError:
             continue
-
         for session_id, turn_id in _ANCHOR_RE.findall(text):
             anchor_cache.add(_make_capture_anchor_key(session_id, turn_id))
 
@@ -564,28 +561,27 @@ def load_capture_anchor_cache(memory_dir: str) -> set[tuple[str, str]]:
 
 
 def write_capture(
-    memory_dir: str,
+    memory_dir: Path,
     turn_text: str,
     session_id: str,
     turn_id: str,
     db_path: str = "",
     anchor_cache: set[tuple[str, str]] | None = None,
-) -> str:
+) -> Path:
     """Write a captured turn to the daily memory file."""
-    os.makedirs(memory_dir, exist_ok=True)
+    memory_dir.mkdir(parents=True, exist_ok=True)
 
     today = datetime.now().strftime("%Y-%m-%d")
     now = datetime.now().strftime("%H:%M")
-    memory_file = os.path.join(memory_dir, f"{today}.md")
+    memory_file = memory_dir / f"{today}.md"
 
-    if not os.path.exists(memory_file):
-        with open(memory_file, "w", encoding="utf-8") as f:
-            f.write(f"# {today}\n\n## Session {now}\n\n")
+    if not memory_file.exists():
+        memory_file.write_text(f"# {today}\n\n## Session {now}\n\n", encoding="utf-8")
 
     anchor = f"<!-- session:{session_id} turn:{turn_id} db:{db_path} -->\n" if session_id else ""
     entry = f"### {now}\n{anchor}{turn_text}\n\n"
 
-    with open(memory_file, "a", encoding="utf-8") as f:
+    with memory_file.open("a", encoding="utf-8") as f:
         f.write(entry)
 
     if session_id and anchor_cache is not None:
@@ -594,19 +590,17 @@ def write_capture(
     return memory_file
 
 
-def capture_exists(memory_dir: str, session_id: str, turn_id: str) -> bool:
+def capture_exists(memory_dir: Path, session_id: str, turn_id: str) -> bool:
     """Check whether a turn anchor was already written to memory markdown."""
-    if not os.path.isdir(memory_dir):
+    if not memory_dir.is_dir():
         return False
 
     anchor = f"<!-- session:{session_id} turn:{turn_id} "
-    for name in os.listdir(memory_dir):
-        if not name.endswith(".md"):
+    for path in memory_dir.iterdir():
+        if not path.name.endswith(".md"):
             continue
-
-        path = os.path.join(memory_dir, name)
         try:
-            with open(path, encoding="utf-8") as handle:
+            with path.open(encoding="utf-8") as handle:
                 if anchor in handle.read():
                     return True
         except OSError:
@@ -709,7 +703,7 @@ def _turn_ready_for_capture(
 def capture_session_turns(
     conn: sqlite3.Connection,
     turn_db: sqlite3.Connection,
-    memory_dir: str,
+    memory_dir: Path,
     session_id: str,
     small_model: str,
     memsearch_cmd: str,
@@ -725,11 +719,11 @@ def capture_session_turns(
         tail_turn_cache = {}
 
     # The memsearch storage dir holds the memory/ folder and the legacy checkpoint.
-    memsearch_dir = Path(memory_dir).resolve().parent
+    memsearch_dir = memory_dir.resolve().parent
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(memsearch_dir.as_posix())
+        legacy_after_time = _load_legacy_last_msg_time(memsearch_dir)
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None
@@ -797,25 +791,24 @@ def main() -> None:
     parser.add_argument("--parent-pid", type=int, default=0, help="Exit when this parent process is gone")
     args = parser.parse_args()
 
-    db_path = get_db_path()
-    if not os.path.exists(db_path):
-        sys.stderr.write(f"OpenCode database not found at {db_path}\n")
+    _db_path = get_db_path()
+    if not _db_path.exists():
+        sys.stderr.write(f"OpenCode database not found at {_db_path}\n")
         sys.exit(1)
+    db_path = _db_path.as_posix()
 
     # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
     # OpenCode session/config lookups still key off the real project_dir.
-    _memsearch_path = Path(args.memsearch_dir) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
-    memsearch_dir = _memsearch_path.as_posix()
-    memory_dir = (_memsearch_path / "memory").as_posix()
-    pid_file = (_memsearch_path / ".capture.pid").as_posix()
+    memsearch_dir = Path(args.memsearch_dir) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
+    memory_dir = memsearch_dir / "memory"
+    pid_file = memsearch_dir / ".capture.pid"
 
-    _memsearch_path.mkdir(parents=True, exist_ok=True)
-    with open(pid_file, "w", encoding="utf-8") as f:
-        f.write(str(os.getpid()))
+    memsearch_dir.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
     def cleanup(signum=None, frame=None) -> None:
         with contextlib.suppress(OSError):
-            os.remove(pid_file)
+            pid_file.unlink()
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, cleanup)
@@ -851,7 +844,7 @@ def main() -> None:
                 )
 
             if any_new:
-                os.system(f"{args.memsearch_cmd} index '{memory_dir}' --collection {args.collection_name} &")
+                os.system(f"{args.memsearch_cmd} index '{memory_dir.as_posix()}' --collection {args.collection_name} &")
                 wake_maintenance(args.project_dir, memsearch_dir)
         except Exception:
             pass

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -810,7 +810,7 @@ def main() -> None:
 
     # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
     # OpenCode session/config lookups still key off the real project_dir.
-    memsearch_dir = Path(args.memsearch_dir) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
+    memsearch_dir = Path(os.path.abspath(args.memsearch_dir)) if args.memsearch_dir else Path(args.project_dir) / ".memsearch"
     memory_dir = memsearch_dir / "memory"
     # PID file is per-project so each project has its own daemon even when sharing memsearch_dir.
     pid_file = Path(args.project_dir) / ".memsearch" / ".capture.pid"

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -463,10 +463,9 @@ def summarize_with_llm(
     return None
 
 
-def wake_maintenance(project_dir: str, memsearch_dir: str | None = None) -> None:
+def wake_maintenance(project_dir: str, memsearch_dir: str) -> None:
     """Start maintenance in a hook-disabled child environment."""
     runner = Path(__file__).resolve().parent / "maintenance-runner.py"
-    resolved_memsearch_dir = memsearch_dir or os.path.join(project_dir, ".memsearch")
     subprocess.Popen(
         [
             "python3",
@@ -476,7 +475,7 @@ def wake_maintenance(project_dir: str, memsearch_dir: str | None = None) -> None
             "--project-dir",
             project_dir,
             "--memsearch-dir",
-            resolved_memsearch_dir,
+            memsearch_dir,
         ],
         env={**os.environ, "MEMSEARCH_NO_WATCH": "1", "MEMSEARCH_DISABLE": "1"},
         stdin=subprocess.DEVNULL,

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -47,9 +47,12 @@ _TAIL_TURN_QUIET_PERIOD_MS = int(os.environ.get("MEMSEARCH_OPENCODE_TAIL_QUIET_M
 
 
 class TailTurnObservation:
+    """Track when the tail turn of a session last changed content."""
+
     __slots__ = ("fingerprint", "stable_since_ms", "turn_id")
 
     def __init__(self, turn_id: str, fingerprint: str, stable_since_ms: int) -> None:
+        """Initialize with the turn ID, content fingerprint, and observation timestamp."""
         self.turn_id = turn_id
         self.fingerprint = fingerprint
         self.stable_since_ms = stable_since_ms
@@ -137,6 +140,7 @@ def _strip_jsonc(text: str) -> str:
 
 
 def _read_jsonc_config(path: Path) -> dict:
+    """Parse a JSONC file, returning an empty dict on any error."""
     try:
         data = json.loads(_strip_jsonc(path.read_text(encoding="utf-8")))
     except Exception:
@@ -145,6 +149,7 @@ def _read_jsonc_config(path: Path) -> dict:
 
 
 def _deep_merge_config(base: dict, override: dict) -> dict:
+    """Recursively merge override into base, deep-merging nested dicts."""
     result = dict(base)
     for key, value in override.items():
         if isinstance(value, dict) and isinstance(result.get(key), dict):
@@ -155,6 +160,7 @@ def _deep_merge_config(base: dict, override: dict) -> dict:
 
 
 def _rewrite_relative_file_refs(value, config_dir: Path):
+    """Resolve relative {file:...} references in config values to absolute paths."""
     if isinstance(value, dict):
         return {key: _rewrite_relative_file_refs(item, config_dir) for key, item in value.items()}
     if isinstance(value, list):
@@ -163,6 +169,7 @@ def _rewrite_relative_file_refs(value, config_dir: Path):
         return value
 
     def replace(match: re.Match[str]) -> str:
+        """Resolve one {file:...} match to an absolute path."""
         file_ref = match.group(1)
         if file_ref.startswith("~/") or os.path.isabs(file_ref):
             return match.group(0)
@@ -172,6 +179,7 @@ def _rewrite_relative_file_refs(value, config_dir: Path):
 
 
 def _load_opencode_config_file(path: Path) -> dict:
+    """Load a single OpenCode config file and resolve relative file references."""
     cfg = _read_jsonc_config(path)
     if not cfg:
         return {}
@@ -179,6 +187,7 @@ def _load_opencode_config_file(path: Path) -> dict:
 
 
 def _opencode_global_config_dir() -> Path:
+    """Return the OpenCode global config directory, respecting XDG_CONFIG_HOME."""
     xdg_config = os.environ.get("XDG_CONFIG_HOME")
     if xdg_config:
         return Path(xdg_config).expanduser() / "opencode"
@@ -186,10 +195,12 @@ def _opencode_global_config_dir() -> Path:
 
 
 def _env_flag_enabled(name: str) -> bool:
+    """Return True if the named environment variable is set to a truthy value."""
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
 
 
 def _opencode_project_config_files(project_dir: Path) -> list[Path]:
+    """Walk ancestors of project_dir to collect opencode config files (nearest last)."""
     found: list[Path] = []
     current = project_dir.resolve()
     while True:
@@ -205,6 +216,7 @@ def _opencode_project_config_files(project_dir: Path) -> list[Path]:
 
 
 def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
+    """Collect config files from .opencode dirs, home, and OPENCODE_CONFIG_DIR."""
     dirs: list[Path] = []
     if not _env_flag_enabled("OPENCODE_DISABLE_PROJECT_CONFIG"):
         current = project_dir.resolve()
@@ -237,6 +249,7 @@ def _opencode_directory_config_files(project_dir: Path) -> list[Path]:
 
 
 def _iter_opencode_config_files(project_dir: str | os.PathLike[str] | None = None) -> list[Path]:
+    """Return all OpenCode config files in load order (global → env → project → local)."""
     project = Path(project_dir or os.getcwd()).expanduser().resolve()
     files: list[Path] = []
 
@@ -274,6 +287,7 @@ def load_opencode_config(project_dir: str | os.PathLike[str] | None = None) -> d
 
 
 def _read_jsonc_config_from_text(text: str) -> dict:
+    """Parse a JSONC string, returning an empty dict on any error."""
     try:
         data = json.loads(_strip_jsonc(text))
     except Exception:
@@ -282,6 +296,7 @@ def _read_jsonc_config_from_text(text: str) -> dict:
 
 
 def _sanitize_opencode_config(cfg: dict) -> dict:
+    """Strip plugin keys from a config dict to prevent recursion during summarization."""
     sanitized = dict(cfg)
     for key in ("plugin", "plugins", "plugin_origins"):
         sanitized.pop(key, None)
@@ -838,7 +853,11 @@ def main() -> None:
                 )
 
             if any_new:
-                os.system(f"{args.memsearch_cmd} index '{memory_dir.as_posix()}' --collection {args.collection_name} &")
+                subprocess.Popen(
+                    [*split_memsearch_cmd(args.memsearch_cmd), "index", memory_dir.as_posix(), "--collection", args.collection_name],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
                 wake_maintenance(args.project_dir, memsearch_dir)
         except Exception:
             pass

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -78,33 +78,28 @@ class TurnState:
 
 def get_db_path() -> str:
     """Find the OpenCode SQLite database."""
-    default = os.path.expanduser("~/.local/share/opencode/opencode.db")
-    if os.path.exists(default):
-        return default
+    default = Path("~/.local/share/opencode/opencode.db").expanduser()
+    if default.exists():
+        return default.as_posix()
 
     xdg_data = os.environ.get("XDG_DATA_HOME", "")
     if xdg_data:
-        alt = os.path.join(xdg_data, "opencode", "opencode.db")
-        if os.path.exists(alt):
-            return alt
+        alt = Path(xdg_data) / "opencode" / "opencode.db"
+        if alt.exists():
+            return alt.as_posix()
 
-    return default
-
-
-def get_turn_db_path(project_dir: str, memsearch_dir: str | None = None) -> str:
-    """Return the derived turn metadata database path for a project.
-
-    When ``memsearch_dir`` is given (honoring MEMSEARCH_DIR global scope), the
-    sidecar lives there; otherwise it defaults to ``<project_dir>/.memsearch``.
-    """
-    base = memsearch_dir or os.path.join(project_dir, ".memsearch")
-    return os.path.join(base, "opencode-turns.db")
+    return default.as_posix()
 
 
-def open_turn_db(project_dir: str, memsearch_dir: str | None = None) -> sqlite3.Connection:
+def get_turn_db_path(memsearch_dir: str) -> str:
+    """Return the sidecar database path inside the resolved memsearch storage dir."""
+    return (Path(memsearch_dir) / "opencode-turns.db").as_posix()
+
+
+def open_turn_db(memsearch_dir: str) -> sqlite3.Connection:
     """Open the sidecar turn database and ensure its schema exists."""
-    turn_db_path = get_turn_db_path(project_dir, memsearch_dir)
-    Path(turn_db_path).parent.mkdir(parents=True, exist_ok=True)
+    turn_db_path = get_turn_db_path(memsearch_dir)
+    Path(memsearch_dir).mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(turn_db_path, timeout=5)
     conn.row_factory = sqlite3.Row
     ensure_turn_schema(conn)

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -91,14 +91,19 @@ def get_db_path() -> str:
     return default
 
 
-def get_turn_db_path(project_dir: str) -> str:
-    """Return the derived turn metadata database path for a project."""
-    return os.path.join(project_dir, ".memsearch", "opencode-turns.db")
+def get_turn_db_path(project_dir: str, memsearch_dir: str | None = None) -> str:
+    """Return the derived turn metadata database path for a project.
+
+    When ``memsearch_dir`` is given (honoring MEMSEARCH_DIR global scope), the
+    sidecar lives there; otherwise it defaults to ``<project_dir>/.memsearch``.
+    """
+    base = memsearch_dir or os.path.join(project_dir, ".memsearch")
+    return os.path.join(base, "opencode-turns.db")
 
 
-def open_turn_db(project_dir: str) -> sqlite3.Connection:
+def open_turn_db(project_dir: str, memsearch_dir: str | None = None) -> sqlite3.Connection:
     """Open the sidecar turn database and ensure its schema exists."""
-    turn_db_path = get_turn_db_path(project_dir)
+    turn_db_path = get_turn_db_path(project_dir, memsearch_dir)
     Path(turn_db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(turn_db_path, timeout=5)
     conn.row_factory = sqlite3.Row

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -76,30 +76,30 @@ class TurnState:
     last_completed_turn_id: str
 
 
-def get_db_path() -> str:
+def get_db_path() -> Path:
     """Find the OpenCode SQLite database."""
     default = Path("~/.local/share/opencode/opencode.db").expanduser()
     if default.exists():
-        return default.as_posix()
+        return default
 
     xdg_data = os.environ.get("XDG_DATA_HOME", "")
     if xdg_data:
         alt = Path(xdg_data) / "opencode" / "opencode.db"
         if alt.exists():
-            return alt.as_posix()
+            return alt
 
-    return default.as_posix()
+    return default
 
 
-def get_turn_db_path(memsearch_dir: str) -> str:
+def get_turn_db_path(memsearch_dir: Path) -> Path:
     """Return the sidecar database path inside the resolved memsearch storage dir."""
-    return (Path(memsearch_dir) / "opencode-turns.db").as_posix()
+    return memsearch_dir / "opencode-turns.db"
 
 
-def open_turn_db(memsearch_dir: str) -> sqlite3.Connection:
+def open_turn_db(memsearch_dir: Path) -> sqlite3.Connection:
     """Open the sidecar turn database and ensure its schema exists."""
     turn_db_path = get_turn_db_path(memsearch_dir)
-    Path(memsearch_dir).mkdir(parents=True, exist_ok=True)
+    memsearch_dir.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(turn_db_path, timeout=5)
     conn.row_factory = sqlite3.Row
     ensure_turn_schema(conn)

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -144,12 +144,8 @@ def ensure_turn_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS turns_session_index_idx ON turns (session_id, turn_index)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS turns_session_time_idx ON turns (session_id, end_time, turn_id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS turns_session_index_idx ON turns (session_id, turn_index)")
+    conn.execute("CREATE INDEX IF NOT EXISTS turns_session_time_idx ON turns (session_id, end_time, turn_id)")
     conn.commit()
 
 
@@ -165,7 +161,9 @@ def load_turn_state(conn: sqlite3.Connection, session_id: str) -> TurnState:
     ).fetchone()
 
     if row is None:
-        return TurnState(session_id=session_id, last_completed_time=0, last_completed_message_id="", last_completed_turn_id="")
+        return TurnState(
+            session_id=session_id, last_completed_time=0, last_completed_message_id="", last_completed_turn_id=""
+        )
 
     return TurnState(
         session_id=row["session_id"],
@@ -269,9 +267,7 @@ def load_messages(
 
     if after_time is not None:
         if after_message_id:
-            query.append(
-                "AND (time_created > ? OR (time_created = ? AND id > ?))"
-            )
+            query.append("AND (time_created > ? OR (time_created = ? AND id > ?))")
             params.extend([after_time, after_time, after_message_id])
         else:
             query.append("AND time_created > ?")

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -164,12 +164,12 @@ def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeyp
     monkeypatch.setenv("MEMSEARCH_NO_WATCH", "0")
     monkeypatch.delenv("MEMSEARCH_DISABLE", raising=False)
 
-    memsearch_dir = (project / ".memsearch").as_posix()
+    memsearch_dir = project / ".memsearch"
     capture_daemon.wake_maintenance(project.as_posix(), memsearch_dir)
 
     assert captured["cmd"][:4] == ["python3", str(SCRIPT_DIR / "maintenance-runner.py"), "--platform", "opencode"]
     assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == project.as_posix()
-    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == memsearch_dir
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == memsearch_dir.as_posix()
     assert captured["env"]["MEMSEARCH_NO_WATCH"] == "1"
     assert captured["env"]["MEMSEARCH_DISABLE"] == "1"
     assert captured["stdin"] == capture_daemon.subprocess.DEVNULL
@@ -530,7 +530,7 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     turn = OpenCodeTurn(
         session_id="ses_1",
         turn_id="u1",
@@ -559,7 +559,7 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     rows = load_session_turn_rows(turn_db, "ses_1")
     state = load_turn_state(turn_db, "ses_1")
 
-    assert get_turn_db_path((project_dir / ".memsearch").as_posix()).endswith(".memsearch/opencode-turns.db")
+    assert get_turn_db_path(project_dir / ".memsearch") == project_dir / ".memsearch" / "opencode-turns.db"
     assert len(rows) == 1
     assert rows[0]["turn_id"] == "u1"
     assert state.last_completed_turn_id == "u1"
@@ -574,11 +574,12 @@ def test_turn_db_path_honors_explicit_memsearch_dir(tmp_path: Path) -> None:
 
     # With MEMSEARCH_DIR (global scope), the sidecar lives in the shared dir,
     # not under the project directory.
-    path = get_turn_db_path(shared_dir.as_posix())
-    assert path == (shared_dir / "opencode-turns.db").as_posix()
-    assert project_dir.as_posix() not in path
+    path = get_turn_db_path(shared_dir)
+    assert path == shared_dir / "opencode-turns.db"
+    assert shared_dir in path.parents or path.parent == shared_dir
+    assert project_dir not in path.parents
 
-    turn_db = open_turn_db(shared_dir.as_posix())
+    turn_db = open_turn_db(shared_dir)
     try:
         assert (shared_dir / "opencode-turns.db").exists()
         assert not (project_dir / ".memsearch").exists()
@@ -601,7 +602,7 @@ def test_wake_maintenance_passes_explicit_memsearch_dir(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(capture_daemon.subprocess, "Popen", fake_popen)
 
-    capture_daemon.wake_maintenance(project.as_posix(), shared.as_posix())
+    capture_daemon.wake_maintenance(project.as_posix(), shared)
 
     assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == project.as_posix()
     assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == shared.as_posix()
@@ -635,11 +636,11 @@ def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
     _insert_message(conn, "u2", session_id, 300, "user", text="Next question")
     conn.commit()
 
-    turn_db = open_turn_db(shared_memsearch.as_posix())
+    turn_db = open_turn_db(shared_memsearch)
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -674,11 +675,11 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -694,7 +695,7 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -710,7 +711,7 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -752,14 +753,14 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
             raise RuntimeError("simulated crash before cursor persisted")
         return original_save_turn_state(*args, **kwargs)
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     monkeypatch.setattr(capture_daemon, "save_turn_state", flaky_save_turn_state)
 
     with suppress(RuntimeError):
         capture_daemon.capture_session_turns(
             conn,
             turn_db,
-            memory_dir.as_posix(),
+            memory_dir,
             session_id,
             "",
             "memsearch",
@@ -770,7 +771,7 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -809,11 +810,11 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
     conn.commit()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -826,7 +827,7 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -839,7 +840,7 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -874,11 +875,11 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Draft answer")
     conn.commit()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -894,7 +895,7 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -907,7 +908,7 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -920,7 +921,7 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -955,11 +956,11 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -975,7 +976,7 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -1024,11 +1025,11 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
 
     monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -1074,13 +1075,13 @@ def test_capture_session_turns_does_not_advance_sidecar_when_markdown_write_fail
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
     )
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
 
     with suppress(OSError):
         capture_daemon.capture_session_turns(
             conn,
             turn_db,
-            memory_dir.as_posix(),
+            memory_dir,
             session_id,
             "",
             "memsearch",
@@ -1124,11 +1125,11 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
     _insert_message(conn, "u2", session_id, 200, "user", text="Follow-up")
     conn.commit()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",
@@ -1141,11 +1142,11 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
 
     turn_db.close()
 
-    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
+    turn_db = open_turn_db(project_dir / ".memsearch")
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        memory_dir.as_posix(),
+        memory_dir,
         session_id,
         "",
         "memsearch",

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -164,11 +164,11 @@ def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeyp
     monkeypatch.setenv("MEMSEARCH_NO_WATCH", "0")
     monkeypatch.delenv("MEMSEARCH_DISABLE", raising=False)
 
-    memsearch_dir = str(project / ".memsearch")
-    capture_daemon.wake_maintenance(str(project), memsearch_dir)
+    memsearch_dir = (project / ".memsearch").as_posix()
+    capture_daemon.wake_maintenance(project.as_posix(), memsearch_dir)
 
     assert captured["cmd"][:4] == ["python3", str(SCRIPT_DIR / "maintenance-runner.py"), "--platform", "opencode"]
-    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
+    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == project.as_posix()
     assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == memsearch_dir
     assert captured["env"]["MEMSEARCH_NO_WATCH"] == "1"
     assert captured["env"]["MEMSEARCH_DISABLE"] == "1"
@@ -530,7 +530,7 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     turn = OpenCodeTurn(
         session_id="ses_1",
         turn_id="u1",
@@ -559,7 +559,7 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     rows = load_session_turn_rows(turn_db, "ses_1")
     state = load_turn_state(turn_db, "ses_1")
 
-    assert get_turn_db_path(str(project_dir)).endswith(".memsearch/opencode-turns.db")
+    assert get_turn_db_path((project_dir / ".memsearch").as_posix()).endswith(".memsearch/opencode-turns.db")
     assert len(rows) == 1
     assert rows[0]["turn_id"] == "u1"
     assert state.last_completed_turn_id == "u1"
@@ -574,11 +574,11 @@ def test_turn_db_path_honors_explicit_memsearch_dir(tmp_path: Path) -> None:
 
     # With MEMSEARCH_DIR (global scope), the sidecar lives in the shared dir,
     # not under the project directory.
-    path = get_turn_db_path(str(project_dir), str(shared_dir))
-    assert path == str(shared_dir / "opencode-turns.db")
-    assert str(project_dir) not in path
+    path = get_turn_db_path(shared_dir.as_posix())
+    assert path == (shared_dir / "opencode-turns.db").as_posix()
+    assert project_dir.as_posix() not in path
 
-    turn_db = open_turn_db(str(project_dir), str(shared_dir))
+    turn_db = open_turn_db(shared_dir.as_posix())
     try:
         assert (shared_dir / "opencode-turns.db").exists()
         assert not (project_dir / ".memsearch").exists()
@@ -601,10 +601,10 @@ def test_wake_maintenance_passes_explicit_memsearch_dir(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(capture_daemon.subprocess, "Popen", fake_popen)
 
-    capture_daemon.wake_maintenance(str(project), str(shared))
+    capture_daemon.wake_maintenance(project.as_posix(), shared.as_posix())
 
-    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
-    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(shared)
+    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == project.as_posix()
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == shared.as_posix()
 
 
 def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
@@ -635,15 +635,15 @@ def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
     _insert_message(conn, "u2", session_id, 300, "user", text="Next question")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir), str(shared_memsearch))
+    turn_db = open_turn_db(shared_memsearch.as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         None,
         project_dir,
     )
@@ -674,15 +674,15 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -694,11 +694,11 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     rows = load_session_turn_rows(turn_db, session_id)
@@ -710,11 +710,11 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     rows = load_session_turn_rows(turn_db, session_id)
@@ -752,29 +752,29 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
             raise RuntimeError("simulated crash before cursor persisted")
         return original_save_turn_state(*args, **kwargs)
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     monkeypatch.setattr(capture_daemon, "save_turn_state", flaky_save_turn_state)
 
     with suppress(RuntimeError):
         capture_daemon.capture_session_turns(
             conn,
             turn_db,
-            str(memory_dir),
+            memory_dir.as_posix(),
             session_id,
             "",
             "memsearch",
-            str(db_path),
+            db_path.as_posix(),
         )
 
     monkeypatch.setattr(capture_daemon, "save_turn_state", original_save_turn_state)
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     files = sorted(memory_dir.glob("*.md"))
@@ -809,15 +809,15 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -826,11 +826,11 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -839,11 +839,11 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
 
@@ -874,15 +874,15 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Draft answer")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -894,11 +894,11 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -907,11 +907,11 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -920,11 +920,11 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
 
@@ -955,15 +955,15 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
     assert load_session_turn_rows(turn_db, session_id) == []
@@ -975,11 +975,11 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
         tail_cache,
     )
 
@@ -1024,15 +1024,15 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
 
     monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     rows = load_session_turn_rows(turn_db, session_id)
@@ -1074,17 +1074,17 @@ def test_capture_session_turns_does_not_advance_sidecar_when_markdown_write_fail
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
     )
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
 
     with suppress(OSError):
         capture_daemon.capture_session_turns(
             conn,
             turn_db,
-            str(memory_dir),
+            memory_dir.as_posix(),
             session_id,
             "",
             "memsearch",
-            str(db_path),
+            db_path.as_posix(),
         )
 
     state = load_turn_state(turn_db, session_id)
@@ -1124,15 +1124,15 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
     _insert_message(conn, "u2", session_id, 200, "user", text="Follow-up")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     assert summarize_calls["count"] == 1
@@ -1141,15 +1141,15 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
 
     turn_db.close()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db((project_dir / ".memsearch").as_posix())
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
-        str(memory_dir),
+        memory_dir.as_posix(),
         session_id,
         "",
         "memsearch",
-        str(db_path),
+        db_path.as_posix(),
     )
 
     assert summarize_calls["count"] == 1

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -164,11 +164,12 @@ def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeyp
     monkeypatch.setenv("MEMSEARCH_NO_WATCH", "0")
     monkeypatch.delenv("MEMSEARCH_DISABLE", raising=False)
 
-    capture_daemon.wake_maintenance(str(project))
+    memsearch_dir = str(project / ".memsearch")
+    capture_daemon.wake_maintenance(str(project), memsearch_dir)
 
     assert captured["cmd"][:4] == ["python3", str(SCRIPT_DIR / "maintenance-runner.py"), "--platform", "opencode"]
     assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
-    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(project / ".memsearch")
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == memsearch_dir
     assert captured["env"]["MEMSEARCH_NO_WATCH"] == "1"
     assert captured["env"]["MEMSEARCH_DISABLE"] == "1"
     assert captured["stdin"] == capture_daemon.subprocess.DEVNULL
@@ -604,6 +605,54 @@ def test_wake_maintenance_passes_explicit_memsearch_dir(tmp_path: Path, monkeypa
 
     assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
     assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(shared)
+
+
+def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """project_dir kwarg is forwarded to summarize_with_llm (not derived from memory_dir)."""
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_explicit_proj"
+    project_dir = tmp_path / "real-project"
+    shared_memsearch = tmp_path / "shared" / ".memsearch"
+    memory_dir = shared_memsearch / "memory"
+    memory_dir.mkdir(parents=True)
+    project_dir.mkdir()
+
+    received_project_dir: list = []
+
+    def fake_summarize(turn_text, small_model, memsearch_cmd, proj_dir):
+        received_project_dir.append(proj_dir)
+        return None
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", fake_summarize)
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda _: True)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 200, "assistant", parent_id="u1", finish="stop", text="Answer")
+    _insert_message(conn, "u2", session_id, 300, "user", text="Next question")
+    conn.commit()
+
+    turn_db = open_turn_db(str(project_dir), str(shared_memsearch))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        None,
+        project_dir,
+    )
+
+    assert len(received_project_dir) == 1
+    assert received_project_dir[0] == project_dir
+
+    turn_db.close()
+    conn.close()
 
 
 def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -645,7 +645,7 @@ def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
         "",
         "memsearch",
         db_path.as_posix(),
-        None,
+        None,  # tail_turn_cache
         project_dir,
     )
 

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -1034,6 +1034,7 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
         "",
         "memsearch",
         db_path.as_posix(),
+        project_dir=project_dir,
     )
 
     rows = load_session_turn_rows(turn_db, session_id)

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -567,6 +567,45 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     turn_db.close()
 
 
+def test_turn_db_path_honors_explicit_memsearch_dir(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    shared_dir = tmp_path / "shared" / ".memsearch"
+
+    # With MEMSEARCH_DIR (global scope), the sidecar lives in the shared dir,
+    # not under the project directory.
+    path = get_turn_db_path(str(project_dir), str(shared_dir))
+    assert path == str(shared_dir / "opencode-turns.db")
+    assert str(project_dir) not in path
+
+    turn_db = open_turn_db(str(project_dir), str(shared_dir))
+    try:
+        assert (shared_dir / "opencode-turns.db").exists()
+        assert not (project_dir / ".memsearch").exists()
+    finally:
+        turn_db.close()
+
+
+def test_wake_maintenance_passes_explicit_memsearch_dir(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    shared = tmp_path / "shared" / ".memsearch"
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+
+        class Process:
+            pass
+
+        return Process()
+
+    monkeypatch.setattr(capture_daemon.subprocess, "Popen", fake_popen)
+
+    capture_daemon.wake_maintenance(str(project), str(shared))
+
+    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(shared)
+
+
 def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Closes #627

## Summary

- **openclaw**: `getMemsearchDir()` returns `MEMSEARCH_DIR` when set, else `<project_dir>/.memsearch`; `getCollectionScopeDir()` keys collection off `MEMSEARCH_DIR` or `projectDir` (matching `claude-code`/`codex` behavior exactly)
- **opencode**: `resolveScope()` resolves storage dir and collection in one place; capture daemon receives `--memsearch-dir` and forwards it through maintenance/summarize flows; PID file stays per-project so each project gets its own daemon even when sharing `MEMSEARCH_DIR`
- Legacy upgrade checkpoint (`_load_legacy_last_msg_time`) always reads from `project_dir/.memsearch` regardless of `MEMSEARCH_DIR`, preserving compatibility for existing installs

## Test plan

- [ ] `uv run python -m pytest tests/test_opencode_turns.py` — all 24 pass
- [ ] `bun test plugins/opencode/index.test.ts` — resolveScope per-project and shared-scope tests pass
- [ ] Set `MEMSEARCH_DIR=~/.memsearch`, run a claude-code session then an opencode session on the same project — both write to the same memory dir and share the same collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)