### PR TITLE
Add Atlas Cloud LLM provider shortcut

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 
 from .config import (
+    ATLASCLOUD_DEFAULT_LLM_MODEL,
     GLOBAL_CONFIG_PATH,
     PROJECT_CONFIG_PATH,
     ConfigEnvVarError,
@@ -1051,12 +1052,13 @@ def config_init(project: bool) -> None:
     click.echo("  Plugin summarization uses plugins.<platform>.summarize.model.")
     _llm_defaults = {
         "openai": "gpt-5-mini",
+        "atlascloud": ATLASCLOUD_DEFAULT_LLM_MODEL,
         "anthropic": "claude-sonnet-4-6",
         "gemini": "gemini-3-flash-preview",
     }
     result["llm"] = {}
     result["llm"]["provider"] = click.prompt(
-        "  Provider (empty/openai/anthropic/gemini)",
+        "  Provider (empty/openai/anthropic/gemini/atlascloud)",
         default=current.llm.provider,
     )
     _llm_provider = result["llm"]["provider"]

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -1,8 +1,9 @@
 """Memory compact — compress and summarize chunks using an LLM.
 
-Supports OpenAI (default), Anthropic, and Gemini as LLM backends.
+Supports OpenAI (default), OpenAI-compatible, Anthropic, Gemini, and Atlas Cloud as LLM backends.
 API keys are read from environment variables:
     OPENAI_API_KEY / OPENAI_BASE_URL
+    ATLASCLOUD_API_KEY / ATLAS_CLOUD_API_KEY
     ANTHROPIC_API_KEY
     GOOGLE_API_KEY
 """
@@ -12,7 +13,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from .config import resolve_env_ref
+from .config import resolve_env_ref, resolve_llm_provider_settings
 
 COMPACT_PROMPT = """\
 You are a knowledge compression assistant. Given the following chunks of text \
@@ -42,7 +43,8 @@ async def compact_chunks(
     chunks:
         List of chunk dicts (must contain ``"content"`` key).
     llm_provider:
-        One of ``"openai"``, ``"anthropic"``, ``"gemini"``.
+        One of ``"openai"``, ``"openai-compatible"``, ``"anthropic"``,
+        ``"gemini"``, ``"atlascloud"``, ``"atlas-cloud"``, or ``"atlas"``.
     model:
         Override the default model for the provider.
     prompt_template:
@@ -50,10 +52,10 @@ async def compact_chunks(
         Defaults to the built-in ``COMPACT_PROMPT``.
     base_url:
         Custom base URL for OpenAI-compatible API endpoints.  Only used
-        when *llm_provider* is ``"openai"``.
+        when *llm_provider* uses an OpenAI-compatible route.
     api_key:
-        API key for the LLM provider.  Only used when *llm_provider* is
-        ``"openai"``.
+        API key for the LLM provider.  Only used when *llm_provider* uses an
+        OpenAI-compatible route.
 
     Returns
     -------
@@ -68,14 +70,20 @@ async def compact_chunks(
         raise ValueError("prompt_template must include the {chunks} placeholder")
     prompt = template.format(chunks=combined)
 
-    if llm_provider == "openai":
+    llm_provider, model, base_url, api_key = resolve_llm_provider_settings(llm_provider, model, base_url, api_key)
+    provider = "openai" if llm_provider == "openai-compatible" else llm_provider
+
+    if provider == "openai":
         return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
-    elif llm_provider == "anthropic":
+    elif provider == "anthropic":
         return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
-    elif llm_provider == "gemini":
+    elif provider == "gemini":
         return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
     else:
-        raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
+        raise ValueError(
+            f"Unknown LLM provider {llm_provider!r}. "
+            "Available: openai, openai-compatible, anthropic, gemini, atlascloud"
+        )
 
 
 async def summarize_text(
@@ -87,6 +95,7 @@ async def summarize_text(
     api_key: str | None = None,
 ) -> str:
     """Summarize preformatted text with a memsearch-managed LLM provider."""
+    llm_provider, model, base_url, api_key = resolve_llm_provider_settings(llm_provider, model, base_url, api_key)
     provider = "openai" if llm_provider == "openai-compatible" else llm_provider
     if provider == "openai":
         return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -249,6 +249,16 @@ _PLUGIN_FIELD_TO_KEY = {
 
 
 _ENV_PREFIX = "env:"
+ATLASCLOUD_DEFAULT_LLM_BASE_URL = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_DEFAULT_LLM_MODEL = "qwen/qwen3.5-flash"
+ATLASCLOUD_LLM_PROVIDER_ALIASES = frozenset({"atlascloud", "atlas-cloud", "atlas"})
+ATLASCLOUD_API_KEY_ENV_VARS = ("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+ATLASCLOUD_BASE_URL_ENV_VARS = (
+    "ATLASCLOUD_API_BASE",
+    "ATLASCLOUD_BASE_URL",
+    "ATLAS_CLOUD_API_BASE",
+    "ATLAS_CLOUD_BASE_URL",
+)
 
 
 class ConfigEnvVarError(KeyError):
@@ -275,6 +285,48 @@ def resolve_env_ref(value: str) -> str:
     if env_val is None:
         raise ConfigEnvVarError(f"Environment variable {var_name!r} referenced in config (via {value!r}) is not set")
     return env_val
+
+
+def is_atlascloud_llm_provider(provider: str | None) -> bool:
+    """Return whether *provider* names the built-in Atlas Cloud LLM shortcut."""
+    return (provider or "").strip().lower() in ATLASCLOUD_LLM_PROVIDER_ALIASES
+
+
+def _first_set_env(names: tuple[str, ...]) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return ""
+
+
+def _first_set_env_ref(names: tuple[str, ...]) -> str:
+    for name in names:
+        if os.environ.get(name):
+            return f"{_ENV_PREFIX}{name}"
+    return f"{_ENV_PREFIX}{names[0]}"
+
+
+def resolve_llm_provider_settings(
+    provider: str,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve built-in LLM provider shortcuts to concrete provider settings.
+
+    Atlas Cloud exposes an OpenAI-compatible LLM endpoint, so the shortcut keeps
+    the existing OpenAI-compatible code path while supplying Atlas defaults.
+    """
+    normalized = (provider or "").strip()
+    if not is_atlascloud_llm_provider(normalized):
+        return normalized, model, base_url, api_key
+    return (
+        "openai-compatible",
+        model or ATLASCLOUD_DEFAULT_LLM_MODEL,
+        base_url or _first_set_env(ATLASCLOUD_BASE_URL_ENV_VARS) or ATLASCLOUD_DEFAULT_LLM_BASE_URL,
+        api_key or _first_set_env_ref(ATLASCLOUD_API_KEY_ENV_VARS),
+    )
 
 
 def _resolve_env_refs_in_dict(d: dict[str, Any], path: tuple[str, ...] = ()) -> dict[str, Any]:

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -10,7 +10,7 @@ import re
 import shlex
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
@@ -22,7 +22,9 @@ from .config import (
     MemSearchConfig,
     PluginMaintenanceTaskConfig,
     config_to_dict,
+    is_atlascloud_llm_provider,
     resolve_env_ref,
+    resolve_llm_provider_settings,
 )
 from .io import read_utf8_text_replace
 
@@ -284,9 +286,25 @@ def run_task_llm(ctx: TaskContext, prompt: str, cfg: MemSearchConfig) -> str:
 
     provider_cfg = cfg.llm.providers.get(provider_name)
     if provider_cfg is None:
-        raise RuntimeError(f"Unknown LLM provider {provider_name!r}")
+        if is_atlascloud_llm_provider(provider_name):
+            provider_cfg = LLMProviderConfig(type=provider_name)
+        else:
+            raise RuntimeError(f"Unknown LLM provider {provider_name!r}")
     provider_type = provider_cfg.type or provider_name
     model = ctx.task_config.model or provider_cfg.model or None
+    provider_type, model, base_url, api_key = resolve_llm_provider_settings(
+        provider_type,
+        model=model,
+        base_url=provider_cfg.base_url or None,
+        api_key=provider_cfg.api_key or None,
+    )
+    provider_cfg = replace(
+        provider_cfg,
+        type=provider_type,
+        model=model or "",
+        base_url=base_url or "",
+        api_key=api_key or "",
+    )
 
     if provider_type in {"openai", "openai-compatible"}:
         return _run_openai_with_tools(ctx, prompt, provider_type, model, provider_cfg)

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -44,6 +44,34 @@ async def test_compact_chunks_dispatches_to_openai(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_compact_chunks_dispatches_atlascloud_to_openai_compatible(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def fake_openai(prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None) -> str:
+        captured["prompt"] = prompt
+        captured["model"] = model
+        captured["base_url"] = base_url
+        captured["api_key"] = api_key
+        return "atlas-summary"
+
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "atlas-key")
+    monkeypatch.setattr(compact_module, "_compact_openai", fake_openai)
+
+    result = await compact_module.compact_chunks(
+        [{"content": "atlas memory"}],
+        llm_provider="atlascloud",
+    )
+
+    assert result == "atlas-summary"
+    assert captured == {
+        "prompt": compact_module.COMPACT_PROMPT.format(chunks="atlas memory"),
+        "model": "qwen/qwen3.5-flash",
+        "base_url": "https://api.atlascloud.ai/v1",
+        "api_key": "env:ATLAS_CLOUD_API_KEY",
+    }
+
+
+@pytest.mark.asyncio
 async def test_openai_compact_uses_default_temperature(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from memsearch.config import (
     load_config_file,
     resolve_config,
     resolve_env_ref,
+    resolve_llm_provider_settings,
     save_config,
     set_config_value,
 )
@@ -331,6 +332,20 @@ def test_named_llm_provider_config_roundtrip(tmp_path: Path, monkeypatch: pytest
     saved = load_config_file(cfg_path)
     assert saved["llm"]["providers"]["openai"]["model"] == "gpt-test"
     assert saved["llm"]["providers"]["openai"]["api_key"] == "env:OPENAI_API_KEY"
+
+
+def test_atlascloud_llm_provider_shortcut_uses_openai_compatible_defaults(monkeypatch: pytest.MonkeyPatch):
+    """Atlas Cloud shortcuts should resolve to the existing OpenAI-compatible route."""
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "atlas-key")
+    monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://atlas.example/v1")
+
+    provider, model, base_url, api_key = resolve_llm_provider_settings("atlas-cloud")
+
+    assert provider == "openai-compatible"
+    assert model == "qwen/qwen3.5-flash"
+    assert base_url == "https://atlas.example/v1"
+    assert api_key == "env:ATLAS_CLOUD_API_KEY"
 
 
 def test_plugin_summarize_model_empty_preserves_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -37,6 +37,43 @@ def test_maintenance_routes_gemini_provider_to_tool_runner(tmp_path: Path, monke
     assert captured == {"model": "gemini-test", "provider_type": "gemini"}
 
 
+def test_maintenance_routes_atlascloud_shortcut_to_openai_compatible_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("- User discussed Atlas Cloud maintenance.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "atlascloud"
+
+    captured = {}
+
+    def fake_openai(ctx, prompt: str, provider_type: str, model: str | None, provider_cfg) -> str:
+        captured["model"] = model
+        captured["provider_type"] = provider_type
+        captured["config_type"] = provider_cfg.type
+        captured["base_url"] = provider_cfg.base_url
+        captured["api_key"] = provider_cfg.api_key
+        return json.dumps({"action": "none", "reason": "ok"})
+
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+    monkeypatch.setattr("memsearch.maintenance._run_openai_with_tools", fake_openai)
+
+    results = run_due_tasks(platform="codex", project_dir=project, cfg=cfg)
+
+    assert results[0].action == "none"
+    assert captured == {
+        "model": "qwen/qwen3.5-flash",
+        "provider_type": "openai-compatible",
+        "config_type": "openai-compatible",
+        "base_url": "https://api.atlascloud.ai/v1",
+        "api_key": "env:ATLASCLOUD_API_KEY",
+    }
+
+
 def test_read_recent_journals_replaces_invalid_utf8_bytes(tmp_path: Path) -> None:
     memory = tmp_path / "memory"
     memory.mkdir()


### PR DESCRIPTION
## Summary

- Add an Atlas Cloud LLM provider shortcut (`atlascloud`, `atlas-cloud`, `atlas`) that resolves to the existing OpenAI-compatible route.
- Default the shortcut to `https://api.atlascloud.ai/v1`, `qwen/qwen3.5-flash`, and `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY` env var references.
- Wire the shortcut into compact summarization, maintenance task LLM routing, and `memsearch config init` model defaults.
- Add focused tests for config resolution, compact dispatch, and maintenance routing.

No README/docs/logo changes.

## Validation

- `uv run --python /Users/zby/.local/bin/python3.11 --group dev pytest tests/test_config.py tests/test_compact.py tests/test_maintenance.py` (66 passed)
- `uv run --python /Users/zby/.local/bin/python3.11 --group dev ruff check src/memsearch/config.py src/memsearch/compact.py src/memsearch/maintenance.py src/memsearch/cli.py tests/test_config.py tests/test_compact.py tests/test_maintenance.py`
- `PYTHONPYCACHEPREFIX=/tmp/memsearch_pycache python3 -m compileall src/memsearch/config.py src/memsearch/compact.py src/memsearch/maintenance.py src/memsearch/cli.py tests/test_config.py tests/test_compact.py tests/test_maintenance.py`
- `git diff --check`
- Atlas Cloud live model catalog returned 436 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.
