### PR TITLE
fix(claude-code): write session heading lazily to avoid stub journals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,9 @@ The plugin is a first-class component of memsearch — it's the primary real-wor
 plugins/claude-code/
 ├── hooks/
 │   ├── common.sh                # Shared setup: PATH, memsearch detection, collection name, watch PID
-│   ├── session-start.sh         # SessionStart: start watch, write session heading, inject recent memories
+│   ├── session-start.sh         # SessionStart: start watch and inject recent memories
 │   ├── user-prompt-submit.sh    # UserPromptSubmit: lightweight hint reminding Claude about memory skill
-│   ├── stop.sh                  # Stop: extract last turn → haiku summarize (third-person) → append to daily .md (async)
+│   ├── stop.sh                  # Stop: extract last turn → summarize → lazily create heading → append (async)
 │   ├── session-end.sh           # SessionEnd: stop watch process
 │   └── parse-transcript.sh      # Last-turn extractor: finds last user question → EOF, formats with role labels for LLM (Python 3, no jq)
 ├── scripts/

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -43,9 +43,9 @@ The plugin defines 4 lifecycle hooks that map to Claude Code's session events:
 
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
-| **SessionStart** | command | no | 10s | Start `memsearch watch`, write session heading, inject recent memories as cold-start context, display config status |
+| **SessionStart** | command | no | 10s | Start `memsearch watch`, inject recent memories as cold-start context, display config status |
 | **UserPromptSubmit** | command | no | 15s | Return `systemMessage` hint "[memsearch] Memory available" (skips prompts < 10 chars) |
-| **Stop** | command | **yes** | 120s | Parse last turn from transcript, summarize via native Haiku by default or configured API provider, append to daily `.md`, re-index |
+| **Stop** | command | **yes** | 120s | Parse and summarize the last turn, lazily create its session heading, append to the daily `.md`, re-index |
 | **SessionEnd** | command | no | 10s | Stop the `memsearch watch` background process |
 
 All hooks output JSON to stdout -- `additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}` for no-op. The `common.sh` shared library is sourced by every hook, providing JSON parsing, memsearch binary detection, and watch process management.
@@ -78,7 +78,7 @@ stateDiagram-v2
         ClaudeProcesses --> ClaudeResponds: no memory needed
         ClaudeResponds --> UserInput: next turn
         ClaudeResponds --> Summary: Stop hook (async)
-        Summary --> WriteMD: append to YYYY-MM-DD.md
+        Summary --> WriteMD: create heading if needed, then append
     }
 
     Prompting --> SessionEnd: user exits
@@ -88,13 +88,14 @@ stateDiagram-v2
 
 ### SessionStart -- Bootstrapping the Session
 
-The SessionStart hook runs once when Claude Code opens a new session. It performs five steps:
+The SessionStart hook runs once when Claude Code opens a new session. It performs four steps:
 
-1. **Config validation** -- reads the memsearch config and validates the API key for the configured embedding provider (ONNX needs no key)
+1. **Config validation** -- loads resolved config in one snapshot and validates the API key for the configured embedding provider (ONNX needs no key)
 2. **Start watcher** -- launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file at `.memsearch/.watch.pid` prevents duplicates)
-3. **Session heading** -- writes `## Session HH:MM` to today's memory file (`YYYY-MM-DD.md`), marking the start of a new session
-4. **Cold-start injection** -- reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext` so Claude has immediate awareness of recent work
-5. **Update check** -- queries PyPI (2s timeout) and shows an update banner if a newer version exists
+3. **Cold-start injection** -- reads up to 40 lines from each of the 2 most recent daily logs and returns them as `additionalContext` so Claude has immediate awareness of recent work
+4. **Update check** -- queries PyPI (2s timeout) and shows an update banner if a newer version exists
+
+SessionStart prepares the memory directory but does not create a daily journal. A journal appears only after the Stop hook captures content.
 
 The cold-start injection is critical for early-session context. Without it, Claude would have no idea what happened yesterday until the memory-recall skill triggers -- but the skill only triggers when Claude judges it would help, which requires knowing that relevant history exists.
 
@@ -116,7 +117,7 @@ graph TD
     C -->|"< 3 lines"| Z
     C -->|Valid| D["parse-transcript.sh<br/>Extract last turn"]
     D --> E["claude -p --model haiku<br/>Summarize as 3rd-person notes"]
-    E --> F["Append to YYYY-MM-DD.md<br/>with session anchors"]
+    E --> F["Create session heading if needed<br/>and append with anchors"]
     F --> G["memsearch index<br/>Re-index immediately"]
 ```
 
