### PR TITLE
fix: record index health state

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -115,6 +115,37 @@ _json_encode_str() {
   return 0
 }
 
+# Return a concise user-facing warning when the persisted index state says
+# search may be stale. Detailed diagnosis stays in the memory-config skill.
+index_state_warning() {
+  local state_path="$MEMSEARCH_DIR/.index-state.json"
+  [ -f "$state_path" ] || return 0
+  python3 - "$state_path" <<'PY' 2>/dev/null || true
+import json
+import sys
+from datetime import datetime, timezone
+
+try:
+    state = json.loads(open(sys.argv[1], encoding="utf-8").read())
+except Exception:
+    raise SystemExit(0)
+
+status = state.get("status")
+if status in {"error", "degraded"}:
+    print("WARNING: memory index may be stale; run the memory-config skill to diagnose")
+    raise SystemExit(0)
+
+if status == "running":
+    raw_started = state.get("last_started_at")
+    try:
+        started = datetime.fromisoformat(str(raw_started).replace("Z", "+00:00"))
+    except Exception:
+        raise SystemExit(0)
+    if datetime.now(timezone.utc).timestamp() - started.timestamp() > 3600:
+        print("WARNING: memory index has been running for over 1h; run the memory-config skill to diagnose")
+PY
+}
+
 # Helper: ensure memory directory exists
 ensure_memory_dir() {
   mkdir -p "$MEMORY_DIR"

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -101,6 +101,11 @@ status="[memsearch${VERSION_TAG}] embedding: ${PROVIDER}/${MODEL:-unknown} | mil
 if [ "$KEY_MISSING" = true ]; then
   status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
   status+=" | Tip: switch to free local embedding: memsearch config set embedding.provider onnx && memsearch index --force"
+else
+  INDEX_WARNING=$(index_state_warning || true)
+  if [ -n "$INDEX_WARNING" ]; then
+    status+=" | ${INDEX_WARNING}"
+  fi
 fi
 
 # Build collection description: "<project_basename> | <provider>/<model>"

--- a/plugins/claude-code/skills/memory-config/SKILL.md
+++ b/plugins/claude-code/skills/memory-config/SKILL.md
@@ -95,6 +95,8 @@ Check index health:
 
 ```bash
 memsearch stats
+STATE_DIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"
+test -f "$STATE_DIR/.index-state.json" && cat "$STATE_DIR/.index-state.json"
 ```
 
 ## Background and Compatibility
@@ -207,6 +209,11 @@ Model guidance:
 - If quality matters more than cost for maintenance, set `plugins.claude-code.project_review.model` and `plugins.claude-code.user_profile.model` explicitly.
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+If indexing seems silent or search looks stale, check `.memsearch/.index-state.json`
+for `status`, `last_error`, and `failed_files`. `status: degraded` means the
+scan completed but one or more files failed; `status: error` means the index run
+did not complete.
 
 If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -72,6 +72,37 @@ _json_encode_str() {
   return 0
 }
 
+# Return a concise user-facing warning when the persisted index state says
+# search may be stale. Detailed diagnosis stays in the memory-config skill.
+index_state_warning() {
+  local state_path="$MEMSEARCH_DIR/.index-state.json"
+  [ -f "$state_path" ] || return 0
+  python3 - "$state_path" <<'PY' 2>/dev/null || true
+import json
+import sys
+from datetime import datetime, timezone
+
+try:
+    state = json.loads(open(sys.argv[1], encoding="utf-8").read())
+except Exception:
+    raise SystemExit(0)
+
+status = state.get("status")
+if status in {"error", "degraded"}:
+    print("WARNING: memory index may be stale; run the memory-config skill to diagnose")
+    raise SystemExit(0)
+
+if status == "running":
+    raw_started = state.get("last_started_at")
+    try:
+        started = datetime.fromisoformat(str(raw_started).replace("Z", "+00:00"))
+    except Exception:
+        raise SystemExit(0)
+    if datetime.now(timezone.utc).timestamp() - started.timestamp() > 3600:
+        print("WARNING: memory index has been running for over 1h; run the memory-config skill to diagnose")
+PY
+}
+
 # --- Project directory ---
 #
 # Prefer the git root so hooks and the memory-recall skill converge on the

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -96,6 +96,11 @@ status="[memsearch${VERSION_TAG}] embedding: ${PROVIDER}/${MODEL:-unknown} | mil
 if [ "$KEY_MISSING" = true ]; then
   status+=" | ERROR: ${REQUIRED_KEY} not set — memory search disabled"
   status+=" | Tip: switch to free local embedding: memsearch config set embedding.provider onnx && memsearch index --force"
+else
+  INDEX_WARNING=$(index_state_warning || true)
+  if [ -n "$INDEX_WARNING" ]; then
+    status+=" | ${INDEX_WARNING}"
+  fi
 fi
 
 # Build collection description: "<project_basename> | <provider>/<model>"

--- a/plugins/codex/skills/memory-config/SKILL.md
+++ b/plugins/codex/skills/memory-config/SKILL.md
@@ -93,6 +93,8 @@ Check index health:
 
 ```bash
 memsearch stats
+STATE_DIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"
+test -f "$STATE_DIR/.index-state.json" && cat "$STATE_DIR/.index-state.json"
 ```
 
 ## Background and Compatibility
@@ -205,6 +207,11 @@ Model guidance:
 - If quality matters more than cost for maintenance, set `plugins.codex.project_review.model` and `plugins.codex.user_profile.model` explicitly.
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+If indexing seems silent or search looks stale, check `.memsearch/.index-state.json`
+for `status`, `last_error`, and `failed_files`. `status: degraded` means the
+scan completed but one or more files failed; `status: error` means the index run
+did not complete.
 
 If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and

--- a/plugins/openclaw/skills/memory-config/SKILL.md
+++ b/plugins/openclaw/skills/memory-config/SKILL.md
@@ -93,6 +93,8 @@ Check index health:
 
 ```bash
 memsearch stats
+STATE_DIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"
+test -f "$STATE_DIR/.index-state.json" && cat "$STATE_DIR/.index-state.json"
 ```
 
 ## Background and Compatibility
@@ -205,6 +207,11 @@ Model guidance:
 - If quality matters more than cost for maintenance, set `plugins.openclaw.project_review.model` and `plugins.openclaw.user_profile.model` explicitly.
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+If indexing seems silent or search looks stale, check `.memsearch/.index-state.json`
+for `status`, `last_error`, and `failed_files`. `status: degraded` means the
+scan completed but one or more files failed; `status: error` means the index run
+did not complete.
 
 If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and

--- a/plugins/opencode/skills/memory-config/SKILL.md
+++ b/plugins/opencode/skills/memory-config/SKILL.md
@@ -93,6 +93,8 @@ Check index health:
 
 ```bash
 memsearch stats
+STATE_DIR="${MEMSEARCH_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.memsearch}"
+test -f "$STATE_DIR/.index-state.json" && cat "$STATE_DIR/.index-state.json"
 ```
 
 OpenCode transcript recall reads from OpenCode's SQLite database, while captured MemSearch memory lives as markdown under `.memsearch/memory/`.
@@ -207,6 +209,11 @@ Model guidance:
 - If quality matters more than cost for maintenance, set `plugins.opencode.project_review.model` and `plugins.opencode.user_profile.model` explicitly.
 
 Advanced maintenance runs after the plugin wakes it, only when enabled, journal input changed, and `min_interval_hours` elapsed. `PROJECT.md` and `USER.md` are maintenance artifacts by default and are not automatically indexed.
+
+If indexing seems silent or search looks stale, check `.memsearch/.index-state.json`
+for `status`, `last_error`, and `failed_files`. `status: degraded` means the
+scan completed but one or more files failed; `status: error` means the index run
+did not complete.
 
 If advanced maintenance or `memory_to_skill` seems silent, check
 `.memsearch/.maintenance-state.json` for `<plugin>.<task>.last_error` and

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -21,6 +21,13 @@ from .config import (
     save_config,
     set_config_value,
 )
+from .index_report import IndexFailure, format_error
+from .index_state import (
+    record_index_error,
+    record_index_report,
+    record_index_started,
+    resolve_index_state_path,
+)
 from .io import read_utf8_text_replace
 
 try:
@@ -193,6 +200,7 @@ def index(
     """Index markdown files from PATHS."""
     from .core import MemSearch
 
+    state_path = resolve_index_state_path(paths)
     cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
@@ -208,12 +216,45 @@ def index(
     )
     ms = None
     try:
+        record_index_started(
+            state_path,
+            operation="index",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
         ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
-        n = _run(ms.index(force=force))
-        click.echo(f"Indexed {n} chunks.")
+        report = _run(ms.index_with_report(force=force))
+        record_index_report(
+            state_path,
+            report,
+            operation="index",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
+        click.echo(f"Indexed {report.indexed_chunks} chunks.")
     except MilvusException as e:
+        record_index_error(
+            state_path,
+            e,
+            operation="index",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
         click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
+    except Exception as e:
+        record_index_error(
+            state_path,
+            e,
+            operation="index",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
+        raise
     finally:
         if ms is not None:
             ms.close()
@@ -495,6 +536,7 @@ def watch(
     """Watch PATHS for markdown changes and auto-index."""
     from .core import MemSearch
 
+    state_path = resolve_index_state_path(paths)
     cfg = _safe_resolve_config(
         _build_cli_overrides(
             provider=provider,
@@ -512,18 +554,45 @@ def watch(
     ms = None
     watcher = None
     try:
+        record_index_started(
+            state_path,
+            operation="watch",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
         ms = MemSearch(list(paths), **_cfg_to_memsearch_kwargs(cfg), description=description or "")
 
         # Initial index: ensure existing files are indexed before watching
-        n = _run(ms.index())
-        if n:
-            click.echo(f"Indexed {n} chunks.")
+        report = _run(ms.index_with_report())
+        record_index_report(
+            state_path,
+            report,
+            operation="watch",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
+        if report.indexed_chunks:
+            click.echo(f"Indexed {report.indexed_chunks} chunks.")
 
         def _on_event(event_type: str, summary: str, file_path) -> None:
             click.echo(summary)
 
+        def _on_error(event_type: str, error: BaseException, file_path) -> None:
+            record_index_error(
+                state_path,
+                error,
+                operation=f"watch:{event_type}",
+                paths=(str(file_path),),
+                collection=cfg.milvus.collection,
+                milvus_uri=cfg.milvus.uri,
+                status="degraded",
+                failed_files=(IndexFailure(path=str(file_path), error=format_error(error)),),
+            )
+
         click.echo(f"Watching {len(paths)} path(s) for changes... (Ctrl+C to stop)")
-        watcher = ms.watch(on_event=_on_event, debounce_ms=cfg.watch.debounce_ms)
+        watcher = ms.watch(on_event=_on_event, on_error=_on_error, debounce_ms=cfg.watch.debounce_ms)
         while True:
             import time
 
@@ -531,8 +600,26 @@ def watch(
     except KeyboardInterrupt:
         click.echo("\nStopping watcher.")
     except MilvusException as e:
+        record_index_error(
+            state_path,
+            e,
+            operation="watch",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
         click.echo(f"Milvus error (code {e.code}): {e.message}", err=True)
         raise SystemExit(1) from None
+    except Exception as e:
+        record_index_error(
+            state_path,
+            e,
+            operation="watch",
+            paths=paths,
+            collection=cfg.milvus.collection,
+            milvus_uri=cfg.milvus.uri,
+        )
+        raise
     finally:
         if watcher is not None:
             watcher.stop()

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 from .chunker import Chunk, chunk_markdown, clean_content_for_embedding, compute_chunk_id
 from .compact import compact_chunks
 from .embeddings import EmbeddingProvider, get_provider
+from .index_report import IndexFailure, IndexReport, format_error
 from .io import read_utf8_text_replace
 from .scanner import ScannedFile, scan_paths
 from .store import MilvusStore
@@ -91,17 +92,22 @@ class MemSearch:
         Returns the number of chunks indexed.  Also removes chunks for
         files that no longer exist on disk (deleted-file cleanup).
         """
+        report = await self.index_with_report(force=force)
+        return report.indexed_chunks
+
+    async def index_with_report(self, *, force: bool = False) -> IndexReport:
+        """Scan paths and index all markdown files with structured status."""
         files = scan_paths(self._paths)
         total = 0
-        failed = 0
+        failed_files: list[IndexFailure] = []
         active_sources: set[str] = set()
         for f in files:
             active_sources.add(str(f.path))
             try:
                 n = await self._index_file(f, force=force)
                 total += n
-            except Exception:
-                failed += 1
+            except Exception as exc:
+                failed_files.append(IndexFailure(path=str(f.path), error=format_error(exc)))
                 logger.exception("Failed to index %s, skipping", f.path)
 
         # Clean up deleted files only inside directory roots from this run.
@@ -115,11 +121,21 @@ class MemSearch:
                     self._store.delete_by_source(source)
                     logger.info("Removed stale chunks for deleted file: %s", source)
 
-        if failed:
-            logger.warning("Indexed %d chunks from %d files (%d files failed)", total, len(files) - failed, failed)
+        if failed_files:
+            logger.warning(
+                "Indexed %d chunks from %d files (%d files failed)",
+                total,
+                len(files) - len(failed_files),
+                len(failed_files),
+            )
         else:
             logger.info("Indexed %d chunks from %d files", total, len(files))
-        return total
+        return IndexReport(
+            indexed_chunks=total,
+            total_files=len(files),
+            indexed_files=len(files) - len(failed_files),
+            failed_files=tuple(failed_files),
+        )
 
     async def index_file(self, path: str | Path) -> int:
         """Index a single file.  Returns number of chunks."""
@@ -313,6 +329,7 @@ class MemSearch:
         self,
         *,
         on_event: Callable[[str, str, Path], None] | None = None,
+        on_error: Callable[[str, BaseException, Path], None] | None = None,
         debounce_ms: int | None = None,
     ) -> FileWatcher:
         """Watch configured paths for markdown changes and auto-index.
@@ -327,6 +344,9 @@ class MemSearch:
             Optional callback invoked *after* each event is processed.
             Signature: ``(event_type, action_summary, file_path)``.
             ``event_type`` is ``"created"``, ``"modified"``, or ``"deleted"``.
+        on_error:
+            Optional callback invoked after an event fails. The watcher keeps
+            running after the callback.
 
         Returns
         -------
@@ -367,11 +387,13 @@ class MemSearch:
                 logger.info(summary)
                 if on_event is not None:
                     on_event(event_type, summary, file_path)
-            except Exception:
+            except Exception as exc:
                 # Watch is a long-running daemon callback — swallow any failure
                 # (network blips, provider 500s, malformed embeddings, disk
                 # errors, etc.) so a single bad file cannot crash the watcher.
                 logger.exception("Failed to process %s event for %s", event_type, file_path)
+                if on_error is not None:
+                    on_error(event_type, exc, file_path)
 
         fw_kwargs: dict[str, Any] = {}
         if debounce_ms is not None:

--- a/src/memsearch/index_report.py
+++ b/src/memsearch/index_report.py
@@ -1,0 +1,39 @@
+"""Structured index results shared by core and diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IndexFailure:
+    """A per-file indexing failure captured during a best-effort scan."""
+
+    path: str
+    error: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"path": self.path, "error": self.error}
+
+
+@dataclass(frozen=True)
+class IndexReport:
+    """Structured result for a completed indexing pass."""
+
+    indexed_chunks: int
+    total_files: int
+    indexed_files: int
+    failed_files: tuple[IndexFailure, ...] = ()
+
+    @property
+    def status(self) -> str:
+        return "degraded" if self.failed_files else "ok"
+
+
+def format_error(error: BaseException, limit: int = 2000) -> str:
+    """Return a compact, JSON-safe error string for diagnostics."""
+    message = f"{type(error).__name__}: {error}"
+    suffix = "... [truncated]"
+    if len(message) > limit:
+        return message[: limit - len(suffix)] + suffix
+    return message

--- a/src/memsearch/index_state.py
+++ b/src/memsearch/index_state.py
@@ -1,0 +1,210 @@
+"""Index health state used by CLI and plugin diagnostics."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .index_report import IndexFailure, IndexReport, format_error
+
+INDEX_STATE_FILENAME = ".index-state.json"
+INDEX_STATE_SCHEMA_VERSION = 1
+
+
+def resolve_index_state_path(
+    paths: list[str | Path] | tuple[str | Path, ...],
+    *,
+    memsearch_dir: str | Path | None = None,
+    cwd: str | Path | None = None,
+) -> Path | None:
+    """Resolve the state file for an index command.
+
+    Plugin calls usually index ``<root>/.memsearch/memory``.  The hook-local
+    ``MEMSEARCH_DIR`` shell variable is not always exported to the child CLI, so
+    this helper can infer the state root from any path containing ``.memsearch``.
+    For arbitrary user paths outside a MemSearch tree, no state file is written.
+    """
+    explicit_dir = memsearch_dir or os.environ.get("MEMSEARCH_DIR")
+    if explicit_dir:
+        return Path(explicit_dir).expanduser().resolve() / INDEX_STATE_FILENAME
+
+    base = Path(cwd).expanduser().resolve() if cwd is not None else Path.cwd()
+    for raw_path in paths:
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            path = base / path
+        resolved = path.resolve(strict=False)
+        parts = resolved.parts
+        for idx, part in enumerate(parts):
+            if part == ".memsearch":
+                return Path(*parts[: idx + 1]) / INDEX_STATE_FILENAME
+
+    return None
+
+
+def load_index_state(state_path: Path | None) -> dict[str, Any]:
+    """Load an index state file, returning an empty dict if unavailable."""
+    if state_path is None or not state_path.is_file():
+        return {}
+    with contextlib.suppress(json.JSONDecodeError, OSError):
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    return {}
+
+
+def record_index_started(
+    state_path: Path | None,
+    *,
+    operation: str,
+    paths: list[str | Path] | tuple[str | Path, ...],
+    collection: str,
+    milvus_uri: str,
+) -> None:
+    """Persist that an indexing operation has started."""
+    if state_path is None:
+        return
+
+    previous = load_index_state(state_path)
+    now = _now()
+    state = _base_state(
+        status="running",
+        operation=operation,
+        paths=paths,
+        collection=collection,
+        milvus_uri=milvus_uri,
+        previous=previous,
+        now=now,
+    )
+    state["last_started_at"] = now
+    _try_save_index_state(state_path, state)
+
+
+def record_index_report(
+    state_path: Path | None,
+    report: IndexReport,
+    *,
+    operation: str,
+    paths: list[str | Path] | tuple[str | Path, ...],
+    collection: str,
+    milvus_uri: str,
+) -> None:
+    """Persist a completed indexing report."""
+    if state_path is None:
+        return
+
+    previous = load_index_state(state_path)
+    now = _now()
+    state = _base_state(
+        status=report.status,
+        operation=operation,
+        paths=paths,
+        collection=collection,
+        milvus_uri=milvus_uri,
+        previous=previous,
+        now=now,
+    )
+    state.update(
+        {
+            "last_started_at": previous.get("last_started_at", now),
+            "last_completed_at": now,
+            "indexed_chunks": report.indexed_chunks,
+            "total_files": report.total_files,
+            "indexed_files": report.indexed_files,
+            "failed_files": [failure.to_dict() for failure in report.failed_files],
+        }
+    )
+
+    if report.status == "ok":
+        state["last_success_at"] = now
+    else:
+        state["last_failed_at"] = now
+        state["last_error"] = f"{len(report.failed_files)} file(s) failed during indexing."
+
+    _try_save_index_state(state_path, state)
+
+
+def record_index_error(
+    state_path: Path | None,
+    error: BaseException,
+    *,
+    operation: str,
+    paths: list[str | Path] | tuple[str | Path, ...],
+    collection: str,
+    milvus_uri: str,
+    status: str = "error",
+    failed_files: list[IndexFailure] | tuple[IndexFailure, ...] = (),
+) -> None:
+    """Persist a failed indexing operation."""
+    if state_path is None:
+        return
+
+    previous = load_index_state(state_path)
+    now = _now()
+    state = _base_state(
+        status=status,
+        operation=operation,
+        paths=paths,
+        collection=collection,
+        milvus_uri=milvus_uri,
+        previous=previous,
+        now=now,
+    )
+    state.update(
+        {
+            "last_started_at": previous.get("last_started_at", now),
+            "last_completed_at": now,
+            "last_failed_at": now,
+            "last_error": format_error(error),
+            "failed_files": [failure.to_dict() for failure in failed_files],
+        }
+    )
+    _try_save_index_state(state_path, state)
+
+
+def _base_state(
+    *,
+    status: str,
+    operation: str,
+    paths: list[str | Path] | tuple[str | Path, ...],
+    collection: str,
+    milvus_uri: str,
+    previous: dict[str, Any],
+    now: str,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "schema_version": INDEX_STATE_SCHEMA_VERSION,
+        "status": status,
+        "operation": operation,
+        "updated_at": now,
+        "paths": [str(path) for path in paths],
+        "collection": collection,
+        "milvus_uri": milvus_uri,
+    }
+    if previous.get("last_success_at"):
+        state["last_success_at"] = previous["last_success_at"]
+    return state
+
+
+def _save_index_state(state_path: Path, state: dict[str, Any]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = state_path.with_name(f"{state_path.name}.{os.getpid()}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp_path.replace(state_path)
+    finally:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+
+
+def _try_save_index_state(state_path: Path, state: dict[str, Any]) -> None:
+    with contextlib.suppress(OSError):
+        _save_index_state(state_path, state)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -208,6 +208,79 @@ def test_session_start_recent_memory_selects_daily_journals() -> None:
         assert "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md" in source
 
 
+def test_session_start_warns_when_index_state_is_unhealthy(tmp_path: Path) -> None:
+    for name, script in (
+        ("claude", Path("plugins/claude-code/hooks/session-start.sh")),
+        ("codex", Path("plugins/codex/hooks/session-start.sh")),
+    ):
+        project = tmp_path / name
+        home = project / "home"
+        fake_bin = project / "bin"
+        memsearch_dir = project / ".memsearch"
+        home.mkdir(parents=True)
+        fake_bin.mkdir()
+        memsearch_dir.mkdir()
+        (memsearch_dir / ".index-state.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "error",
+                    "last_error": "RuntimeError: store unavailable",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        fake_memsearch = fake_bin / "memsearch"
+        fake_memsearch.write_text(
+            """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    embedding.model) echo "" ;;
+    milvus.uri) echo "http://localhost:19530" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.14"
+  exit 0
+fi
+exit 0
+""",
+            encoding="utf-8",
+        )
+        fake_memsearch.chmod(0o755)
+
+        fake_curl = fake_bin / "curl"
+        fake_curl.write_text("""#!/usr/bin/env bash\necho '{"info":{"version":"0.4.14"}}'\n""", encoding="utf-8")
+        fake_curl.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "CLAUDE_PROJECT_DIR": str(project),
+            "MEMSEARCH_PROJECT_DIR": str(project),
+            "MEMSEARCH_DIR": str(memsearch_dir),
+            "MEMSEARCH_NO_WATCH": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", str(script)],
+            input=json.dumps({"cwd": str(project)}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+
+        status = json.loads(result.stdout)["systemMessage"]
+        assert "WARNING: memory index may be stale" in status
+        assert "memory-config skill" in status
+
+
 def test_claude_stop_hook_writes_summary_without_safe_mode_flag(tmp_path: Path) -> None:
     script = Path("plugins/claude-code/hooks/stop.sh")
     plugin_root = Path("plugins/claude-code").resolve()

--- a/tests/test_index_cleanup.py
+++ b/tests/test_index_cleanup.py
@@ -145,3 +145,30 @@ async def test_directory_cleanup_uses_path_boundaries_not_string_prefixes(tmp_pa
     assert str(doc) in store.indexed_sources()
     assert str(similar_prefix_doc) in store.indexed_sources()
     assert store.deleted_sources == []
+
+
+@pytest.mark.asyncio
+async def test_index_with_report_captures_file_failures(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    good = write_note(docs / "good.md", "# Good\n\nalpha\n")
+    bad = write_note(docs / "bad.md", "# Bad\n\nbravo\n")
+
+    ms, store = make_memsearch([docs])
+    original_index_file = ms._index_file
+
+    async def fail_bad_file(f, *, force=False):
+        if f.path == bad:
+            raise RuntimeError("embedding provider failed")
+        return await original_index_file(f, force=force)
+
+    ms._index_file = fail_bad_file
+
+    report = await ms.index_with_report()
+
+    assert report.status == "degraded"
+    assert report.total_files == 2
+    assert report.indexed_files == 1
+    assert len(report.failed_files) == 1
+    assert report.failed_files[0].path == str(bad)
+    assert "RuntimeError: embedding provider failed" in report.failed_files[0].error
+    assert str(good) in store.indexed_sources()

--- a/tests/test_index_state.py
+++ b/tests/test_index_state.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memsearch import cli as cli_module
+from memsearch import core as core_module
+from memsearch import index_state as index_state_module
+from memsearch.cli import cli
+from memsearch.config import MemSearchConfig
+from memsearch.index_report import IndexFailure, IndexReport
+from memsearch.index_state import (
+    load_index_state,
+    record_index_error,
+    record_index_report,
+    record_index_started,
+    resolve_index_state_path,
+)
+
+
+def test_resolve_index_state_path_uses_explicit_memsearch_dir(tmp_path: Path) -> None:
+    state_path = resolve_index_state_path([tmp_path / "docs"], memsearch_dir=tmp_path / ".memsearch")
+
+    assert state_path == (tmp_path / ".memsearch" / ".index-state.json").resolve()
+
+
+def test_resolve_index_state_path_infers_memsearch_root(tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+
+    state_path = resolve_index_state_path([memory_dir / "2026-07-20.md"])
+
+    assert state_path == tmp_path / ".memsearch" / ".index-state.json"
+
+
+def test_resolve_index_state_path_skips_arbitrary_paths(tmp_path: Path) -> None:
+    state_path = resolve_index_state_path([tmp_path / "docs"])
+
+    assert state_path is None
+
+
+def test_index_state_success_clears_previous_error(tmp_path: Path) -> None:
+    state_path = tmp_path / ".memsearch" / ".index-state.json"
+    paths = [tmp_path / ".memsearch" / "memory"]
+
+    record_index_started(state_path, operation="index", paths=paths, collection="c", milvus_uri="lite.db")
+    record_index_error(
+        state_path,
+        RuntimeError("provider timeout"),
+        operation="index",
+        paths=paths,
+        collection="c",
+        milvus_uri="lite.db",
+    )
+    record_index_report(
+        state_path,
+        IndexReport(indexed_chunks=3, total_files=1, indexed_files=1),
+        operation="index",
+        paths=paths,
+        collection="c",
+        milvus_uri="lite.db",
+    )
+
+    state = load_index_state(state_path)
+    assert state["status"] == "ok"
+    assert state["indexed_chunks"] == 3
+    assert state["last_success_at"]
+    assert "last_error" not in state
+    assert state["failed_files"] == []
+
+
+def test_index_state_degraded_preserves_previous_success(tmp_path: Path) -> None:
+    state_path = tmp_path / ".memsearch" / ".index-state.json"
+    paths = [tmp_path / ".memsearch" / "memory"]
+
+    record_index_report(
+        state_path,
+        IndexReport(indexed_chunks=3, total_files=1, indexed_files=1),
+        operation="index",
+        paths=paths,
+        collection="c",
+        milvus_uri="lite.db",
+    )
+    success_at = load_index_state(state_path)["last_success_at"]
+    record_index_report(
+        state_path,
+        IndexReport(
+            indexed_chunks=2,
+            total_files=2,
+            indexed_files=1,
+            failed_files=(IndexFailure(path="bad.md", error="RuntimeError: broken"),),
+        ),
+        operation="index",
+        paths=paths,
+        collection="c",
+        milvus_uri="lite.db",
+    )
+
+    state = load_index_state(state_path)
+    assert state["status"] == "degraded"
+    assert state["last_success_at"] == success_at
+    assert state["last_failed_at"]
+    assert state["failed_files"] == [{"path": "bad.md", "error": "RuntimeError: broken"}]
+
+
+def test_index_state_write_failures_are_best_effort(monkeypatch, tmp_path: Path) -> None:
+    def fail_save(_state_path, _state):
+        raise OSError("read-only state directory")
+
+    monkeypatch.setattr(index_state_module, "_save_index_state", fail_save)
+
+    record_index_started(
+        tmp_path / ".memsearch" / ".index-state.json",
+        operation="index",
+        paths=[tmp_path / ".memsearch" / "memory"],
+        collection="c",
+        milvus_uri="lite.db",
+    )
+
+
+def test_cli_index_records_ok_state(monkeypatch, tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+
+    class FakeMemSearch:
+        def __init__(self, paths, **kwargs):
+            assert paths == [str(memory_dir)]
+            assert kwargs["collection"] == "memsearch_chunks"
+
+        async def index_with_report(self, *, force=False):
+            assert force is False
+            return IndexReport(indexed_chunks=7, total_files=2, indexed_files=2)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda _overrides=None: MemSearchConfig())
+    monkeypatch.setattr(core_module, "MemSearch", FakeMemSearch)
+
+    result = CliRunner().invoke(cli, ["index", str(memory_dir)])
+
+    assert result.exit_code == 0
+    assert "Indexed 7 chunks." in result.output
+    state = json.loads((tmp_path / ".memsearch" / ".index-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "ok"
+    assert state["indexed_chunks"] == 7
+    assert state["total_files"] == 2
+
+
+def test_cli_index_records_degraded_state(monkeypatch, tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+
+    class FakeMemSearch:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def index_with_report(self, *, force=False):
+            return IndexReport(
+                indexed_chunks=2,
+                total_files=2,
+                indexed_files=1,
+                failed_files=(IndexFailure(path=str(memory_dir / "bad.md"), error="RuntimeError: failed"),),
+            )
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda _overrides=None: MemSearchConfig())
+    monkeypatch.setattr(core_module, "MemSearch", FakeMemSearch)
+
+    result = CliRunner().invoke(cli, ["index", str(memory_dir)])
+
+    assert result.exit_code == 0
+    state = json.loads((tmp_path / ".memsearch" / ".index-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "degraded"
+    assert state["last_failed_at"]
+    assert state["failed_files"][0]["path"] == str(memory_dir / "bad.md")
+
+
+def test_cli_index_records_error_state(monkeypatch, tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+
+    class FakeMemSearch:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def index_with_report(self, *, force=False):
+            raise RuntimeError("store unavailable")
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda _overrides=None: MemSearchConfig())
+    monkeypatch.setattr(core_module, "MemSearch", FakeMemSearch)
+
+    result = CliRunner().invoke(cli, ["index", str(memory_dir)])
+
+    assert result.exit_code != 0
+    state = json.loads((tmp_path / ".memsearch" / ".index-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "error"
+    assert "RuntimeError: store unavailable" in state["last_error"]
+
+
+def test_cli_watch_records_event_error_state(monkeypatch, tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".memsearch" / "memory"
+    memory_dir.mkdir(parents=True)
+    changed_file = memory_dir / "2026-07-20.md"
+
+    class FakeWatcher:
+        def stop(self) -> None:
+            pass
+
+    class FakeMemSearch:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def index_with_report(self, *, force=False):
+            return IndexReport(indexed_chunks=1, total_files=1, indexed_files=1)
+
+        def watch(self, *, on_event=None, on_error=None, debounce_ms=None):
+            assert debounce_ms == 1500
+            on_error("modified", RuntimeError("event failed"), changed_file)
+            return FakeWatcher()
+
+        def close(self) -> None:
+            pass
+
+    def stop_loop(_seconds: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_module, "resolve_config", lambda _overrides=None: MemSearchConfig())
+    monkeypatch.setattr(core_module, "MemSearch", FakeMemSearch)
+    monkeypatch.setattr(time, "sleep", stop_loop)
+
+    result = CliRunner().invoke(cli, ["watch", str(memory_dir)])
+
+    assert result.exit_code == 0
+    state = json.loads((tmp_path / ".memsearch" / ".index-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "degraded"
+    assert state["operation"] == "watch:modified"
+    assert state["failed_files"] == [
+        {"path": str(changed_file), "error": "RuntimeError: event failed"},
+    ]


### PR DESCRIPTION
## Summary
- add structured index reports and persisted `.memsearch/.index-state.json` snapshots for `index` and `watch`
- record full failures as `error` and per-file failures as `degraded` while preserving successful indexing work
- surface concise stale-index warnings in startup status where supported, and document the state file in `memory-config`

## Tests
- `git diff --check`
- `uv run ruff check src tests`
- shell hook syntax checks
- `uv run python -m pytest`
- plugin package test suite
- local all-plugin capture/index E2E with isolated projects and Milvus Lite
