### PR TITLE
fix(claude): surface stop-hook index failures

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -123,13 +123,35 @@ ensure_memory_dir() {
 # Collection description (set by session-start.sh, empty by default)
 COLLECTION_DESC=""
 
-# Helper: run memsearch with arguments, silently fail if not available
+# Helper: run memsearch with arguments. If memsearch is available, preserve its
+# stderr and exit status so callers can report failures instead of hiding them.
 run_memsearch() {
   if [ -n "$MEMSEARCH_CMD" ] && [ -n "$COLLECTION_NAME" ]; then
-    $MEMSEARCH_CMD "$@" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
+    $MEMSEARCH_CMD "$@" --collection "$COLLECTION_NAME" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"}
   elif [ -n "$MEMSEARCH_CMD" ]; then
-    $MEMSEARCH_CMD "$@" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} 2>/dev/null || true
+    $MEMSEARCH_CMD "$@" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"}
   fi
+}
+
+# Print the first zero-byte parquet segment in a local Milvus Lite directory.
+# Remote Milvus URIs do not expose local segment files and are skipped.
+find_zero_byte_segment() {
+  local milvus_uri="${1:-}"
+  case "$milvus_uri" in
+    ""|http://*|https://*|tcp://*) return 1 ;;
+  esac
+
+  local resolved_uri
+  resolved_uri=$(python3 - "$milvus_uri" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).expanduser())
+PY
+  ) || return 1
+
+  [ -d "$resolved_uri" ] || return 1
+  find "$resolved_uri" -type f -name '*.parquet' -size 0 -print -quit 2>/dev/null
 }
 
 run_maintenance() {

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -175,6 +175,35 @@ fi
 kill_orphaned_index
 
 # Index immediately — don't rely on watch (which may be killed by SessionEnd before debounce fires)
-run_memsearch index "$MEMORY_DIR"
+INDEX_MILVUS_URI=""
+if [ -n "$MEMSEARCH_CMD" ]; then
+  INDEX_MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || true)
+fi
+
+INDEX_OUTPUT=""
+INDEX_STATUS=0
+INDEX_OUTPUT=$(run_memsearch index "$MEMORY_DIR" 2>&1) || INDEX_STATUS=$?
+
+# A successful command is not sufficient evidence that the local Lite store is
+# healthy. Detect a truncated segment created by this or an overlapping index.
+ZERO_BYTE_SEGMENT=$(find_zero_byte_segment "$INDEX_MILVUS_URI" || true)
+
+if [ "$INDEX_STATUS" -ne 0 ] || [ -n "$ZERO_BYTE_SEGMENT" ]; then
+  INDEX_MESSAGE="[memsearch] Stop-hook indexing failed. Markdown memory was saved, but search may be stale."
+  if [ "$INDEX_STATUS" -ne 0 ]; then
+    INDEX_MESSAGE+=" Index exited with status $INDEX_STATUS."
+    INDEX_DETAIL=$(printf '%s\n' "$INDEX_OUTPUT" | sed '/^[[:space:]]*$/d' | tail -n 1 | cut -c1-500)
+    if [ -n "$INDEX_DETAIL" ]; then
+      INDEX_MESSAGE+=" $INDEX_DETAIL"
+    fi
+  fi
+  if [ -n "$ZERO_BYTE_SEGMENT" ]; then
+    INDEX_MESSAGE+=" Zero-byte Milvus segment detected: $ZERO_BYTE_SEGMENT."
+  fi
+  INDEX_MESSAGE+=" Repair or rebuild the derived index before relying on memory search."
+  JSON_INDEX_MESSAGE=$(_json_encode_str "$INDEX_MESSAGE")
+  echo "{\"systemMessage\": $JSON_INDEX_MESSAGE}"
+  exit 0
+fi
 
 echo '{}'