@@ -137,8 +138,10 @@ Step by step:
 
 4. **Haiku summarization** -- the extracted turn is piped to `claude -p --model haiku` with a system prompt instructing it to write 2-10 third-person bullet points in the same language as the user's message. Set `plugins.claude-code.summarize.model` to override only this native capture model. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name. Empty or `native` keeps the Haiku default. The third-person framing ("User asked about...", "Agent implemented...") makes the summaries more useful as memory entries than first-person notes.
 
-5. **Append with anchors** -- the summary is written to `.memsearch/memory/YYYY-MM-DD.md` under a `### HH:MM` heading with an HTML comment anchor:
+5. **Append with anchors** -- on the first content-bearing Stop for a session, the hook creates the daily file if needed and writes `## Session HH:MM`. Each captured turn is written under a `### HH:MM` heading with an HTML comment anchor. Later Stops in the same session reuse its heading:
     ```markdown
+    ## Session 14:30
+
     ### 14:30
     <!-- session:abc123def turn:ghi789jkl transcript:/home/user/.claude/projects/.../abc123def.jsonl -->
     - User asked about N+1 query performance in order-service
@@ -233,9 +236,9 @@ plugins/claude-code/
 ├── hooks/
 │   ├── hooks.json               # Hook definitions (4 lifecycle hooks)
 │   ├── common.sh                # Shared setup: env, PATH, memsearch detection, watch management
-│   ├── session-start.sh         # Start watch + write session heading + inject cold-start context
+│   ├── session-start.sh         # Start watch + inject cold-start context
 │   ├── user-prompt-submit.sh    # Lightweight systemMessage hint
-│   ├── stop.sh                  # Parse transcript -> haiku summary -> append to daily .md
+│   ├── stop.sh                  # Parse transcript -> summarize -> lazily create heading -> append
 │   ├── parse-transcript.sh      # Deterministic JSONL-to-text parser with truncation
 │   └── session-end.sh           # Stop watch process (cleanup)
 ├── scripts/
@@ -251,9 +254,9 @@ plugins/claude-code/
 | `plugin.json` | Claude Code plugin manifest. Declares the plugin name (`memsearch`), version, and description. |
 | `hooks.json` | Defines the 4 lifecycle hooks with their types, timeouts, and async flags. |
 | `common.sh` | Shared shell library sourced by all hooks. Handles stdin JSON parsing, PATH setup, memsearch binary detection (prefers PATH, falls back to `uv run`), memory directory management, and the watch singleton (start/stop with PID file and orphan cleanup). Changes here affect all hooks. |
-| `session-start.sh` | Starts the watcher, writes session heading, reads recent memory files for cold-start injection, checks for updates. |
+| `session-start.sh` | Starts the watcher, reads recent memory files for cold-start injection, and checks for updates. |
 | `user-prompt-submit.sh` | Returns lightweight `systemMessage` hint. No search -- retrieval is handled by the memory-recall skill. |
-| `stop.sh` | Extracts transcript, validates it, calls `parse-transcript.sh`, summarizes via native Haiku by default or configured API provider, appends with anchors. Has recursion guard (`stop_hook_active`) and sets `CLAUDECODE=` / `MEMSEARCH_NO_WATCH=1` on child processes. |
+| `stop.sh` | Extracts and validates the transcript, calls `parse-transcript.sh`, summarizes via native Haiku by default or a configured API provider, creates the session heading on the first captured turn, and appends with anchors. Has recursion guard (`stop_hook_active`) and sets `CLAUDECODE=` / `MEMSEARCH_NO_WATCH=1` on child processes. |
 | `parse-transcript.sh` | Standalone last-turn extractor using Python 3. Outputs role-labeled text. No `jq` dependency. |
 | `session-end.sh` | Calls `stop_watch` to terminate background watcher and clean up. |
 | `derive-collection.sh` | Generates a deterministic per-project Milvus collection name from the project path (e.g., `ms_myproject_a1b2c3`). |

--- a/docs/platforms/claude-code/memory-recall.md
+++ b/docs/platforms/claude-code/memory-recall.md
@@ -107,7 +107,7 @@ Manual invocation is useful when:
 
 **Use specific queries.** "Redis caching" will return better results than "the thing we did last week". The search uses both semantic similarity (dense vectors) and keyword matching (BM25), so including specific terms helps.
 
-**Check cold-start context.** The SessionStart hook injects the last 30 lines from recent daily logs. For very recent work (today or yesterday), Claude may already have the context without needing to invoke the skill.
+**Check cold-start context.** The SessionStart hook injects up to 40 lines from each of the 2 most recent daily logs. For very recent work (today or yesterday), Claude may already have the context without needing to invoke the skill.
 
 **Don't over-manage.** The system is designed to be autonomous. You don't need to tell Claude to "check memory" -- if the question benefits from historical context, the `UserPromptSubmit` hint and Claude's own judgment will trigger the skill.
 

--- a/docs/platforms/claude-code/troubleshooting.md
+++ b/docs/platforms/claude-code/troubleshooting.md
@@ -157,16 +157,27 @@ All memories are written to `.memsearch/memory/YYYY-MM-DD.md`.
 **Verify files exist:**
 ```bash
 ls -la .memsearch/memory/
