### PR TITLE
feat: surface pending skill candidates

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -146,6 +146,11 @@ if status == "running":
 PY
 }
 
+skill_candidate_hint() {
+  [ -n "$MEMSEARCH_CMD" ] || return 0
+  MEMSEARCH_DIR="$MEMSEARCH_DIR" $MEMSEARCH_CMD skills status --hint 2>/dev/null || true
+}
+
 # Helper: ensure memory directory exists
 ensure_memory_dir() {
   mkdir -p "$MEMORY_DIR"

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -107,6 +107,10 @@ else
     status+=" | ${INDEX_WARNING}"
   fi
 fi
+SKILL_HINT=$(skill_candidate_hint || true)
+if [ -n "$SKILL_HINT" ]; then
+  status+=" | ${SKILL_HINT}"
+fi
 
 # Build collection description: "<project_basename> | <provider>/<model>"
 PROJECT_BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-.}")

--- a/plugins/claude-code/skills/memory-to-skill/SKILL.md
+++ b/plugins/claude-code/skills/memory-to-skill/SKILL.md
@@ -49,9 +49,15 @@ captured automatically going forward) — do not force it.
 ## B. Review & install candidates (1→2)
 
 ```bash
+memsearch skills status          # pending candidate versions needing install
 memsearch skills list            # add -j for sources / installed paths
 git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
+
+`skills status` compares each candidate's current `SKILL.md` content hash with
+the hash recorded by the last `skills install`. It does not inspect live agent
+skill directories. A pending installed skill means the candidate source evolved
+after the last deliberate install; reinstall only after reviewing the candidate.
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 When showing candidates, mention the store's recent git history when it helps

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -103,6 +103,11 @@ if status == "running":
 PY
 }
 
+skill_candidate_hint() {
+  memsearch_available || return 0
+  MEMSEARCH_DIR="$MEMSEARCH_DIR" "${MEMSEARCH_CMD[@]}" skills status --hint 2>/dev/null || true
+}
+
 # --- Project directory ---
 #
 # Prefer the git root so hooks and the memory-recall skill converge on the

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -102,6 +102,10 @@ else
     status+=" | ${INDEX_WARNING}"
   fi
 fi
+SKILL_HINT=$(skill_candidate_hint || true)
+if [ -n "$SKILL_HINT" ]; then
+  status+=" | ${SKILL_HINT}"
+fi
 
 # Build collection description: "<project_basename> | <provider>/<model>"
 PROJECT_BASENAME=$(basename "$PROJECT_DIR")

--- a/plugins/codex/skills/memory-to-skill/SKILL.md
+++ b/plugins/codex/skills/memory-to-skill/SKILL.md
@@ -47,9 +47,15 @@ captured automatically going forward) — do not force it.
 ## B. Review & install candidates (1→2)
 
 ```bash
+memsearch skills status          # pending candidate versions needing install
 memsearch skills list            # add -j for sources / installed paths
 git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
+
+`skills status` compares each candidate's current `SKILL.md` content hash with
+the hash recorded by the last `skills install`. It does not inspect live agent
+skill directories. A pending installed skill means the candidate source evolved
+after the last deliberate install; reinstall only after reviewing the candidate.
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 When showing candidates, mention the store's recent git history when it helps

--- a/plugins/openclaw/index.js
+++ b/plugins/openclaw/index.js
@@ -221,6 +221,23 @@ var index_default = {
       );
       return r.stdout?.trim() || "";
     }
