### PR TITLE
fix: strict upsert accounting and opt-in end-of-index flush

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,6 +266,7 @@ provider = "openai"
 | `milvus.uri` | string | `~/.memsearch/milvus.db` | Milvus connection URI |
 | `milvus.token` | string | `""` | Auth token for Milvus Server / Zilliz Cloud |
 | `milvus.collection` | string | `memsearch_chunks` | Collection name |
+| `milvus.flush_on_index` | bool | `false` | Flush the collection once at the end of each indexing run so writes are immediately visible to other readers (useful for remote Milvus and hook-driven pipelines) |
 | `embedding.provider` | string | `openai` | Embedding provider name |
 | `embedding.model` | string | `""` | Override embedding model (empty = provider default) |
 | `embedding.batch_size` | int | `0` | Embedding batch size (0 = provider default) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,6 +116,14 @@ On remote Milvus Server / Zilliz Cloud, `stats` may lag immediately after upsert
 
 Search results are still the better source of truth for "is my content searchable right now?"
 
+If another process needs to search immediately after `memsearch index` returns (for example a hook-driven pipeline), enable a single end-of-index flush:
+
+```bash
+memsearch config set milvus.flush_on_index true
+```
+
+This seals pending writes once per indexing run. It is off by default because remote Milvus reads normally catch up on their own under Bounded consistency, and flushing after every upsert would create many small sealed segments.
+
 ## First local model download is slow
 
 Local embedding setups such as ONNX may need to download model artifacts on first use. That initial run can feel slow compared with later runs.

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -98,6 +98,7 @@ def _cfg_to_memsearch_kwargs(cfg: MemSearchConfig) -> dict:
         "milvus_uri": cfg.milvus.uri,
         "milvus_token": cfg.milvus.token or None,
         "collection": cfg.milvus.collection,
+        "flush_on_index": cfg.milvus.flush_on_index,
         "max_chunk_size": cfg.chunking.max_chunk_size,
         "overlap_lines": cfg.chunking.overlap_lines,
         "reranker_model": cfg.reranker.model,

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -27,7 +27,7 @@ PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
 _INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
-_BOOL_FIELDS = {"enabled"}
+_BOOL_FIELDS = {"enabled", "flush_on_index"}
 _LIST_FIELDS = {"paths"}
 
 # Project-local config is loaded from the repository being opened, so it must
@@ -48,6 +48,7 @@ class MilvusConfig:
     uri: str = "~/.memsearch/milvus.db"
     token: str = ""
     collection: str = "memsearch_chunks"
+    flush_on_index: bool = False
 
 
 @dataclass

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -44,6 +44,11 @@ class MemSearch:
     collection:
         Milvus collection name.  Use different names to isolate
         agents sharing the same Milvus server.