-cat .memsearch/memory/$(date +%Y-%m-%d).md
+today=".memsearch/memory/$(date +%Y-%m-%d).md"
+if [ -f "$today" ]; then
+  cat "$today"
+else
+  echo "No summaries captured today"
+fi
 ```
 
-**If you see session headings but no bullet-point summaries:**
+SessionStart prepares the memory directory but does not create a daily file. If no content-bearing Stop has completed, today's journal will not exist. This is normal for short or empty sessions.
+
+**If you expected a summary but no entry was written:**
 
 | Cause | Fix |
 |-------|-----|
-| `claude` CLI not found | Ensure `claude` is in PATH |
+| Embedding API key missing | Set the provider's environment variable or configure `embedding.api_key` |
+| Summarization disabled | Set `plugins.claude-code.summarize.enabled` to `true` |
+| Transcript missing or empty | Check the Stop hook payload and transcript path |
 | Transcript too short (< 3 lines) | Normal for very short sessions |
 | Stop hook timed out | Check `~/.claude/logs/` for errors |
+
+If the `claude` CLI is unavailable or native summarization returns no text, the hook falls back to the parsed turn instead of skipping the journal write.
 
 ---
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -145,9 +145,9 @@ stateDiagram-v2
 
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
-| **SessionStart** | command | no | 10s | Start `memsearch watch` singleton, write session heading to today's `.md`, inject recent daily logs as cold-start context via `additionalContext`, display config status (provider/model/milvus) in `systemMessage` |
+| **SessionStart** | command | no | 10s | Start `memsearch watch` singleton, inject recent daily logs as cold-start context via `additionalContext`, display config status (provider/model/milvus) in `systemMessage` |
 | **UserPromptSubmit** | command | no | 15s | Lightweight hint: returns `systemMessage` "[memsearch] Memory available" (skip if < 10 chars). No search — recall is handled by the memory-recall skill |
-| **Stop** | command | **yes** | 120s | Extract last turn from transcript with `parse-transcript.sh`, summarize via native Haiku by default or configured API provider, append summary with session/turn anchors to daily `.md` |
+| **Stop** | command | **yes** | 120s | Extract and summarize the last turn, lazily create its session heading, append the summary with session/turn anchors to the daily `.md` |
 | **SessionEnd** | command | no | 10s | Stop the `memsearch watch` background process (cleanup) |
 
 ### What Each Hook Does
@@ -156,12 +156,13 @@ stateDiagram-v2
 
 Fires once when a Claude Code session begins. This hook:
 
-1. **Reads config and checks API key.** Loads the resolved provider, model, API key, and Milvus URI in one `memsearch config list --json-output` snapshot. Older CLI versions automatically fall back to per-key `config get` calls. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
+1. **Reads config and checks API key.** Loads the resolved provider, model, API key, and Milvus URI in one `memsearch config list --resolved --json-output` snapshot. Older CLI versions automatically fall back to per-key `config get` calls. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
 2. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce. Milvus Lite falls back to a one-time `memsearch index` at session start.
-3. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
-4. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
-5. **Checks for updates.** Queries PyPI (2s timeout) and compares with the installed version. If a newer version is available, appends an `UPDATE` hint to the status line.
-6. **Displays config status.** Every exit path returns a `systemMessage` showing the active configuration, e.g. `[memsearch v0.1.10] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db` (with `| UPDATE: v0.1.12 available` when outdated).
+3. **Injects cold-start context.** Reads up to 40 lines from each of the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.
+4. **Checks for updates.** Queries PyPI (2s timeout) and compares with the installed version. If a newer version is available, appends an `UPDATE` hint to the status line.
+5. **Displays config status.** Every exit path returns a `systemMessage` showing the active configuration, e.g. `[memsearch v0.1.10] embedding: openai/text-embedding-3-small | milvus: ~/.memsearch/milvus.db` (with `| UPDATE: v0.1.12 available` when outdated).
+
+SessionStart prepares the memory directory but does not create a daily journal. A journal appears only after the Stop hook captures content.
 
 #### UserPromptSubmit
 
@@ -181,7 +182,7 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
 2. **Validates the transcript.** Skips if the transcript file is missing or has fewer than 3 lines.
 3. **Extracts the last turn.** Calls `parse-transcript.sh` (Python3 inline, no `jq` dependency), which finds the last real user message and extracts User/Assistant text from there to EOF. Skips progress, `file-history-snapshot`, system, thinking blocks, raw tool calls, and raw tool results. Formats output with clear role labels (`[User]`, `[Claude Code]`) so the summarizer works from a clean third-party transcript while still allowing the assistant's text to mention important files, searches, findings, and tests.
 4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with an external-observer system prompt requesting 2-10 third-person bullet points in the same language as the user's message. To override only this plugin's native summarize model, set `plugins.claude-code.summarize.model`; empty or unset keeps the Haiku default. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name.
-5. **Appends to daily log.** Writes a `### HH:MM` sub-heading with an HTML comment anchor containing session ID, turn UUID, and transcript path. Then runs `memsearch index` to ensure immediate indexing.
+5. **Appends to the daily log.** On the first content-bearing Stop for a session, creates the daily file if needed and writes `## Session HH:MM`. Every captured turn gets a `### HH:MM` sub-heading with an HTML comment anchor containing the session ID, turn UUID, and transcript path. Later Stops in the same session reuse its existing session heading. The hook then runs `memsearch index` for immediate indexing.
 
 #### SessionEnd
 