+    async function getSkillCandidateHint() {
+      try {
+        const cmd = await getMemsearchCmd();
+        const r = await runCmd(
+          [
+            "bash",
+            "-c",
+            `MEMSEARCH_DIR='${shellEscape(memsearchDir)}' ${cmd} skills status --hint`
+          ],
+          { timeoutMs: 5e3 }
+        );
+        if (r.code !== 0) return "";
+        return r.stdout?.trim().split("\n")[0] || "";
+      } catch {
+        return "";
+      }
+    }
     async function wakeMaintenance() {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
@@ -408,8 +425,10 @@ var index_default = {
       api.on("before_agent_start", async () => {
         try {
           const context = getRecentMemories(memoryDir);
-          if (context) {
-            return { prependContext: context };
+          const skillHint = await getSkillCandidateHint();
+          const blocks = [context, skillHint].filter(Boolean);
+          if (blocks.length > 0) {
+            return { prependContext: blocks.join("\n\n") };
           }
         } catch (e) {
           logger?.warn?.(

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -337,6 +337,23 @@ export default {
       return r.stdout?.trim() || "";
     }
 
+    async function getSkillCandidateHint(): Promise<string> {
+      try {
+        const cmd = await getMemsearchCmd();
+        const r = await runCmd(
+          [
+            "bash", "-c",
+            `MEMSEARCH_DIR='${shellEscape(memsearchDir)}' ${cmd} skills status --hint`,
+          ],
+          { timeoutMs: 5000 }
+        );
+        if (r.code !== 0) return "";
+        return r.stdout?.trim().split("\n")[0] || "";
+      } catch {
+        return "";
+      }
+    }
+
     async function wakeMaintenance(): Promise<void> {
       try {
         const runner = join(PLUGIN_DIR, "scripts", "maintenance-runner.py");
@@ -572,8 +589,10 @@ export default {
       api.on("before_agent_start", async () => {
         try {
           const context = getRecentMemories(memoryDir);
-          if (context) {
-            return { prependContext: context };
+          const skillHint = await getSkillCandidateHint();
+          const blocks = [context, skillHint].filter(Boolean);
+          if (blocks.length > 0) {
+            return { prependContext: blocks.join("\n\n") };
           }
         } catch (e: any) {
           logger?.warn?.(

--- a/plugins/openclaw/skills/memory-to-skill/SKILL.md
+++ b/plugins/openclaw/skills/memory-to-skill/SKILL.md
@@ -47,9 +47,15 @@ captured automatically going forward) — do not force it.
 ## B. Review & install candidates (1→2)
 
 ```bash
+memsearch skills status          # pending candidate versions needing install
 memsearch skills list            # add -j for sources / installed paths
 git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
+
+`skills status` compares each candidate's current `SKILL.md` content hash with
+the hash recorded by the last `skills install`. It does not inspect live agent
+skill directories. A pending installed skill means the candidate source evolved
+after the last deliberate install; reinstall only after reviewing the candidate.
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 When showing candidates, mention the store's recent git history when it helps

--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  getSkillCandidateHint,
   getRecentMemories,
   isDailyJournalFile,
   mergeSystemMemoryContext,
@@ -85,5 +86,32 @@ test("recent memories only use dated daily journals", () => {
     assert.doesNotMatch(context, /Scratch content/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("skill candidate hint comes from memsearch status", () => {
+  const root = mkdtempSync(join(tmpdir(), "memsearch-opencode-skills-"));
+  try {
+    const bin = join(root, "bin");
+    const memsearchDir = join(root, ".memsearch");
+    mkdirSync(bin);
+    mkdirSync(memsearchDir);
+    const fakeMemsearch = join(bin, "memsearch");
+    writeFileSync(
+      fakeMemsearch,
+      "#!/usr/bin/env bash\n" +
+        "test \"$MEMSEARCH_DIR\" = \"$1\" && shift\n" +
+        "if [ \"$1\" = \"skills\" ] && [ \"$2\" = \"status\" ] && [ \"$3\" = \"--hint\" ]; then\n" +
+        "  echo 'SKILLS: 1 candidate skill version(s) pending install - run the memory-to-skill skill to review and install.'\n" +
+        "fi\n",
+      "utf-8"
+    );
+    chmodSync(fakeMemsearch, 0o755);
+
+    const hint = getSkillCandidateHint(memsearchDir, `${fakeMemsearch} '${memsearchDir}'`);
+
+    assert.match(hint, /SKILLS: 1 candidate skill version/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -150,6 +150,23 @@ function shellEscape(s: string): string {
   return s.replace(/'/g, "'\\''");
 }
 
+export function getSkillCandidateHint(memsearchDir: string, memsearchCmd: string): string {
+  try {
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `MEMSEARCH_DIR='${shellEscape(memsearchDir)}' ${memsearchCmd} skills status --hint`,
+      ],
+      { encoding: "utf-8", timeout: 5000 }
+    );
+    if (result.status !== 0) return "";
+    return (result.stdout || "").trim().split("\n")[0] || "";
+  } catch {
+    return "";
+  }
+}
+
 /** Marks the start of memsearch's injected block within a system message. */
 export const MEMSEARCH_SYSTEM_MARKER = "[memsearch] Memory available.";
 
@@ -277,6 +294,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
   const collectionName = deriveCollectionName(projectDir);
   const memsearchDir = join(projectDir, ".memsearch");
   const memoryDir = join(memsearchDir, "memory");
+  const skillCandidateHint = getSkillCandidateHint(memsearchDir, memsearchCmd);
   const home = process.env.HOME || "~";
 
   // Skip capture/recall in child processes to prevent recursion
@@ -433,10 +451,12 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
           "experimental.chat.system.transform": async (_input: any, output: any) => {
             try {
               const context = getRecentMemories(memoryDir);
-              if (context) {
+              if (context || skillCandidateHint) {
                 const memoryText =
                   `${MEMSEARCH_SYSTEM_MARKER} You have access to memory_search, ` +
-                  `memory_get, and memory_transcript tools for recalling past sessions.\n\n${context}`;
+                  `memory_get, and memory_transcript tools for recalling past sessions.` +
+                  `${skillCandidateHint ? `\n${skillCandidateHint}` : ""}` +
+                  `${context ? `\n\n${context}` : ""}`;
                 output.system = mergeSystemMemoryContext(output.system, memoryText);
               }
             } catch { /* ignore */ }

--- a/plugins/opencode/skills/memory-to-skill/SKILL.md
+++ b/plugins/opencode/skills/memory-to-skill/SKILL.md
@@ -47,9 +47,15 @@ captured automatically going forward) — do not force it.
 ## B. Review & install candidates (1→2)
 
 ```bash
+memsearch skills status          # pending candidate versions needing install
 memsearch skills list            # add -j for sources / installed paths
 git -C .memsearch/skill-candidates log --oneline -5 2>/dev/null || true
 ```
+
+`skills status` compares each candidate's current `SKILL.md` content hash with
+the hash recorded by the last `skills install`. It does not inspect live agent
+skill directories. A pending installed skill means the candidate source evolved
+after the last deliberate install; reinstall only after reviewing the candidate.
 
 Before recommending or installing, skim the candidate's body: if a step looks uncertain or loosely summarized, re-check it against the source (open the transcript if needed) or flag it to the user and let them decide — installing copies the candidate as-is, so this is the last chance to catch a wrong step.
 When showing candidates, mention the store's recent git history when it helps

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1251,9 +1251,40 @@ def skills_list(json_output: bool) -> None:
     for meta in candidates:
         occ = meta.get("occurrences")
         occ_text = f", seen {occ}x" if isinstance(occ, int) else ""
+        pending_reason = meta.get("pending_reason")
+        pending_text = ""
+        if pending_reason == "new":
+            pending_text = ", install ready"
+        elif pending_reason == "updated":
+            pending_text = ", update ready"
         click.echo(
-            f"- {meta.get('name')} [{meta.get('status', 'candidate')}{occ_text}] — {meta.get('description', '')}"
+            f"- {meta.get('name')} [{meta.get('status', 'candidate')}{occ_text}{pending_text}] "
+            f"- {meta.get('description', '')}"
         )
+
+
+@skills_group.command("status")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+@click.option("--hint", is_flag=True, help="Print only the startup hint when candidate skill versions are pending.")
+def skills_status(json_output: bool, hint: bool) -> None:
+    """Show whether candidate skills need review and installation."""
+    from . import skills as skills_mod
+
+    _project_root, mem_root = skills_mod.resolve_roots(None, None)
+    summary = skills_mod.candidate_review_summary(mem_root)
+    if json_output:
+        click.echo(json.dumps(summary, indent=2, ensure_ascii=False))
+        return
+    if hint:
+        rendered = skills_mod.format_candidate_hint(summary)
+        if rendered:
+            click.echo(rendered)
+        return
+    if summary["pending_count"] == 0:
+        click.echo("No candidate skill versions pending install.")
+        return
+    click.echo(skills_mod.format_candidate_hint(summary))
+    click.echo(f"New: {summary['new_count']}; updated: {summary['updated_count']}.")
 
 
 @skills_group.command("install")

--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -24,6 +24,7 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from hashlib import sha1
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -48,6 +49,7 @@ MAX_EXISTING_BODY_CHARS = 2000
 
 TASK = "memory_to_skill"
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
+_GIT_BLOB_HASH_PREFIX = "gitblob:"
 
 
 @dataclass
@@ -245,6 +247,47 @@ def _git_commit(root: Path, message: str) -> None:
     _git(root, "commit", "-q", "-m", message)
 
 
+def _git_blob_hash(content: str | bytes) -> str:
+    """Return Git's SHA-1 blob hash for content.
+
+    The candidate store is a Git repo, but this local calculation lets us hash
+    a rendered SKILL.md before it is committed and without shelling out.
+    """
+    data = content.encode("utf-8") if isinstance(content, str) else content
+    header = f"blob {len(data)}\0".encode()
+    return f"{_GIT_BLOB_HASH_PREFIX}{sha1(header + data).hexdigest()}"
+
+
+def _skill_file_hash(path: Path) -> str:
+    try:
+        return _git_blob_hash(path.read_bytes())
+    except OSError:
+        return ""
+
+
+def _pending_reason(meta: dict[str, Any], content_hash: str) -> str:
+    installed_hash = str(meta.get("installed_hash") or "")
+    if not content_hash or installed_hash == content_hash:
+        return ""
+    if installed_hash or meta.get("status") == "installed" or meta.get("installed_paths"):
+        return "updated"
+    return "new"
+
+
+def _enrich_candidate_meta(skill_dir: Path, meta: dict[str, Any]) -> dict[str, Any]:
+    enriched = dict(meta)
+    content_hash = _skill_file_hash(skill_dir / "SKILL.md")
+    if content_hash:
+        enriched["content_hash"] = content_hash
+    reason = _pending_reason(enriched, content_hash)
+    enriched["pending_install"] = bool(reason)
+    if reason:
+        enriched["pending_reason"] = reason
+    else:
+        enriched.pop("pending_reason", None)
+    return enriched
+
+
 def list_candidates(mem_root: Path) -> list[dict[str, Any]]:
     """Return metadata for every skill in the candidate store."""
     root = skills_root(mem_root)
@@ -259,8 +302,35 @@ def list_candidates(mem_root: Path) -> list[dict[str, Any]]:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
-        out.append(meta)
+        out.append(_enrich_candidate_meta(child, meta))
     return out
+
+
+def candidate_review_summary(mem_root: Path) -> dict[str, Any]:
+    """Return a lightweight summary of candidate skills needing install."""
+    candidates = list_candidates(mem_root)
+    pending = [meta for meta in candidates if meta.get("pending_install")]
+    new_count = sum(1 for meta in pending if meta.get("pending_reason") == "new")
+    updated_count = sum(1 for meta in pending if meta.get("pending_reason") == "updated")
+    return {
+        "root": str(skills_root(mem_root)),
+        "candidate_count": len(candidates),
+        "pending_count": len(pending),
+        "new_count": new_count,
+        "updated_count": updated_count,
+        "pending_names": [str(meta.get("name", "")) for meta in pending if meta.get("name")],
+    }
+
+
+def format_candidate_hint(summary: dict[str, Any]) -> str:
+    """Render the short startup hint for pending candidate skill versions."""
+    pending_count = int(summary.get("pending_count") or 0)
+    if pending_count <= 0:
+        return ""
+    return (
+        f"SKILLS: {pending_count} candidate skill version(s) pending install - "
+        "run the memory-to-skill skill to review and install."
+    )
 
 
 def _write_candidate(root: Path, skill: dict[str, Any]) -> str:
@@ -284,24 +354,26 @@ def _write_candidate(root: Path, skill: dict[str, Any]) -> str:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             meta = {}
+        skill_md = _render_skill_md(name, skill["description"], skill["body"])
         meta["sources"] = sorted(set(meta.get("sources", [])) | set(sources))
         if isinstance(skill.get("occurrences"), int):
             meta["occurrences"] = max(int(meta.get("occurrences", 0) or 0), skill["occurrences"])
         meta["description"] = skill["description"]
+        meta["content_hash"] = _git_blob_hash(skill_md)
         meta["updated_at"] = _now()
-        (skill_dir / "SKILL.md").write_text(
-            _render_skill_md(name, skill["description"], skill["body"]), encoding="utf-8"
-        )
+        (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
         meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         return "updated"
 
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(_render_skill_md(name, skill["description"], skill["body"]), encoding="utf-8")
+    skill_md = _render_skill_md(name, skill["description"], skill["body"])
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
     now = _now()
     meta = {
         "name": name,
         "status": "candidate",
         "description": skill["description"],
+        "content_hash": _git_blob_hash(skill_md),
         "occurrences": skill.get("occurrences"),
         "sources": sources,
         "reason": skill.get("reason", ""),
@@ -492,9 +564,14 @@ def install(
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             meta = {}
+        content_hash = _git_blob_hash(skill_md)
         meta["status"] = "installed"
+        meta["content_hash"] = content_hash
+        meta["installed_hash"] = content_hash
         meta["installed_paths"] = sorted(set(meta.get("installed_paths", [])) | set(installed))
-        meta["updated_at"] = _now()
+        now = _now()
+        meta["installed_at"] = now
+        meta["updated_at"] = now
         meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         _git_commit(root, f"install: {skill_dir.name} -> {len(installed)} path(s)")
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -281,6 +281,73 @@ exit 0
         assert "memory-config skill" in status
 
 
+def test_session_start_shows_skill_candidate_hint(tmp_path: Path) -> None:
+    hint = "SKILLS: 2 candidate skill version(s) pending install - run the memory-to-skill skill to review and install."
+    for name, script in (
+        ("claude", Path("plugins/claude-code/hooks/session-start.sh")),
+        ("codex", Path("plugins/codex/hooks/session-start.sh")),
+    ):
+        project = tmp_path / name
+        home = project / "home"
+        fake_bin = project / "bin"
+        memsearch_dir = project / ".memsearch"
+        home.mkdir(parents=True)
+        fake_bin.mkdir()
+        memsearch_dir.mkdir()
+
+        fake_memsearch = fake_bin / "memsearch"
+        fake_memsearch.write_text(
+            f"""#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    embedding.model) echo "" ;;
+    milvus.uri) echo "http://localhost:19530" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "skills" ] && [ "$2" = "status" ] && [ "$3" = "--hint" ]; then
+  echo "{hint}"
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.14"
+  exit 0
+fi
+exit 0
+""",
+            encoding="utf-8",
+        )
+        fake_memsearch.chmod(0o755)
+
+        fake_curl = fake_bin / "curl"
+        fake_curl.write_text("""#!/usr/bin/env bash\necho '{"info":{"version":"0.4.14"}}'\n""", encoding="utf-8")
+        fake_curl.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "CLAUDE_PROJECT_DIR": str(project),
+            "MEMSEARCH_PROJECT_DIR": str(project),
+            "MEMSEARCH_DIR": str(memsearch_dir),
+            "MEMSEARCH_NO_WATCH": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", str(script)],
+            input=json.dumps({"cwd": str(project)}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+
+        status = json.loads(result.stdout)["systemMessage"]
+        assert hint in status
+
+
 def test_claude_stop_hook_writes_summary_without_safe_mode_flag(tmp_path: Path) -> None:
     script = Path("plugins/claude-code/hooks/stop.sh")
     plugin_root = Path("plugins/claude-code").resolve()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -61,7 +61,11 @@ def test_distill_creates_candidate_and_commits(tmp_path: Path) -> None:
 
     meta = json.loads((skill_dir / "meta.json").read_text(encoding="utf-8"))
     assert meta["status"] == "candidate"
+    assert meta["content_hash"].startswith("gitblob:")
     assert meta["occurrences"] == 3
+    listed = skills_mod.list_candidates(project / ".memsearch")
+    assert listed[0]["pending_install"] is True
+    assert listed[0]["pending_reason"] == "new"
 
     # The store is a git repo with at least one commit.
     git_dir = project / ".memsearch" / "skill-candidates" / ".git"
@@ -162,7 +166,12 @@ def test_install_copies_to_paths_and_updates_meta(tmp_path: Path) -> None:
     meta_path = project / ".memsearch" / "skill-candidates" / "run-tests" / "meta.json"
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
     assert meta["status"] == "installed"
+    assert meta["content_hash"].startswith("gitblob:")
+    assert meta["installed_hash"] == meta["content_hash"]
+    assert meta["installed_at"]
     assert meta["installed_paths"] == installed
+    listed = skills_mod.list_candidates(project / ".memsearch")
+    assert listed[0]["pending_install"] is False
 
 
 def test_install_missing_candidate_raises(tmp_path: Path) -> None:
@@ -260,6 +269,92 @@ def test_installed_skill_source_keeps_evolving(tmp_path: Path) -> None:
     assert "pytest -x --ff" in source  # source evolved
     installed_copy = (project / ".claude" / "skills" / "run-tests" / "SKILL.md").read_text(encoding="utf-8")
     assert "pytest -x --ff" not in installed_copy  # snapshot unchanged until re-install
+    listed = skills_mod.list_candidates(project / ".memsearch")
+    assert listed[0]["pending_install"] is True
+    assert listed[0]["pending_reason"] == "updated"
+    assert listed[0]["installed_hash"] != listed[0]["content_hash"]
+
+
+def test_candidate_review_summary_counts_pending_versions(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    _seed_memory(project)
+    cfg = MemSearchConfig()
+    _enable(cfg)
+
+    skills_mod.distill(
+        platform="claude-code",
+        project_dir=project,
+        cfg=cfg,
+        llm_runner=_body_runner("## v1\n\n1. pytest", name="installed-skill"),
+    )
+    skills_mod.install("installed-skill", [str(project / ".claude" / "skills")], project_dir=project)
+    skills_mod.distill(
+        platform="claude-code",
+        project_dir=project,
+        cfg=cfg,
+        force=True,
+        llm_runner=_body_runner("## v2\n\n1. pytest -x --ff", name="installed-skill"),
+    )
+    skills_mod.add(
+        "New Flow",
+        "Capture a new flow. Use when asked to capture this flow.",
+        "## New flow\n\n1. Do the thing",
+        project_dir=project,
+    )
+
+    summary = skills_mod.candidate_review_summary(project / ".memsearch")
+
+    assert summary["candidate_count"] == 2
+    assert summary["pending_count"] == 2
+    assert summary["new_count"] == 1
+    assert summary["updated_count"] == 1
+    assert summary["pending_names"] == ["installed-skill", "new-flow"]
+    assert skills_mod.format_candidate_hint(summary).startswith("SKILLS: 2 candidate skill version(s) pending install")
+
+
+def test_installed_candidate_with_legacy_meta_is_pending(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    skill_dir = project / ".memsearch" / "skill-candidates" / "legacy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: legacy\n---\n\n## Legacy\n", encoding="utf-8")
+    (skill_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "name": "legacy",
+                "status": "installed",
+                "description": "Legacy installed skill.",
+                "installed_paths": [str(project / ".agents" / "skills" / "legacy" / "SKILL.md")],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    listed = skills_mod.list_candidates(project / ".memsearch")
+
+    assert listed[0]["content_hash"].startswith("gitblob:")
+    assert listed[0]["pending_install"] is True
+    assert listed[0]["pending_reason"] == "updated"
+
+
+def test_cli_skills_status_outputs_hint(tmp_path: Path, monkeypatch) -> None:
+    from click.testing import CliRunner
+
+    from memsearch.cli import cli
+
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    skills_mod.add(
+        "Review Me",
+        "Review this candidate. Use when testing skill status.",
+        "## Review\n\n1. Check it",
+        project_dir=project,
+    )
+
+    result = CliRunner().invoke(cli, ["skills", "status", "--hint"])
+
+    assert result.exit_code == 0
+    assert "SKILLS: 1 candidate skill version(s) pending install" in result.output
 
 
 def test_load_template_respects_custom_prompt(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- track candidate skill content hashes and installed hashes
- add a skills status command for pending candidate versions
- surface pending skill hints in Claude Code, Codex, OpenCode, and OpenClaw startup context

## Tests
- uv run ruff check src tests
- uv run python -m pytest tests/test_skills.py tests/test_claude_hooks.py
- npm test (plugins/opencode)
- bash -n plugin hook scripts
- node --check plugins/openclaw/index.ts plugins/openclaw/index.js
- CLI skill status state-machine smoke test