### PR TITLE
fix: lowercase booleans in `config get` output so hook gates match

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1048,7 +1048,9 @@ def config_get(key: str) -> None:
     """Get a resolved config value (e.g. memsearch config get milvus.uri)."""
     try:
         val = get_config_value(key)
-        click.echo(val)
+        # Lowercase booleans so shell consumers (e.g. hooks comparing against
+        # "false") don't trip over Python's "True"/"False" repr.
+        click.echo(str(val).lower() if isinstance(val, bool) else val)
     except KeyError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -115,3 +115,13 @@ def test_config_init_project_writes_only_allowlisted_keys(monkeypatch) -> None:
         "chunking": {"max_chunk_size": 2048, "overlap_lines": 4},
         "watch": {"debounce_ms": 300},
     }
+
+
+def test_config_get_prints_lowercase_booleans(monkeypatch) -> None:
+    monkeypatch.setattr(cli_module, "get_config_value", lambda _key: False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "get", "plugins.claude-code.summarize.enabled"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "false"


### PR DESCRIPTION
Fixes #633.

## Problem

`memsearch config get` echoes the raw Python value, so booleans print as `False`/`True` (capitalized). The claude-code and codex stop hooks gate on:

```bash
SUMMARIZE_ENABLED=$($MEMSEARCH_CMD config get plugins.claude-code.summarize.enabled 2>/dev/null || echo "true")
if [ "$SUMMARIZE_ENABLED" = "false" ]; then
```

`"False" != "false"`, so `summarize.enabled = false` is silently ignored and the hooks keep summarizing + indexing every turn.

## Fix

One line in `config_get`: normalize booleans to lowercase at the output boundary. This fixes both hooks (and any other shell consumer) without touching the shell scripts:

```python
click.echo(str(val).lower() if isinstance(val, bool) else val)
```

## Verification

- New regression test `test_config_get_prints_lowercase_booleans` (CliRunner, asserts `false` output).
- End-to-end with an isolated `$HOME`: `config set ...summarize.enabled false` → `config get` now prints `false`, which matches the hook comparison.
- `tests/test_cli_config_helpers.py` passes; the full-suite failures on my machine are identical on clean `main` (env-dependent `test_skills` etc.) and unrelated to this change.