@@ -439,9 +440,9 @@ plugins/claude-code/
 ├── hooks/
 │   ├── hooks.json               # Hook definitions (4 lifecycle hooks)
 │   ├── common.sh                # Shared setup: env, PATH, memsearch detection, watch management
-│   ├── session-start.sh         # Start watch + write session heading + inject cold-start context
+│   ├── session-start.sh         # Start watch + inject cold-start context
 │   ├── user-prompt-submit.sh    # Lightweight systemMessage hint ("[memsearch] Memory available")
-│   ├── stop.sh                  # Extract last turn → haiku summary (third-person) → append to daily .md
+│   ├── stop.sh                  # Extract last turn → summarize → lazily create heading → append to daily .md
 │   ├── parse-transcript.sh      # Extract last turn from JSONL, format with role labels (Python3, no jq)
 │   └── session-end.sh           # Stop watch process (cleanup)
 └── skills/
@@ -770,18 +771,19 @@ All memories are stored as plain markdown in `.memsearch/memory/`.
 **Verify the Stop hook is working:**
 
 ```bash
-# Check if today's file exists and has content
-cat .memsearch/memory/$(date +%Y-%m-%d).md
-
-# Check if recent sessions have summaries (not just headings)
-tail -20 .memsearch/memory/$(date +%Y-%m-%d).md
+# Inspect today's captured summaries if the Stop hook created a journal
+today=.memsearch/memory/$(date +%Y-%m-%d).md
+if [ -f "$today" ]; then tail -20 "$today"; else echo "No summaries captured today"; fi
 ```
 
-If you see `## Session HH:MM` headings but no `### HH:MM` sub-headings with bullet points underneath, the Stop hook is not completing successfully. Common causes:
+SessionStart does not create a daily file. If no content-bearing Stop has completed, today's journal will not exist. This is normal for short or empty sessions. If you expected a summary, check these early-exit conditions:
 
-- `claude` CLI not found — the Stop hook calls `claude -p --model haiku` to summarize
-- API key missing — the Stop hook skips summarization when the embedding provider key is not set
-- Transcript too short — sessions with fewer than 3 JSONL lines are skipped
+- The embedding provider requires an API key and neither the environment nor memsearch config supplies it.
+- The transcript is missing, has fewer than 3 JSONL lines, or contains no usable user turn.
+- `plugins.claude-code.summarize.enabled` is `false`.
+- The Stop hook timed out or failed; inspect the Claude Code debug log for the hook result.
+
+If the `claude` CLI is unavailable or native summarization returns no text, the hook falls back to the parsed turn instead of skipping the journal write.
 
 ---
 