+    flush_on_index:
+        Flush the collection once at the end of each indexing run so
+        writes are immediately visible to readers in other processes.
+        Off by default: remote Milvus reads usually catch up on their
+        own, and frequent flushes create many small sealed segments.
     """
 
     def __init__(
@@ -58,6 +63,7 @@ class MemSearch:
         milvus_uri: str = "~/.memsearch/milvus.db",
         milvus_token: str | None = None,
         collection: str = "memsearch_chunks",
+        flush_on_index: bool = False,
         description: str = "",
         max_chunk_size: int = 1500,
         overlap_lines: int = 2,
@@ -81,6 +87,7 @@ class MemSearch:
             description=description,
         )
         self._reranker_model = reranker_model
+        self._flush_on_index = flush_on_index
 
     # ------------------------------------------------------------------
     # Indexing
@@ -120,6 +127,9 @@ class MemSearch:
                 if source not in active_sources and _source_under_any_root(source, cleanup_roots):
                     self._store.delete_by_source(source)
                     logger.info("Removed stale chunks for deleted file: %s", source)
+
+        if total and self._flush_on_index:
+            self._store.flush()
 
         if failed_files:
             logger.warning(

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -120,13 +120,15 @@ class MemSearch:
             exclude=self._exclude,
         )
         total = 0
+        wrote = False
         failed_files: list[IndexFailure] = []
         active_sources: set[str] = set()
         for f in files:
             active_sources.add(str(f.path))
             try:
-                n = await self._index_file(f, force=force)
+                n, deleted_stale = await self._index_file(f, force=force)
                 total += n
+                wrote = wrote or n > 0 or deleted_stale
             except Exception as exc:
                 failed_files.append(IndexFailure(path=str(f.path), error=format_error(exc)))
                 logger.exception("Failed to index %s, skipping", f.path)
@@ -141,8 +143,11 @@ class MemSearch:
                 if source not in active_sources and _source_under_any_root(source, cleanup_roots):
                     self._store.delete_by_source(source)
                     logger.info("Removed stale chunks for deleted file: %s", source)
+                    wrote = True
 
-        if total and self._flush_on_index:
+        # Deletions count as writes: a run that only removed chunks still
+        # changed what other readers should see.
+        if wrote and self._flush_on_index:
             self._store.flush()
 
         if failed_files:
@@ -166,9 +171,11 @@ class MemSearch:
         p = Path(path).expanduser().resolve()
         _st = p.stat()
         sf = ScannedFile(path=p, mtime=_st.st_mtime, size=_st.st_size)
-        return await self._index_file(sf)
+        upserted, _ = await self._index_file(sf)
+        return upserted
 
-    async def _index_file(self, f: ScannedFile, *, force: bool = False) -> int:
+    async def _index_file(self, f: ScannedFile, *, force: bool = False) -> tuple[int, bool]:
+        """Index one file; returns (upserted chunk count, whether stale chunks were deleted)."""
         source = str(f.path)
         text = read_utf8_text_replace(f.path)
         chunks = chunk_markdown(
@@ -189,7 +196,7 @@ class MemSearch:
             self._store.delete_by_hashes(list(stale))
 
         if not chunks:
-            return 0
+            return 0, bool(stale)
 
         if not force:
             # Only embed chunks whose ID doesn't already exist
@@ -199,9 +206,9 @@ class MemSearch:
                 if compute_chunk_id(c.source, c.start_line, c.end_line, c.content_hash, model) not in old_ids
             ]
             if not chunks:
-                return 0
+                return 0, bool(stale)
 
-        return await self._embed_and_store(chunks)
+        return await self._embed_and_store(chunks), bool(stale)
 
     async def _embed_and_store(self, chunks: list[Chunk]) -> int:
         if not chunks:

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -154,7 +154,24 @@ class MilvusStore:
             collection_name=self._collection,
             data=chunks,
         )
-        return result.get("upsert_count", len(chunks)) if isinstance(result, dict) else len(chunks)
+        count = result.get("upsert_count") if isinstance(result, dict) else None
+        if count == 0:
+            raise RuntimeError(
+                f"Milvus reported 0 written rows for an upsert of {len(chunks)} chunks; "
+                "refusing to report a zero-write upsert as success"
+            )
+        return count if count is not None else len(chunks)
+
+    def flush(self) -> None:
+        """Seal pending writes so they are durable and visible to other readers.
+
+        Remote Milvus does not flush after upsert, and under the default
+        Bounded consistency freshly written chunks may be invisible to
+        search (and to ``get_collection_stats``) until a flush or segment
+        seal happens.  Flushing after every upsert would create many small
+        sealed segments, so callers should flush once per indexing run.
+        """
+        self._client.flush(self._collection)
 
     def search(
         self,

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -160,6 +160,12 @@ class MilvusStore:
                 f"Milvus reported 0 written rows for an upsert of {len(chunks)} chunks; "
                 "refusing to report a zero-write upsert as success"
             )
+        if count is not None and count < len(chunks):
+            logger.warning(
+                "Milvus reported %d written rows for an upsert of %d chunks; reporting the server count",
+                count,
+                len(chunks),
+            )
         return count if count is not None else len(chunks)
 
     def flush(self) -> None:

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -69,6 +69,7 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
     cfg.milvus.uri = "http://milvus.local:19530"
     cfg.milvus.token = "milvus-token"
     cfg.milvus.collection = "team_notes"
+    cfg.milvus.flush_on_index = True
     cfg.chunking.max_chunk_size = 1800
     cfg.chunking.overlap_lines = 4
     cfg.reranker.model = ""
@@ -84,6 +85,7 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
         "milvus_uri": "http://milvus.local:19530",
         "milvus_token": "milvus-token",
         "collection": "team_notes",
+        "flush_on_index": True,
         "max_chunk_size": 1800,
         "overlap_lines": 4,
         "reranker_model": "",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,6 +284,21 @@ def test_plugin_summarize_provider_config_roundtrip(tmp_path: Path, monkeypatch:
     assert saved["plugins"]["codex"]["summarize"]["provider"] == "openai"
 
 
+def test_flush_on_index_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The CLI string "true" parses to a bool for milvus.flush_on_index."""
+    cfg_path = tmp_path / "config.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+
+    set_config_value("milvus.flush_on_index", "true")
+
+    cfg = resolve_config()
+    assert cfg.milvus.flush_on_index is True
+
+    saved = load_config_file(cfg_path)
+    assert saved["milvus"]["flush_on_index"] is True
+
+
 def test_plugin_maintenance_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Plugin maintenance tasks should be addressable by dotted keys."""
     cfg_path = tmp_path / "config.toml"

--- a/tests/test_core_encoding.py
+++ b/tests/test_core_encoding.py
@@ -49,6 +49,7 @@ def make_memsearch() -> tuple[MemSearch, RecordingStore]:
     store = RecordingStore()
     ms._store = store
     ms._reranker_model = ""
+    ms._flush_on_index = False
     return ms, store
 
 

--- a/tests/test_embed_batching.py
+++ b/tests/test_embed_batching.py
@@ -114,6 +114,7 @@ def mem_with_fake(tmp_path: Path):
     ms._overlap_lines = 2
     ms._embedder = fake
     ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
+    ms._flush_on_index = False
     yield ms, fake
     ms.close()
 
@@ -142,6 +143,7 @@ def mem_with_recording_store():
     ms._overlap_lines = 2
     ms._embedder = fake
     ms._store = store
+    ms._flush_on_index = False
     return ms, fake, store
 
 
@@ -216,6 +218,7 @@ async def test_index_continues_after_file_failure(tmp_path: Path):
     ms._overlap_lines = 2
     ms._embedder = fake
     ms._store = MilvusStore(uri=str(tmp_path / "test.db"), dimension=fake.dimension)
+    ms._flush_on_index = False
 
     # Patch _index_file to fail on the bad file
     original_index_file = ms._index_file

--- a/tests/test_flush_on_index.py
+++ b/tests/test_flush_on_index.py
@@ -1,0 +1,74 @@
+"""End-of-index flush wiring for ``milvus.flush_on_index``."""
+
+from pathlib import Path
+
+import pytest
+
+from memsearch.core import MemSearch
+
+
+class _StubEmbedder:
+    """Deterministic embedder so indexing runs without network access."""
+
+    model_name = "stub-model"
+    batch_size = 8
+    dimension = 4
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0, 0.0, 0.0] for _ in texts]
+
+
+@pytest.fixture
+def sample_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "notes.md").write_text("# Title\n\nSome content worth indexing.\n")
+    return d
+
+
+def _make(tmp_path: Path, paths: list[str], *, flush_on_index: bool) -> tuple[MemSearch, list]:
+    m = MemSearch(paths, milvus_uri=str(tmp_path / "flush_test.db"), embedding_api_key="test-key")
+    m._embedder = _StubEmbedder()
+    # Rebuild the store at the stub's dimension so real upserts succeed.
+    m._store.close()
+    from memsearch.store import MilvusStore
+
+    m._store = MilvusStore(uri=str(tmp_path / "flush_test_stub.db"), dimension=4)
+    m._flush_on_index = flush_on_index
+    flush_calls: list[bool] = []
+    m._store.flush = lambda: flush_calls.append(True)  # type: ignore[method-assign]
+    return m, flush_calls
+
+
+@pytest.mark.asyncio
+async def test_index_flushes_once_when_enabled(tmp_path: Path, sample_dir: Path):
+    m, flush_calls = _make(tmp_path, [str(sample_dir)], flush_on_index=True)
+    try:
+        n = await m.index()
+        assert n > 0
+        assert flush_calls == [True]
+    finally:
+        m.close()
+
+
+@pytest.mark.asyncio
+async def test_index_does_not_flush_by_default(tmp_path: Path, sample_dir: Path):
+    m, flush_calls = _make(tmp_path, [str(sample_dir)], flush_on_index=False)
+    try:
+        n = await m.index()
+        assert n > 0
+        assert flush_calls == []
+    finally:
+        m.close()
+
+
+@pytest.mark.asyncio
+async def test_no_flush_when_nothing_indexed(tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    m, flush_calls = _make(tmp_path, [str(empty)], flush_on_index=True)
+    try:
+        assert await m.index() == 0
+        assert flush_calls == []
+    finally:
+        m.close()

--- a/tests/test_flush_on_index.py
+++ b/tests/test_flush_on_index.py
@@ -72,3 +72,46 @@ async def test_no_flush_when_nothing_indexed(tmp_path: Path):
         assert flush_calls == []
     finally:
         m.close()
+
+
+@pytest.mark.asyncio
+async def test_deleted_file_cleanup_flushes(tmp_path: Path, sample_dir: Path):
+    """A run whose only write is deleted-file cleanup still flushes."""
+    m, flush_calls = _make(tmp_path, [str(sample_dir)], flush_on_index=True)
+    try:
+        await m.index()
+        flush_calls.clear()
+        (sample_dir / "notes.md").unlink()
+        assert await m.index() == 0
+        assert flush_calls == [True]
+    finally:
+        m.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_chunk_deletion_flushes(tmp_path: Path, sample_dir: Path):
+    """A run whose only write is removing a section's chunks still flushes."""
+    (sample_dir / "notes.md").write_text("# Title\n\nSome content worth indexing.\n\n# Extra\n\nA second section.\n")
+    m, flush_calls = _make(tmp_path, [str(sample_dir)], flush_on_index=True)
+    try:
+        await m.index()
+        flush_calls.clear()
+        (sample_dir / "notes.md").write_text("# Title\n\nSome content worth indexing.\n")
+        assert await m.index() == 0
+        assert flush_calls == [True]
+    finally:
+        m.close()
+
+
+@pytest.mark.asyncio
+async def test_zero_write_upsert_surfaces_as_index_failure(tmp_path: Path, sample_dir: Path):
+    """A server-reported zero-write fails the file instead of counting as success."""
+    m, _ = _make(tmp_path, [str(sample_dir)], flush_on_index=False)
+    try:
+        m._store._client.upsert = lambda **kwargs: {"upsert_count": 0}  # type: ignore[method-assign]
+        report = await m.index_with_report()
+        assert report.indexed_chunks == 0
+        assert len(report.failed_files) == 1
+        assert "0 written rows" in report.failed_files[0].error
+    finally:
+        m.close()

