### PR TITLE
fix(opencode): honor MEMSEARCH_DIR for storage scope

### DIFF
--- a/plugins/claude-code/transcript.py
+++ b/plugins/claude-code/transcript.py
@@ -229,13 +229,10 @@ def _summarize_tool_input(name: str, tool_input: dict) -> str:
 
 
 if __name__ == "__main__":
+    import argparse
     import sys
 
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="View conversation turns from a Claude Code JSONL transcript."
-    )
+    parser = argparse.ArgumentParser(description="View conversation turns from a Claude Code JSONL transcript.")
     parser.add_argument("jsonl_path", help="Path to the JSONL transcript file.")
     parser.add_argument("--turn", "-t", default=None, help="Target turn UUID (prefix match).")
     parser.add_argument("--context", "-c", default=3, type=int, help="Number of turns before/after target.")

--- a/plugins/opencode/index.test.ts
+++ b/plugins/opencode/index.test.ts
@@ -1,28 +1,35 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import test from "node:test";
 
 import {
   getRecentMemories,
   isDailyJournalFile,
-  mergeSystemMemoryContext,
   MEMSEARCH_SYSTEM_MARKER,
+  mergeSystemMemoryContext,
+  resolveScope,
 } from "./index.ts";
 
 test("appends memory context when no system entry exists yet", () => {
-  const result = mergeSystemMemoryContext(undefined, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  const result = mergeSystemMemoryContext(
+    undefined,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
   assert.deepEqual(result, [`${MEMSEARCH_SYSTEM_MARKER} ctx-a`]);
 });
 
 test("folds memory context into the first entry without growing the array", () => {
   const result = mergeSystemMemoryContext(
     ["You are a helpful assistant."],
-    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
   );
   assert.equal(result.length, 1);
-  assert.equal(result[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
+  assert.equal(
+    result[0],
+    `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
 });
 
 test("repeated calls with the same context stay idempotent", () => {
@@ -41,22 +48,75 @@ test("repeated calls with the same context stay idempotent", () => {
 
 test("repeated calls with updated context replace the previous block", () => {
   const base = ["You are a helpful assistant."];
-  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
-  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  const first = mergeSystemMemoryContext(
+    base,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
+  const second = mergeSystemMemoryContext(
+    first,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
 
   assert.equal(second.length, 1);
-  assert.equal(second[0], `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  assert.equal(
+    second[0],
+    `You are a helpful assistant.\n\n${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
   assert.ok(!second[0].includes("ctx-a"));
 });
 
 test("does not disturb additional system entries beyond the first", () => {
   const base = ["Base prompt.", "Second unrelated system entry."];
-  const first = mergeSystemMemoryContext(base, `${MEMSEARCH_SYSTEM_MARKER} ctx-a`);
-  const second = mergeSystemMemoryContext(first, `${MEMSEARCH_SYSTEM_MARKER} ctx-b`);
+  const first = mergeSystemMemoryContext(
+    base,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-a`,
+  );
+  const second = mergeSystemMemoryContext(
+    first,
+    `${MEMSEARCH_SYSTEM_MARKER} ctx-b`,
+  );
 
   assert.equal(second.length, 2);
   assert.equal(second[1], "Second unrelated system entry.");
   assert.ok(!second[0].includes("ctx-a"));
+});
+
+test("resolveScope defaults to per-project isolation when MEMSEARCH_DIR is unset", () => {
+  const prev = process.env.MEMSEARCH_DIR;
+  delete process.env.MEMSEARCH_DIR;
+  try {
+    const scope = resolveScope("/tmp/my-project");
+    assert.equal(scope.memsearchDir, join("/tmp/my-project", ".memsearch"));
+    assert.equal(
+      scope.memoryDir,
+      join("/tmp/my-project", ".memsearch", "memory"),
+    );
+    // Collection derives from the project dir in per-project scope.
+    assert.match(scope.collection, /^ms_.+_[0-9a-f]{8}$/);
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR;
+    else process.env.MEMSEARCH_DIR = prev;
+  }
+});
+
+test("resolveScope honors MEMSEARCH_DIR for shared/global scope", () => {
+  const prev = process.env.MEMSEARCH_DIR;
+  const shared = mkdtempSync(join(tmpdir(), "memsearch-shared-"));
+  process.env.MEMSEARCH_DIR = shared;
+  try {
+    const a = resolveScope("/tmp/project-a");
+    const b = resolveScope("/tmp/project-b");
+    // Shared storage dir regardless of the working directory.
+    assert.equal(a.memsearchDir, shared);
+    assert.equal(b.memsearchDir, shared);
+    assert.equal(a.memoryDir, join(shared, "memory"));
+    // Same collection across projects — global scope is shared.
+    assert.equal(a.collection, b.collection);
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR;
+    else process.env.MEMSEARCH_DIR = prev;
+    rmSync(shared, { recursive: true, force: true });
+  }
 });
 
 test("recent memories only use dated daily journals", () => {
@@ -69,12 +129,12 @@ test("recent memories only use dated daily journals", () => {
     writeFileSync(
       join(dir, "2026-07-12.md"),
       "# 2026-07-12\n\n## Session 09:00\n\n### 09:00\n- Daily journal content.\n",
-      "utf-8"
+      "utf-8",
     );
     writeFileSync(
       join(dir, "zzz-scratch.md"),
       "# Scratch\n\n## Session 10:00\n\n### 10:00\n- Scratch content should not displace daily journals.\n",
-      "utf-8"
+      "utf-8",
     );
 
     const context = getRecentMemories(dir);

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -23,7 +23,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_DIR = dirname(realpathSync(fileURLToPath(import.meta.url)));
@@ -61,13 +61,47 @@ function detectMemsearchCmd(): string {
 function deriveCollectionName(projectDir: string): string {
   const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
   try {
-    return execSync(`bash "${script}" "${projectDir}"`, {
+    const r = spawnSync("bash", [script, projectDir], {
       encoding: "utf-8",
       timeout: 5000,
-    }).trim();
+    });
+    if (r.status === 0 && r.stdout?.trim()) return r.stdout.trim();
+    return "ms_opencode_default";
   } catch {
     return "ms_opencode_default";
   }
+}
+
+/**
+ * Resolve the memsearch storage scope for a working directory.
+ *
+ * When MEMSEARCH_DIR is set, use it as the shared storage dir and derive the
+ * collection from it (global scope, shared across projects) — matching the
+ * claude-code/codex `common.sh` behavior. Otherwise fall back to per-project
+ * isolation under `<projectDir>/.memsearch`.
+ */
+// exported for unit-testing only
+export function resolveScope(dir: string): {
+  memsearchDir: string;
+  memoryDir: string;
+  collection: string;
+} {
+  const explicit = process.env.MEMSEARCH_DIR?.trim();
+  if (explicit) {
+    // Resolve to absolute path so relative values behave consistently regardless of cwd.
+    const memsearchDir = resolve(explicit);
+    return {
+      memsearchDir,
+      memoryDir: join(memsearchDir, "memory"),
+      collection: deriveCollectionName(memsearchDir),
+    };
+  }
+  const memsearchDir = join(dir, ".memsearch");
+  return {
+    memsearchDir,
+    memoryDir: join(memsearchDir, "memory"),
+    collection: deriveCollectionName(dir),
+  };
 }
 
 /**
@@ -185,9 +219,9 @@ export function mergeSystemMemoryContext(
 function startCaptureDaemon(
   projectDir: string,
   collectionName: string,
-  memsearchCmd: string
+  memsearchCmd: string,
+  memsearchDir: string
 ): void {
-  const stateDir = join(projectDir, ".memsearch");
   const pidFile = join(projectDir, ".memsearch", ".capture.pid");
   const daemonScript = join(PLUGIN_DIR, "scripts", "capture-daemon.py");
 
@@ -209,7 +243,8 @@ function startCaptureDaemon(
   }
 
   try {
-    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(memsearchDir, { recursive: true });
+    mkdirSync(join(projectDir, ".memsearch"), { recursive: true });
     const child = spawn(
       "python3",
       [
@@ -218,6 +253,8 @@ function startCaptureDaemon(
         collectionName,
         "--memsearch-cmd",
         memsearchCmd,
+        "--memsearch-dir",
+        memsearchDir,
         "--poll-interval",
         "10",
         "--parent-pid",
@@ -274,9 +311,12 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
   // worktree can be "/" for global projects — use directory instead
   const projectDir = (worktree && worktree !== "/") ? worktree : (directory || process.cwd());
   const memsearchCmd = detectMemsearchCmd();
-  const collectionName = deriveCollectionName(projectDir);
-  const memsearchDir = join(projectDir, ".memsearch");
-  const memoryDir = join(memsearchDir, "memory");
+  // Honor MEMSEARCH_DIR (shared/global scope) when set, else per-project scope.
+  const {
+    memsearchDir,
+    memoryDir,
+    collection: collectionName,
+  } = resolveScope(projectDir);
   const home = process.env.HOME || "~";
 
   // Skip capture/recall in child processes to prevent recursion
@@ -310,7 +350,7 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
 
   // Start capture daemon for auto-capture
   if (autoCapture) {
-    startCaptureDaemon(projectDir, collectionName, memsearchCmd);
+    startCaptureDaemon(projectDir, collectionName, memsearchCmd, memsearchDir);
     wakeMaintenance(projectDir, memsearchDir);
   }
 
@@ -330,10 +370,11 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         async execute(args, context) {
           // Use context.directory for the actual session directory (may differ from init)
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          const memDir = join(dir, ".memsearch", "memory");
+          const scope = dir !== projectDir ? resolveScope(dir) : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
+          const memDir = scope.memoryDir;
           // Ensure daemon is running for current directory
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           const topK = args.top_k || 5;
           try {
             const result = spawnSync(
@@ -362,8 +403,9 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          const scope = dir !== projectDir ? resolveScope(dir) : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
             const result = spawnSync(
               "bash",
@@ -396,8 +438,9 @@ const MemsearchPlugin: Plugin = async ({ project, directory, worktree }) => {
         },
         async execute(args, context) {
           const dir = context?.directory || projectDir;
-          const col = dir !== projectDir ? deriveCollectionName(dir) : collectionName;
-          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd);
+          const scope = dir !== projectDir ? resolveScope(dir) : { memsearchDir, memoryDir, collection: collectionName };
+          const col = scope.collection;
+          if (autoCapture) startCaptureDaemon(dir, col, memsearchCmd, scope.memsearchDir);
           try {
             const scriptPath = join(PLUGIN_DIR, "scripts", "parse-transcript.py");
             const scriptArgs = [

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -459,7 +459,7 @@ def summarize_with_llm(
     return None
 
 
-def wake_maintenance(project_dir: str) -> None:
+def wake_maintenance(project_dir: str, memsearch_dir: str) -> None:
     """Start maintenance in a hook-disabled child environment."""
     runner = Path(__file__).resolve().parent / "maintenance-runner.py"
     subprocess.Popen(
@@ -471,7 +471,7 @@ def wake_maintenance(project_dir: str) -> None:
             "--project-dir",
             project_dir,
             "--memsearch-dir",
-            os.path.join(project_dir, ".memsearch"),
+            memsearch_dir,
         ],
         env={**os.environ, "MEMSEARCH_NO_WATCH": "1", "MEMSEARCH_DISABLE": "1"},
         stdin=subprocess.DEVNULL,
@@ -711,6 +711,7 @@ def capture_session_turns(
     memsearch_cmd: str,
     db_path: str,
     tail_turn_cache: dict[str, TailTurnObservation] | None = None,
+    project_dir: str = "",
 ) -> bool:
     """Capture all newly completed turns for a single session."""
     state = load_turn_state(turn_db, session_id)
@@ -721,7 +722,8 @@ def capture_session_turns(
 
     after_time = state.last_completed_time if state.last_completed_time > 0 else None
     if after_time is None:
-        legacy_after_time = _load_legacy_last_msg_time(str(Path(memory_dir).resolve().parent.parent))
+        legacy_dir = project_dir or os.path.dirname(os.path.dirname(os.path.abspath(memory_dir)))
+        legacy_after_time = _load_legacy_last_msg_time(legacy_dir)
         if legacy_after_time > 0:
             after_time = legacy_after_time
     after_message_id = state.last_completed_message_id or None
@@ -753,8 +755,8 @@ def capture_session_turns(
         if not capture_exists(memory_dir, session_id, turn.turn_id):
             if not get_plugin_summarize_enabled(memsearch_cmd):
                 continue
-            project_dir = Path(memory_dir).resolve().parent.parent
-            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, project_dir)
+            summary_project_dir = project_dir or os.path.dirname(os.path.dirname(os.path.abspath(memory_dir)))
+            summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, summary_project_dir)
             write_capture(
                 memory_dir,
                 summary if summary else turn_text,
@@ -778,6 +780,7 @@ def main() -> None:
     parser.add_argument("project_dir", help="Project directory")
     parser.add_argument("collection_name", help="Milvus collection name")
     parser.add_argument("--memsearch-cmd", default="memsearch", help="memsearch command")
+    parser.add_argument("--memsearch-dir", default="", help="memsearch storage directory (overrides MEMSEARCH_DIR)")
     parser.add_argument("--poll-interval", type=int, default=10, help="Poll interval in seconds")
     parser.add_argument("--parent-pid", type=int, default=0, help="Exit when this parent process is gone")
     args = parser.parse_args()
@@ -787,7 +790,13 @@ def main() -> None:
         sys.stderr.write(f"OpenCode database not found at {db_path}\n")
         sys.exit(1)
 
-    memory_dir = os.path.join(args.project_dir, ".memsearch", "memory")
+    # Storage keys off memsearch_dir (honoring MEMSEARCH_DIR global scope);
+    # OpenCode session/config lookups still key off the real project_dir.
+    memsearch_dir = (
+        os.path.abspath(args.memsearch_dir) if args.memsearch_dir else os.path.join(args.project_dir, ".memsearch")
+    )
+    memory_dir = os.path.join(memsearch_dir, "memory")
+    # PID file is per-project so each project has its own daemon even when sharing memsearch_dir.
     pid_file = os.path.join(args.project_dir, ".memsearch", ".capture.pid")
 
     os.makedirs(os.path.dirname(pid_file), exist_ok=True)
@@ -803,7 +812,7 @@ def main() -> None:
     signal.signal(signal.SIGINT, cleanup)
 
     small_model = get_small_model(args.project_dir)
-    turn_db = open_turn_db(args.project_dir)
+    turn_db = open_turn_db(memsearch_dir)
     tail_turn_cache: dict[str, TailTurnObservation] = {}
 
     while True:
@@ -826,13 +835,14 @@ def main() -> None:
                         args.memsearch_cmd,
                         db_path,
                         tail_turn_cache,
+                        args.project_dir,
                     )
                     or any_new
                 )
 
             if any_new:
                 os.system(f"{args.memsearch_cmd} index '{memory_dir}' --collection {args.collection_name} &")
-                wake_maintenance(args.project_dir)
+                wake_maintenance(args.project_dir, memsearch_dir)
         except Exception:
             pass
         finally:

--- a/plugins/opencode/scripts/opencode_turns.py
+++ b/plugins/opencode/scripts/opencode_turns.py
@@ -91,14 +91,14 @@ def get_db_path() -> str:
     return default
 
 
-def get_turn_db_path(project_dir: str) -> str:
-    """Return the derived turn metadata database path for a project."""
-    return os.path.join(project_dir, ".memsearch", "opencode-turns.db")
+def get_turn_db_path(memsearch_dir: str) -> str:
+    """Return the sidecar database path inside the resolved memsearch storage dir."""
+    return os.path.join(memsearch_dir, "opencode-turns.db")
 
 
-def open_turn_db(project_dir: str) -> sqlite3.Connection:
+def open_turn_db(memsearch_dir: str) -> sqlite3.Connection:
     """Open the sidecar turn database and ensure its schema exists."""
-    turn_db_path = get_turn_db_path(project_dir)
+    turn_db_path = get_turn_db_path(memsearch_dir)
     Path(turn_db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(turn_db_path, timeout=5)
     conn.row_factory = sqlite3.Row
@@ -139,12 +139,8 @@ def ensure_turn_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS turns_session_index_idx ON turns (session_id, turn_index)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS turns_session_time_idx ON turns (session_id, end_time, turn_id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS turns_session_index_idx ON turns (session_id, turn_index)")
+    conn.execute("CREATE INDEX IF NOT EXISTS turns_session_time_idx ON turns (session_id, end_time, turn_id)")
     conn.commit()
 
 
@@ -160,7 +156,9 @@ def load_turn_state(conn: sqlite3.Connection, session_id: str) -> TurnState:
     ).fetchone()
 
     if row is None:
-        return TurnState(session_id=session_id, last_completed_time=0, last_completed_message_id="", last_completed_turn_id="")
+        return TurnState(
+            session_id=session_id, last_completed_time=0, last_completed_message_id="", last_completed_turn_id=""
+        )
 
     return TurnState(
         session_id=row["session_id"],
@@ -264,9 +262,7 @@ def load_messages(
 
     if after_time is not None:
         if after_message_id:
-            query.append(
-                "AND (time_created > ? OR (time_created = ? AND id > ?))"
-            )
+            query.append("AND (time_created > ? OR (time_created = ? AND id > ?))")
             params.extend([after_time, after_time, after_message_id])
         else:
             query.append("AND time_created > ?")

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -164,7 +164,7 @@ def test_opencode_daemon_wake_maintenance_disables_hooks(tmp_path: Path, monkeyp
     monkeypatch.setenv("MEMSEARCH_NO_WATCH", "0")
     monkeypatch.delenv("MEMSEARCH_DISABLE", raising=False)
 
-    capture_daemon.wake_maintenance(str(project))
+    capture_daemon.wake_maintenance(str(project), str(project / ".memsearch"))
 
     assert captured["cmd"][:4] == ["python3", str(SCRIPT_DIR / "maintenance-runner.py"), "--platform", "opencode"]
     assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
@@ -529,7 +529,7 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     turn = OpenCodeTurn(
         session_id="ses_1",
         turn_id="u1",
@@ -558,13 +558,101 @@ def test_turn_sidecar_persists_state_and_turns(tmp_path: Path) -> None:
     rows = load_session_turn_rows(turn_db, "ses_1")
     state = load_turn_state(turn_db, "ses_1")
 
-    assert get_turn_db_path(str(project_dir)).endswith(".memsearch/opencode-turns.db")
+    assert get_turn_db_path(str(project_dir / ".memsearch")) == str(project_dir / ".memsearch" / "opencode-turns.db")
     assert len(rows) == 1
     assert rows[0]["turn_id"] == "u1"
     assert state.last_completed_turn_id == "u1"
     assert state.last_completed_message_id == "a1"
 
     turn_db.close()
+
+
+def test_turn_db_path_honors_explicit_memsearch_dir(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    shared_dir = tmp_path / "shared" / ".memsearch"
+
+    # With MEMSEARCH_DIR (global scope), the sidecar lives in the shared dir,
+    # not under the project directory.
+    path = get_turn_db_path(str(shared_dir))
+    assert path == str(shared_dir / "opencode-turns.db")
+    assert str(shared_dir) in path
+    assert str(project_dir) not in path
+
+    turn_db = open_turn_db(str(shared_dir))
+    try:
+        assert (shared_dir / "opencode-turns.db").exists()
+        assert not (project_dir / ".memsearch").exists()
+    finally:
+        turn_db.close()
+
+
+def test_wake_maintenance_passes_explicit_memsearch_dir(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    shared = tmp_path / "shared" / ".memsearch"
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+
+        class Process:
+            pass
+
+        return Process()
+
+    monkeypatch.setattr(capture_daemon.subprocess, "Popen", fake_popen)
+
+    capture_daemon.wake_maintenance(str(project), str(shared))
+
+    assert captured["cmd"][captured["cmd"].index("--project-dir") + 1] == str(project)
+    assert captured["cmd"][captured["cmd"].index("--memsearch-dir") + 1] == str(shared)
+
+
+def test_capture_session_turns_uses_explicit_project_dir_for_summarizer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """project_dir kwarg is forwarded to summarize_with_llm (not derived from memory_dir)."""
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    session_id = "ses_explicit_proj"
+    project_dir = tmp_path / "real-project"
+    shared_memsearch = tmp_path / "shared" / ".memsearch"
+    memory_dir = shared_memsearch / "memory"
+    memory_dir.mkdir(parents=True)
+    project_dir.mkdir()
+
+    received_project_dir: list = []
+
+    def fake_summarize(turn_text, small_model, memsearch_cmd, proj_dir):
+        received_project_dir.append(proj_dir)
+        return None
+
+    monkeypatch.setattr(capture_daemon, "summarize_with_llm", fake_summarize)
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda _: True)
+
+    _insert_message(conn, "u1", session_id, 100, "user", text="Question")
+    _insert_message(conn, "a1", session_id, 200, "assistant", parent_id="u1", finish="stop", text="Answer")
+    _insert_message(conn, "u2", session_id, 300, "user", text="Next question")
+    conn.commit()
+
+    turn_db = open_turn_db(str(shared_memsearch))
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+        None,  # tail_turn_cache
+        str(project_dir),
+    )
+
+    assert len(received_project_dir) == 1
+    assert received_project_dir[0] == str(project_dir)
+
+    turn_db.close()
+    conn.close()
 
 
 def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
@@ -586,7 +674,7 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -664,7 +752,7 @@ def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
             raise RuntimeError("simulated crash before cursor persisted")
         return original_save_turn_state(*args, **kwargs)
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     monkeypatch.setattr(capture_daemon, "save_turn_state", flaky_save_turn_state)
 
     with suppress(RuntimeError):
@@ -721,7 +809,7 @@ def test_capture_session_turns_waits_for_tail_turn_stability_before_capture(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -786,7 +874,7 @@ def test_capture_session_turns_resets_tail_stability_when_content_changes(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Draft answer")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -867,7 +955,7 @@ def test_capture_session_turns_closes_prior_turn_as_soon_as_next_user_arrives(
     _insert_message(conn, "a1", session_id, 110, "assistant", parent_id="u1", finish="stop", text="Answer one")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -936,7 +1024,7 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
 
     monkeypatch.setattr(capture_daemon, "summarize_with_llm", lambda *args, **kwargs: None)
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -945,6 +1033,7 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
         "",
         "memsearch",
         str(db_path),
+        project_dir=str(project_dir),
     )
 
     rows = load_session_turn_rows(turn_db, session_id)
@@ -986,7 +1075,7 @@ def test_capture_session_turns_does_not_advance_sidecar_when_markdown_write_fail
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
     )
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
 
     with suppress(OSError):
         capture_daemon.capture_session_turns(
@@ -1036,7 +1125,7 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
     _insert_message(conn, "u2", session_id, 200, "user", text="Follow-up")
     conn.commit()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,
@@ -1053,7 +1142,7 @@ def test_capture_session_turns_skips_summarizer_when_anchor_already_exists(
 
     turn_db.close()
 
-    turn_db = open_turn_db(str(project_dir))
+    turn_db = open_turn_db(str(project_dir / ".memsearch"))
     capture_daemon.capture_session_turns(
         conn,
         turn_db,


### PR DESCRIPTION
Closes #627

## Summary

- `resolveScope()` resolves storage dir and collection in one place from `MEMSEARCH_DIR` env or project dir
- Capture daemon receives `--memsearch-dir` and forwards through maintenance/summarize flows
- PID file stays per-project so each project has its own daemon even when sharing `MEMSEARCH_DIR`
- Legacy upgrade checkpoint (`_load_legacy_last_msg_time`) reads from `project_dir/.memsearch` for compatibility with existing installs

## Test plan

- [ ] `uv run python -m pytest tests/test_opencode_turns.py` — all tests pass
- [ ] `bun test plugins/opencode/index.test.ts` — `resolveScope` per-project and shared-scope tests pass
- [ ] Set `MEMSEARCH_DIR=~/.memsearch`, run an OpenCode session — storage writes to shared dir
- [ ] Two projects sharing `MEMSEARCH_DIR` each have their own daemon PID file and separate collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)