@@ -795,7 +797,7 @@ If you see `## Session HH:MM` headings but no `### HH:MM` sub-headings with bull
 | Search returns no results | Run `memsearch stats` and `memsearch search` manually | [§3](#3-cli-diagnostic-commands) |
 | New memories not being indexed | Check watch process is running | [§4](#4-watch-process) |
 | Claude never invokes memory recall | Try `/memory-recall <query>` manually | [§5](#5-skill-execution--progressive-disclosure) |
-| Session summaries missing from memory files | Check `claude` CLI is available and API key is set | [§6](#6-memory-files) |
+| Session summaries missing from memory files | Check the Stop hook log, transcript, summarize setting, and embedding API key | [§6](#6-memory-files) |
 
 ---
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -223,8 +223,8 @@ if [ -n "$recent_files" ]; then
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     basename_f=$(basename "$f")
-    # Extract recent non-empty session sections. Empty SessionStart headings are
-    # common after short sessions, but they do not carry useful context.
+    # Extract recent non-empty session sections. Legacy journals may contain
+    # empty headings, but they do not carry useful context.
     content=$(_recent_memory_preview "$f" 40)
     if [ -n "$content" ]; then
       context+="## $basename_f\n$content\n\n"

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -164,14 +164,12 @@ _recent_memory_preview() {
   ' "$file" 2>/dev/null | tail -n "$max_lines" || true
 }
 
-# Write session heading to today's memory file
+# The session heading is written lazily by stop.sh on the first
+# content-bearing Stop. Writing it eagerly here left header-only stub
+# journals (bare "## Session HH:MM" files) for every session in which the
+# Stop hook never appended a summary, and those stubs occupied one of the
+# two recent-memory injection slots below.
 ensure_memory_dir
-TODAY=$(date +%Y-%m-%d)
-NOW=$(date +%H:%M)
-MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
-if [ ! -f "$MEMORY_FILE" ] || ! grep -qF "## Session $NOW" "$MEMORY_FILE"; then
-  echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
-fi
 
 # If API key is missing, show status and exit early (watch/search would fail)
 if [ "$KEY_MISSING" = true ]; then
@@ -208,7 +206,7 @@ fi
 # Always include status in systemMessage
 json_status=$(_json_encode_str "$status")
 
-# If memory dir has no .md files (other than the one we just created), nothing to inject
+# If memory dir has no .md files, nothing to inject
 if [ ! -d "$MEMORY_DIR" ] || ! ls "$MEMORY_DIR"/*.md &>/dev/null; then
   echo "{\"systemMessage\": $json_status}"
   exit 0

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -160,9 +160,14 @@ if [ -z "$SUMMARY" ]; then
   SUMMARY="$PARSED"
 fi
 
-# Append as a sub-heading under the session heading written by SessionStart
-# Include HTML comment anchor for progressive disclosure (L3 transcript lookup)
+# Append under a session heading, writing the heading lazily on the first
+# content-bearing Stop of this session (SessionStart no longer writes it
+# eagerly, so sessions without summaries leave no stub journals). The
+# progressive-disclosure anchor comment doubles as the heading-written marker.
 {
+  if [ -z "$SESSION_ID" ] || ! grep -qF "session:${SESSION_ID}" "$MEMORY_FILE" 2>/dev/null; then
+    echo -e "\n## Session $NOW\n"
+  fi
   echo "### $NOW"
   if [ -n "$SESSION_ID" ]; then
     echo "<!-- session:${SESSION_ID} turn:${LAST_USER_TURN_UUID} transcript:${TRANSCRIPT_PATH} -->"

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -6,6 +6,30 @@ import subprocess
 from pathlib import Path
 
 
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _write_claude_transcript(path: Path, *, turn_uuid: str) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "system", "message": {"content": "start"}}),
+                json.dumps({"type": "user", "uuid": turn_uuid, "message": {"content": "Summarize this session"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "I explained the hook behavior."}]},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Path) -> None:
     script = Path("plugins/claude-code/hooks/session-start.sh")
     env = {
@@ -26,6 +50,61 @@ def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Pat
 
     assert result.stdout.strip() == "{}"
     assert not (tmp_path / ".memsearch").exists()
+
+
+def test_claude_session_start_does_not_create_journal(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    home.mkdir()
+    fake_bin.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"","api_key":""},"milvus":{"uri":"http://localhost:19530"}}'
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.16"
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+echo '{"info":{"version":"0.4.16"}}'
+""",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    memory_dir = memsearch_dir / "memory"
+    assert "systemMessage" in payload
+    assert memory_dir.is_dir()
+    assert list(memory_dir.glob("*.md")) == []
 
 
 def test_claude_session_start_recent_memory_skips_empty_sessions(tmp_path: Path) -> None:
@@ -591,6 +670,103 @@ echo "- User discussed a macOS stop hook regression."
     assert captured_args[:4] == ["-p", "--strict-mcp-config", "--tools", ""]
     assert "--safe-mode" not in captured_args
     assert captured_args[captured_args.index("--model") + 1] == "haiku"
+
+
+def test_claude_stop_hook_groups_session_headings(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    plugin_root = Path("plugins/claude-code").resolve()
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    transcript_a = tmp_path / "session-a.jsonl"
+    transcript_b = tmp_path / "session-b.jsonl"
+    home.mkdir()
+    fake_bin.mkdir()
+    _write_claude_transcript(transcript_a, turn_uuid="turn-a")
+    _write_claude_transcript(transcript_b, turn_uuid="turn-b")
+
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "onnx" ;;
+    plugins.claude-code.summarize.enabled) echo "true" ;;
+    plugins.claude-code.summarize.model) echo "" ;;
+    plugins.claude-code.summarize.provider) echo "" ;;
+    prompts.summarize) echo "" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "index" ]; then
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "claude",
+        """#!/usr/bin/env bash
+if [ "${1:-}" = "--help" ]; then
+  echo "Usage: claude"
+  exit 0
+fi
+echo "- Captured a session summary."
+""",
+    )
+    _write_executable(
+        fake_bin / "date",
+        """#!/usr/bin/env bash
+case "${1:-}" in
+  +%Y-%m-%d) echo "2026-07-23" ;;
+  +%H:%M) echo "12:34" ;;
+  *) /bin/date "$@" ;;
+esac
+""",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+    }
+
+    def run_stop(transcript: Path) -> None:
+        result = subprocess.run(
+            ["bash", str(script)],
+            input=json.dumps({"transcript_path": str(transcript)}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        assert result.stdout.strip() == "{}"
+
+    memory_file = memsearch_dir / "memory" / "2026-07-23.md"
+
+    run_stop(transcript_a)
+    memory_text = memory_file.read_text(encoding="utf-8")
+    assert memory_text.count("## Session 12:34") == 1
+    assert memory_text.count("### 12:34") == 1
+    assert memory_text.count("session:session-a ") == 1
+
+    run_stop(transcript_a)
+    memory_text = memory_file.read_text(encoding="utf-8")
+    assert memory_text.count("## Session 12:34") == 1
+    assert memory_text.count("### 12:34") == 2
+    assert memory_text.count("session:session-a ") == 2
+
+    run_stop(transcript_b)
+    memory_text = memory_file.read_text(encoding="utf-8")
+    sections = memory_text.split("## Session 12:34")
+    assert len(sections) == 3
+    assert sections[1].count("session:session-a ") == 2
+    assert "session:session-b " not in sections[1]
+    assert sections[2].count("session:session-b ") == 1
 
 
 def test_claude_stop_hook_avoids_empty_array_expansion_under_nounset() -> None:


### PR DESCRIPTION
## Summary
- Write Claude Code's `## Session HH:MM` heading only on the first content-bearing Stop, so skipped Stops leave no empty daily journal.
- Preserve the resolved-config SessionStart path from #645, the existing session/turn anchors, summarization flow, indexing behavior, and the Codex plugin's eager heading behavior.
- Add deterministic regression coverage for SessionStart and stateful Stop lifecycles, and reconcile the Claude Code README, lifecycle, recall, troubleshooting, and contributor documentation.

## Test plan
- [x] `uv run python -m pytest tests/test_claude_hooks.py` (13 passed)
- [x] `bash -n plugins/claude-code/hooks/session-start.sh plugins/claude-code/hooks/stop.sh`
- [x] `uv run python -m pytest` (287 passed, 7 skipped)
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run --group docs mkdocs build --strict`
- [x] `git diff --check`