--- a/tests/test_index_cleanup.py
+++ b/tests/test_index_cleanup.py
@@ -69,6 +69,7 @@ def make_memsearch(paths: list[str | Path]) -> tuple[MemSearch, InMemoryStore]:
     store = InMemoryStore()
     ms._store = store
     ms._reranker_model = ""
+    ms._flush_on_index = False
     return ms, store
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -203,3 +203,42 @@ def test_collection_description_empty_by_default(tmp_path: Path):
     info = s._client.describe_collection(s._collection)
     assert info.get("description") == ""
     s.close()
+
+
+def _minimal_chunk() -> dict:
+    return {
+        "embedding": [1.0, 0.0, 0.0, 0.0],
+        "content": "hello",
+        "source": "x.md",
+        "heading": "",
+        "chunk_hash": "hx",
+        "heading_level": 0,
+        "start_line": 1,
+        "end_line": 1,
+    }
+
+
+def test_upsert_trusts_server_count(store: MilvusStore, monkeypatch):
+    """The server-reported upsert_count wins over len(chunks)."""
+    monkeypatch.setattr(store._client, "upsert", lambda **kw: {"upsert_count": 5})
+    assert store.upsert([_minimal_chunk()]) == 5
+
+
+def test_upsert_zero_write_raises(store: MilvusStore, monkeypatch):
+    """An explicit zero-write response must fail loudly, not report success."""
+    monkeypatch.setattr(store._client, "upsert", lambda **kw: {"upsert_count": 0})
+    with pytest.raises(RuntimeError, match="0 written rows"):
+        store.upsert([_minimal_chunk()])
+
+
+def test_upsert_falls_back_when_count_missing(store: MilvusStore, monkeypatch):
+    """Responses without upsert_count keep the historical len(chunks) fallback."""
+    monkeypatch.setattr(store._client, "upsert", lambda **kw: {})
+    assert store.upsert([_minimal_chunk()]) == 1
+
+
+def test_flush_targets_collection(store: MilvusStore, monkeypatch):
+    flushed = []
+    monkeypatch.setattr(store._client, "flush", lambda name: flushed.append(name))
+    store.flush()
+    assert flushed == [store._collection]


