### PR TITLE
fix(plugin): reduce SessionStart configuration overhead

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,13 +186,14 @@ $ memsearch config get chunking.max_chunk_size
 
 #### `memsearch config list`
 
-Display configuration in TOML format.
+Display configuration in TOML format by default, or JSON for scripting.
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--resolved` | *(default)* | Show the fully merged configuration from all sources |
 | `--global` | | Show only the global config file (`~/.memsearch/config.toml`) |
 | `--project` | | Show only the project config file (`.memsearch.toml`) |
+| `--json-output`, `-j` | `false` | Output the selected configuration as JSON |
 
 ```bash
 $ memsearch config list --resolved
@@ -248,6 +249,13 @@ model = ""
 [prompts]
 compact = ""
 summarize = ""
+```
+
+Use JSON when another process needs several resolved values without launching
+the CLI once per key:
+
+```bash
+$ memsearch config list --resolved --json-output > resolved-config.json
 ```
 
 ```bash

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -156,7 +156,7 @@ stateDiagram-v2
 
 Fires once when a Claude Code session begins. This hook:
 
-1. **Reads config and checks API key.** Runs `memsearch config get` to read the configured embedding provider, model, and Milvus URI. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
+1. **Reads config and checks API key.** Loads the resolved provider, model, API key, and Milvus URI in one `memsearch config list --json-output` snapshot. Older CLI versions automatically fall back to per-key `config get` calls. Checks whether the required API key is set for the provider (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, `VOYAGE_API_KEY`, `JINA_API_KEY`, `MISTRAL_API_KEY`; `onnx`, `ollama`, and `local` need no key). If missing, shows an error in `systemMessage` and exits early.
 2. **Starts the watcher.** Launches `memsearch watch .memsearch/memory/` as a singleton background process (PID file lock prevents duplicates). The watcher monitors markdown files and auto-re-indexes on changes with a 1500ms debounce. Milvus Lite falls back to a one-time `memsearch index` at session start.
 3. **Writes a session heading.** Appends `## Session HH:MM` to today's memory file (`.memsearch/memory/YYYY-MM-DD.md`), creating the file if it does not exist.
 4. **Injects cold-start context.** Reads the last 30 lines from the 2 most recent daily logs and returns them as `additionalContext`. This gives Claude awareness of recent sessions, which helps it decide when to invoke the memory-recall skill.

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -76,12 +76,12 @@ _json_val() {
     # Build jq filter from dotted key: "info.version" → ".info.version"
     result=$(printf '%s' "$json" | jq -r ".${key} // empty" 2>/dev/null) || true
   else
-    result=$(python3 -c "
+    result=$(printf '%s' "$json" | python3 -c "
 import json, sys
 try:
-    obj = json.loads(sys.argv[1])
+    obj = json.load(sys.stdin)
     val = obj
-    for k in sys.argv[2].split('.'):
+    for k in sys.argv[1].split('.'):
         val = val[k]
     if val is None:
         print('')
@@ -91,7 +91,7 @@ try:
         print(val)
 except Exception:
     print('')
-" "$json" "$key" 2>/dev/null) || true
+" "$key" 2>/dev/null) || true
   fi
 
   if [ -z "$result" ]; then
@@ -148,6 +148,7 @@ PY
 
 skill_candidate_hint() {
   [ -n "$MEMSEARCH_CMD" ] || return 0
+  [ -d "$MEMSEARCH_DIR/skill-candidates" ] || return 0
   MEMSEARCH_DIR="$MEMSEARCH_DIR" $MEMSEARCH_CMD skills status --hint 2>/dev/null || true
 }
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -31,12 +31,24 @@ if [ -n "$MEMSEARCH_CMD" ]; then
   fi
 fi
 
-# Read resolved config and version for status display
-PROVIDER="onnx"; MODEL=""; MILVUS_URI=""; VERSION=""
+# Read resolved config in one CLI call. Older CLI versions do not support
+# --json-output, so keep the existing per-key reads as a compatibility fallback.
+PROVIDER="onnx"; MODEL=""; MILVUS_URI=""; CONFIG_API_KEY=""; VERSION=""
+CONFIG_SNAPSHOT_LOADED=false
 if [ -n "$MEMSEARCH_CMD" ]; then
-  PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "onnx")
-  MODEL=$($MEMSEARCH_CMD config get embedding.model 2>/dev/null || echo "")
-  MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")
+  CONFIG_JSON=$($MEMSEARCH_CMD config list --resolved --json-output 2>/dev/null || true)
+  SNAPSHOT_PROVIDER=$(_json_val "$CONFIG_JSON" "embedding.provider" "")
+  if [ -n "$SNAPSHOT_PROVIDER" ]; then
+    PROVIDER="$SNAPSHOT_PROVIDER"
+    MODEL=$(_json_val "$CONFIG_JSON" "embedding.model" "")
+    MILVUS_URI=$(_json_val "$CONFIG_JSON" "milvus.uri" "")
+    CONFIG_API_KEY=$(_json_val "$CONFIG_JSON" "embedding.api_key" "")
+    CONFIG_SNAPSHOT_LOADED=true
+  else
+    PROVIDER=$($MEMSEARCH_CMD config get embedding.provider 2>/dev/null || echo "onnx")
+    MODEL=$($MEMSEARCH_CMD config get embedding.model 2>/dev/null || echo "")
+    MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")
+  fi
   # "memsearch, version 0.1.10" → "0.1.10"
   VERSION=$($MEMSEARCH_CMD --version 2>/dev/null | sed 's/.*version //' || echo "")
 fi
@@ -57,8 +69,7 @@ REQUIRED_KEY=$(_required_env_var "$PROVIDER")
 KEY_MISSING=false
 if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
   # Env var not set — check if API key is configured in memsearch config file
-  CONFIG_API_KEY=""
-  if [ -n "$MEMSEARCH_CMD" ]; then
+  if [ "$CONFIG_SNAPSHOT_LOADED" != true ] && [ -n "$MEMSEARCH_CMD" ]; then
     CONFIG_API_KEY=$($MEMSEARCH_CMD config get embedding.api_key 2>/dev/null || echo "")
   fi
   if [ -z "$CONFIG_API_KEY" ]; then

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1212,10 +1212,9 @@ def config_get(key: str) -> None:
 @click.option("--resolved", "mode", flag_value="resolved", default=True, help="Show fully resolved config (default).")
 @click.option("--global", "mode", flag_value="global", help="Show global config file only.")
 @click.option("--project", "mode", flag_value="project", help="Show project config file only.")
-def config_list(mode: str) -> None:
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+def config_list(mode: str, json_output: bool) -> None:
     """Show configuration."""
-    import tomli_w
-
     if mode == "global":
         data = load_config_file(GLOBAL_CONFIG_PATH)
         label = f"Global ({GLOBAL_CONFIG_PATH})"
@@ -1226,6 +1225,12 @@ def config_list(mode: str) -> None:
         cfg = resolve_config()
         data = config_to_dict(cfg)
         label = "Resolved (all sources merged)"
+
+    if json_output:
+        click.echo(json.dumps(data, ensure_ascii=False))
+        return
+
+    import tomli_w
 
     click.echo(f"# {label}\n")
     if data:

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -66,6 +66,10 @@ def test_claude_session_start_recent_memory_skips_empty_sessions(tmp_path: Path)
     fake_memsearch = fake_bin / "memsearch"
     fake_memsearch.write_text(
         """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"","api_key":""},"milvus":{"uri":"~/.memsearch/milvus.db"}}'
+  exit 0
+fi
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     embedding.provider) echo "onnx" ;;
@@ -131,6 +135,10 @@ def test_claude_session_start_uv_tool_upgrade_hint_preserves_extras(tmp_path: Pa
     fake_memsearch = uv_tool_bin / "memsearch"
     fake_memsearch.write_text(
         """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"voyage","model":"voyage-3-lite","api_key":""},"milvus":{"uri":"http://localhost:19530"}}'
+  exit 0
+fi
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     embedding.provider) echo "voyage" ;;
@@ -184,6 +192,140 @@ echo '{"info":{"version":"0.4.13"}}'
     assert "uv tool install -U 'memsearch[onnx]'" not in status
 
 
