### PR TITLE
Bump versions for 0.4.16 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.15"
+version = "0.4.16"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.15"
+version = "0.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- bump the Python package and primary plugin metadata to 0.4.16
- bump the OpenClaw package to 0.3.15
- retain the pending OpenCode package version at 0.3.13 for publication after merge

## Validation

- `uv lock --check`
- `uv run python -m pytest` — 292 passed
- clean-worktree wheel and source distribution build
- OpenCode npm package dry run
- OpenClaw package dry run