### PR DESCRIPTION
## Summary
- `MilvusStore.upsert()` returns `len(chunks)` as the success count even when the server explicitly reports `upsert_count: 0`, so `memsearch index` can report success while nothing became durable (#534). It now trusts the server-reported count and raises on an explicit zero-write response; responses without a count keep the historical fallback.
- Adds `milvus.flush_on_index` (bool, default `false` — current behavior is unchanged): one `flush()` at the end of an indexing run, for pipelines where a reader in another process searches immediately after `memsearch index` returns. Deliberately not per-upsert flushing, which would create many small sealed segments.
- Documents the read-after-write visibility semantics in `docs/troubleshooting.md` and the config key table.

This is the fix shape proposed by the maintainer in #534 (strict count + opt-in end-of-index flush + documented consistency behavior). Datapoint from a different environment than that issue's repro: we run `memsearch index` from an agent Stop/SessionEnd hook on macOS with Milvus **Lite**, and a separate short-lived process that searches immediately afterwards intermittently missed the fresh chunks until we added an external flush after each run — so the cross-process visibility gap is not exclusive to remote Milvus, even though Lite auto-flushes on close.

## Test plan
- [x] `tests/test_store.py`: server-reported count trusted over `len(chunks)`; explicit zero-write raises `RuntimeError`; missing count falls back; `flush()` targets the configured collection
- [x] `tests/test_flush_on_index.py`: end-of-index flush fires exactly once when enabled, never by default, and not on runs that index nothing
- [x] `_cfg_to_memsearch_kwargs` translation test covers the new key; `config set milvus.flush_on_index true` coerces via `_BOOL_FIELDS`
- [x] Full suite: 271 passed, 7 skipped; `ruff check` / `ruff format --check` clean