--- a/tests/test_claude_stop_hook_index_failures.py
+++ b/tests/test_claude_stop_hook_index_failures.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_stop_hook(
+    tmp_path: Path,
+    *,
+    index_status: int,
+    create_zero_segment: bool,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    plugin_root = Path("plugins/claude-code").resolve()
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    milvus_uri = home / ".memsearch" / "milvus.db"
+    zero_segment = milvus_uri / "data" / "insert_log" / "zero.parquet"
+    transcript = tmp_path / "session-123.jsonl"
+    home.mkdir()
+    fake_bin.mkdir()
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "system", "message": {"content": "start"}}),
+                json.dumps({"type": "user", "uuid": "turn-1", "message": {"content": "Remember this"}}),
+                json.dumps({"type": "assistant", "message": {"content": "I recorded the result."}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    milvus.uri) echo "$FAKE_MILVUS_URI" ;;
+    plugins.claude-code.summarize.enabled) echo "true" ;;
+    plugins.claude-code.summarize.model) echo "" ;;
+    plugins.claude-code.summarize.provider) echo "" ;;
+    prompts.summarize) echo "" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "index" ]; then
+  if [ "$FAKE_CREATE_ZERO_SEGMENT" = "1" ]; then
+    mkdir -p "$(dirname "$FAKE_ZERO_SEGMENT")"
+    : > "$FAKE_ZERO_SEGMENT"
+  fi
+  if [ "$FAKE_INDEX_STATUS" -ne 0 ]; then
+    echo "simulated index failure" >&2
+  fi
+  exit "$FAKE_INDEX_STATUS"
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+
+    fake_claude = fake_bin / "claude"
+    fake_claude.write_text(
+        """#!/usr/bin/env bash
+if [ "${1:-}" = "--help" ]; then
+  echo "Usage: claude"
+  exit 0
+fi
+echo "- User asked Claude Code to remember a result."
+""",
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+        "FAKE_MILVUS_URI": "~/.memsearch/milvus.db",
+        "FAKE_ZERO_SEGMENT": str(zero_segment),
+        "FAKE_CREATE_ZERO_SEGMENT": "1" if create_zero_segment else "0",
+        "FAKE_INDEX_STATUS": str(index_status),
+    }
+    result = subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return result, zero_segment
+
+
+def test_claude_stop_hook_reports_index_exit_and_zero_byte_segment(tmp_path: Path) -> None:
+    result, zero_segment = _run_stop_hook(tmp_path, index_status=23, create_zero_segment=True)
+
+    payload = json.loads(result.stdout)
+    message = payload["systemMessage"]
+
+    assert "Index exited with status 23" in message
+    assert "simulated index failure" in message
+    assert f"Zero-byte Milvus segment detected: {zero_segment}" in message
+    assert result.stderr == ""
+    assert list((tmp_path / ".memsearch" / "memory").glob("*.md"))
+
+
+def test_claude_stop_hook_checks_zero_byte_segments_after_successful_index(tmp_path: Path) -> None:
+    result, zero_segment = _run_stop_hook(tmp_path, index_status=0, create_zero_segment=True)
+
+    payload = json.loads(result.stdout)
+    message = payload["systemMessage"]
+
+    assert "Index exited with status" not in message
+    assert f"Zero-byte Milvus segment detected: {zero_segment}" in message


### PR DESCRIPTION
## Problem

The Claude Code `Stop` hook indexes the memory store on every turn, but failures are invisible:

- `plugins/claude-code/hooks/common.sh` runs the index with `2>/dev/null || true`, discarding stderr and converting any non-zero exit into success.
- The hook runs asynchronously, and async hook output is suppressed by default, so even a surfaced error would not reach the user.

The practical consequence: a local Milvus Lite store can take a zero-byte parquet segment and stop indexing entirely, while memory files keep being written, with **no user-visible signal**. In one real case this went unnoticed for 13 days. Related report: #629.

## Change

`plugins/claude-code/hooks/common.sh` and `stop.sh`:

- Preserve the index command's **stderr and exit status** instead of discarding them.
- After indexing, detect **zero-byte parquet segments** in a local Milvus Lite store — this fires even when the index command exits `0`, which is the exact silent-corruption case.
- Emit an async-visible `systemMessage` reporting the index status and the zero-byte segment path, so the failure surfaces to the user. The Stop process still exits `0` after emitting structured JSON (Claude only processes structured hook output on success); the original index status is propagated into the message.

`tests/test_claude_stop_hook_index_failures.py`: exercises the full Claude Stop path, including a **successful** index (`status 0`) that nevertheless leaves a zero-byte segment — proving the post-index guard is independent of the CLI exit status.

## Scope

This surfaces and diagnoses the failure. It is **detection, not a root-cause fix** for the per-turn Lite reindexing behavior discussed in #629 — hence this references that issue rather than closing it. The zero-byte-segment check alone would have caught the referenced 13-day outage on day one.

No behavior change on the success path beyond the added post-index integrity check; no new dependencies.