+def test_claude_session_start_reads_resolved_config_once(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    call_log = tmp_path / "memsearch-calls.txt"
+    home.mkdir()
+    fake_bin.mkdir()
+    memsearch_dir.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"voyage","model":"voyage-3-lite","api_key":"configured-key"},"milvus":{"uri":"http://localhost:19530"}}'
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.15"
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text("""#!/usr/bin/env bash\necho '{"info":{"version":"0.4.15"}}'\n""", encoding="utf-8")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+        "MEMSEARCH_CALL_LOG": str(call_log),
+        "VOYAGE_API_KEY": "",
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "embedding: voyage/voyage-3-lite" in status
+    assert "ERROR: VOYAGE_API_KEY not set" not in status
+    assert calls.count("config list --resolved --json-output") == 1
+    assert not any(call.startswith("config get ") for call in calls)
+    assert not any(call.startswith("skills status ") for call in calls)
+
+
+def test_claude_session_start_falls_back_for_older_cli(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    call_log = tmp_path / "memsearch-calls.txt"
+    home.mkdir()
+    fake_bin.mkdir()
+    memsearch_dir.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+
+    fake_memsearch = fake_bin / "memsearch"
+    fake_memsearch.write_text(
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  exit 2
+fi
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo "voyage" ;;
+    embedding.model) echo "voyage-3-lite" ;;
+    embedding.api_key) echo "configured-key" ;;
+    milvus.uri) echo "http://localhost:19530" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.4.14"
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_memsearch.chmod(0o755)
+
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text("""#!/usr/bin/env bash\necho '{"info":{"version":"0.4.14"}}'\n""", encoding="utf-8")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+        "MEMSEARCH_CALL_LOG": str(call_log),
+        "VOYAGE_API_KEY": "",
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "embedding: voyage/voyage-3-lite" in status
+    assert "ERROR: VOYAGE_API_KEY not set" not in status
+    assert calls.count("config list --resolved --json-output") == 1
+    assert "config get embedding.provider" in calls
+    assert "config get embedding.model" in calls
+    assert "config get milvus.uri" in calls
+    assert "config get embedding.api_key" in calls
+
+
 def test_session_start_upgrade_hints_do_not_clobber_extras() -> None:
     for script in (
         Path("plugins/claude-code/hooks/session-start.sh"),
@@ -234,6 +376,10 @@ def test_session_start_warns_when_index_state_is_unhealthy(tmp_path: Path) -> No
         fake_memsearch = fake_bin / "memsearch"
         fake_memsearch.write_text(
             """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"","api_key":""},"milvus":{"uri":"http://localhost:19530"}}'
+  exit 0
+fi
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     embedding.provider) echo "onnx" ;;
@@ -294,10 +440,15 @@ def test_session_start_shows_skill_candidate_hint(tmp_path: Path) -> None:
         home.mkdir(parents=True)
         fake_bin.mkdir()
         memsearch_dir.mkdir()
+        (memsearch_dir / "skill-candidates").mkdir()
 
         fake_memsearch = fake_bin / "memsearch"
         fake_memsearch.write_text(
             f"""#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{{"embedding":{{"provider":"onnx","model":"","api_key":""}},"milvus":{{"uri":"http://localhost:19530"}}}}'
+  exit 0
+fi
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     embedding.provider) echo "onnx" ;;

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from click.testing import CliRunner
 
 from memsearch import cli as cli_module
@@ -149,3 +151,21 @@ def test_config_get_prints_lowercase_booleans(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert result.output.strip() == "false"
+
+
+def test_config_list_json_output_preserves_config_types(monkeypatch) -> None:
+    cfg = MemSearchConfig()
+    cfg.embedding.provider = "onnx"
+    cfg.embedding.batch_size = 32
+    cfg.indexing.ignore_files = [".gitignore"]
+    cfg.plugins.claude_code.summarize.enabled = False
+    monkeypatch.setattr(cli_module, "resolve_config", lambda: cfg)
+
+    result = CliRunner().invoke(cli, ["config", "list", "--resolved", "--json-output"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["embedding"]["provider"] == "onnx"
+    assert data["embedding"]["batch_size"] == 32
+    assert data["indexing"]["ignore_files"] == [".gitignore"]
+    assert data["plugins"]["claude-code"]["summarize"]["enabled"] is False


### PR DESCRIPTION
## Summary

- add JSON output to `memsearch config list` for typed, script-friendly configuration snapshots
- load resolved SessionStart configuration in one CLI invocation while retaining a compatibility fallback for older releases
- avoid an unnecessary status subprocess when no skill candidates directory exists
- update CLI and plugin documentation for the new behavior

## Validation

- `uv run python -m pytest` — 292 passed
- focused Ruff checks passed
- hook shell syntax checks passed
- `uv run mkdocs build --strict` passed
- real interactive plugin E2E passed: capture, markdown write, successful index, and exact recall from a fresh session
- isolated benchmark median: 2.643s to 1.273s
- benchmark with the update request enabled: 3.650s to 1.855s

Fixes #632