### PR TITLE
Cache the PyPI version check and resolve version from dist-info

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -115,6 +115,48 @@ _json_encode_str() {
   return 0
 }
 
+# Resolve the installed memsearch version from its dist-info directory name.
+# Callers already spend one CLI start reading config; asking the CLI for
+# `--version` spawns a second Python interpreter (~0.3s warm, several seconds
+# cold) purely to render a status string. Prints nothing when no dist-info is
+# discoverable (uvx, editable installs) so callers can fall back to the CLI.
+_installed_version_from_dist_info() {
+  local bin real candidate
+  bin=$(command -v memsearch 2>/dev/null) || return 0
+  [ -n "$bin" ] || return 0
+  real=$(readlink -f "$bin" 2>/dev/null || echo "$bin")
+  for candidate in "${real%/bin/memsearch}"/lib/python*/site-packages/memsearch-*.dist-info; do
+    [ -d "$candidate" ] || continue
+    candidate=${candidate##*/memsearch-}
+    candidate=${candidate%.dist-info}
+    # Require a version-shaped string so a sibling distribution whose name
+    # starts with "memsearch-" cannot be mistaken for the package itself.
+    case "$candidate" in
+      [0-9]*) printf '%s' "$candidate"; return 0 ;;
+    esac
+  done
+}
+
+# Latest memsearch version on PyPI, cached for 24h. Keeps the update hint
+# current without making every session start wait on a network round trip: an
+# unreachable PyPI otherwise costs the full curl timeout on every start.
+# Prints nothing when the lookup fails.
+_pypi_latest_version() {
+  local cache="$HOME/.memsearch/.pypi-latest" latest="" json
+  if [ -n "$(find "$cache" -mtime -1 2>/dev/null)" ]; then
+    latest=$(cat "$cache" 2>/dev/null || true)
+  fi
+  if [ -z "$latest" ]; then
+    json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
+    latest=$(_json_val "$json" "info.version" "")
+    if [ -n "$latest" ]; then
+      mkdir -p "$(dirname "$cache")" 2>/dev/null || true
+      printf '%s' "$latest" > "$cache" 2>/dev/null || true
+    fi
+  fi
+  printf '%s' "$latest"
+}
+
 # Return a concise user-facing warning when the persisted index state says
 # search may be stale. Detailed diagnosis stays in the memory-config skill.
 index_state_warning() {

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -142,18 +142,18 @@ _installed_version_from_dist_info() {
 # unreachable PyPI otherwise costs the full curl timeout on every start.
 # Prints nothing when the lookup fails.
 _pypi_latest_version() {
-  local cache="$HOME/.memsearch/.pypi-latest" latest="" json
+  local cache="$HOME/.memsearch/.pypi-latest" latest json
+  # A cache file younger than a day is authoritative even when it is empty: an
+  # empty file records a lookup that failed, so an offline machine stops
+  # re-paying the curl timeout on every session start.
   if [ -n "$(find "$cache" -mtime -1 2>/dev/null)" ]; then
-    latest=$(cat "$cache" 2>/dev/null || true)
+    cat "$cache" 2>/dev/null || true
+    return 0
   fi
-  if [ -z "$latest" ]; then
-    json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
-    latest=$(_json_val "$json" "info.version" "")
-    if [ -n "$latest" ]; then
-      mkdir -p "$(dirname "$cache")" 2>/dev/null || true
-      printf '%s' "$latest" > "$cache" 2>/dev/null || true
-    fi
-  fi
+  json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
+  latest=$(_json_val "$json" "info.version" "")
+  mkdir -p "$(dirname "$cache")" 2>/dev/null || true
+  printf '%s' "$latest" > "$cache" 2>/dev/null || true
   printf '%s' "$latest"
 }
 

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -115,6 +115,26 @@ _json_encode_str() {
   return 0
 }
 
+# _resolve_symlinks <path>
+# Follow a symlink chain to its target without `readlink -f`, which BSD
+# readlink (macOS) does not support. Relative link targets resolve against
+# the link's directory; a hop cap guards against cycles. The directory part
+# is canonicalized with `pwd -P` so `..` segments and directory symlinks
+# collapse the way GNU `readlink -f` would collapse them.
+_resolve_symlinks() {
+  local target="$1" link dir hops=0
+  while [ -L "$target" ] && [ "$hops" -lt 40 ]; do
+    link=$(readlink "$target" 2>/dev/null) || break
+    case "$link" in
+      /*) target="$link" ;;
+      *) target="$(dirname "$target")/$link" ;;
+    esac
+    hops=$((hops + 1))
+  done
+  dir=$(cd "$(dirname "$target")" 2>/dev/null && pwd -P) || { printf '%s' "$target"; return 0; }
+  printf '%s/%s' "$dir" "${target##*/}"
+}
+
 # Resolve the installed memsearch version from its dist-info directory name.
 # Callers already spend one CLI start reading config; asking the CLI for
 # `--version` spawns a second Python interpreter (~0.3s warm, several seconds
@@ -124,7 +144,7 @@ _installed_version_from_dist_info() {
   local bin real candidate
   bin=$(command -v memsearch 2>/dev/null) || return 0
   [ -n "$bin" ] || return 0
-  real=$(readlink -f "$bin" 2>/dev/null || echo "$bin")
+  real=$(_resolve_symlinks "$bin")
   for candidate in "${real%/bin/memsearch}"/lib/python*/site-packages/memsearch-*.dist-info; do
     [ -d "$candidate" ] || continue
     candidate=${candidate##*/memsearch-}

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -88,7 +88,7 @@ if [ -n "$VERSION" ]; then
     _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")
     _MS_REAL=""
     if [ -n "$_MS_BIN" ]; then
-      _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
+      _MS_REAL=$(_resolve_symlinks "$_MS_BIN")
     fi
     if [[ "$MEMSEARCH_CMD" == *"uvx"* ]]; then
       UPGRADE_CMD="uvx --upgrade --from 'memsearch[onnx]' memsearch --version"

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -50,7 +50,8 @@ if [ -n "$MEMSEARCH_CMD" ]; then
     MILVUS_URI=$($MEMSEARCH_CMD config get milvus.uri 2>/dev/null || echo "")
   fi
   # "memsearch, version 0.1.10" → "0.1.10"
-  VERSION=$($MEMSEARCH_CMD --version 2>/dev/null | sed 's/.*version //' || echo "")
+  VERSION=$(_installed_version_from_dist_info)
+  [ -n "$VERSION" ] || VERSION=$($MEMSEARCH_CMD --version 2>/dev/null | sed 's/.*version //' || echo "")
 fi
 
 # Determine required API key for the configured provider
@@ -77,11 +78,11 @@ if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
   fi
 fi
 
-# Check PyPI for newer version (2s timeout, non-blocking on failure)
+# Check PyPI for a newer version. The lookup is cached, so a slow or
+# unreachable index does not delay every session start.
 UPDATE_HINT=""
 if [ -n "$VERSION" ]; then
-  _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
-  LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
+  LATEST=$(_pypi_latest_version)
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
     # Detect install method to suggest the right upgrade command.
     _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -72,6 +72,48 @@ _json_encode_str() {
   return 0
 }
 
+# Resolve the installed memsearch version from its dist-info directory name.
+# Callers already spend one CLI start reading config; asking the CLI for
+# `--version` spawns a second Python interpreter (~0.3s warm, several seconds
+# cold) purely to render a status string. Prints nothing when no dist-info is
+# discoverable (uvx, editable installs) so callers can fall back to the CLI.
+_installed_version_from_dist_info() {
+  local bin real candidate
+  bin=$(command -v memsearch 2>/dev/null) || return 0
+  [ -n "$bin" ] || return 0
+  real=$(readlink -f "$bin" 2>/dev/null || echo "$bin")
+  for candidate in "${real%/bin/memsearch}"/lib/python*/site-packages/memsearch-*.dist-info; do
+    [ -d "$candidate" ] || continue
+    candidate=${candidate##*/memsearch-}
+    candidate=${candidate%.dist-info}
+    # Require a version-shaped string so a sibling distribution whose name
+    # starts with "memsearch-" cannot be mistaken for the package itself.
+    case "$candidate" in
+      [0-9]*) printf '%s' "$candidate"; return 0 ;;
+    esac
+  done
+}
+
+# Latest memsearch version on PyPI, cached for 24h. Keeps the update hint
+# current without making every session start wait on a network round trip: an
+# unreachable PyPI otherwise costs the full curl timeout on every start.
+# Prints nothing when the lookup fails.
+_pypi_latest_version() {
+  local cache="$HOME/.memsearch/.pypi-latest" latest="" json
+  if [ -n "$(find "$cache" -mtime -1 2>/dev/null)" ]; then
+    latest=$(cat "$cache" 2>/dev/null || true)
+  fi
+  if [ -z "$latest" ]; then
+    json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
+    latest=$(_json_val "$json" "info.version" "")
+    if [ -n "$latest" ]; then
+      mkdir -p "$(dirname "$cache")" 2>/dev/null || true
+      printf '%s' "$latest" > "$cache" 2>/dev/null || true
+    fi
+  fi
+  printf '%s' "$latest"
+}
+
 # Return a concise user-facing warning when the persisted index state says
 # search may be stale. Detailed diagnosis stays in the memory-config skill.
 index_state_warning() {

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -99,18 +99,18 @@ _installed_version_from_dist_info() {
 # unreachable PyPI otherwise costs the full curl timeout on every start.
 # Prints nothing when the lookup fails.
 _pypi_latest_version() {
-  local cache="$HOME/.memsearch/.pypi-latest" latest="" json
+  local cache="$HOME/.memsearch/.pypi-latest" latest json
+  # A cache file younger than a day is authoritative even when it is empty: an
+  # empty file records a lookup that failed, so an offline machine stops
+  # re-paying the curl timeout on every session start.
   if [ -n "$(find "$cache" -mtime -1 2>/dev/null)" ]; then
-    latest=$(cat "$cache" 2>/dev/null || true)
+    cat "$cache" 2>/dev/null || true
+    return 0
   fi
-  if [ -z "$latest" ]; then
-    json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
-    latest=$(_json_val "$json" "info.version" "")
-    if [ -n "$latest" ]; then
-      mkdir -p "$(dirname "$cache")" 2>/dev/null || true
-      printf '%s' "$latest" > "$cache" 2>/dev/null || true
-    fi
-  fi
+  json=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
+  latest=$(_json_val "$json" "info.version" "")
+  mkdir -p "$(dirname "$cache")" 2>/dev/null || true
+  printf '%s' "$latest" > "$cache" 2>/dev/null || true
   printf '%s' "$latest"
 }
 

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -72,6 +72,26 @@ _json_encode_str() {
   return 0
 }
 
+# _resolve_symlinks <path>
+# Follow a symlink chain to its target without `readlink -f`, which BSD
+# readlink (macOS) does not support. Relative link targets resolve against
+# the link's directory; a hop cap guards against cycles. The directory part
+# is canonicalized with `pwd -P` so `..` segments and directory symlinks
+# collapse the way GNU `readlink -f` would collapse them.
+_resolve_symlinks() {
+  local target="$1" link dir hops=0
+  while [ -L "$target" ] && [ "$hops" -lt 40 ]; do
+    link=$(readlink "$target" 2>/dev/null) || break
+    case "$link" in
+      /*) target="$link" ;;
+      *) target="$(dirname "$target")/$link" ;;
+    esac
+    hops=$((hops + 1))
+  done
+  dir=$(cd "$(dirname "$target")" 2>/dev/null && pwd -P) || { printf '%s' "$target"; return 0; }
+  printf '%s/%s' "$dir" "${target##*/}"
+}
+
 # Resolve the installed memsearch version from its dist-info directory name.
 # Callers already spend one CLI start reading config; asking the CLI for
 # `--version` spawns a second Python interpreter (~0.3s warm, several seconds
@@ -81,7 +101,7 @@ _installed_version_from_dist_info() {
   local bin real candidate
   bin=$(command -v memsearch 2>/dev/null) || return 0
   [ -n "$bin" ] || return 0
-  real=$(readlink -f "$bin" 2>/dev/null || echo "$bin")
+  real=$(_resolve_symlinks "$bin")
   for candidate in "${real%/bin/memsearch}"/lib/python*/site-packages/memsearch-*.dist-info; do
     [ -d "$candidate" ] || continue
     candidate=${candidate##*/memsearch-}

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -72,7 +72,7 @@ if [ -n "$VERSION" ]; then
     _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")
     _MS_REAL=""
     if [ -n "$_MS_BIN" ]; then
-      _MS_REAL=$(readlink -f "$_MS_BIN" 2>/dev/null || python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$_MS_BIN" 2>/dev/null || echo "$_MS_BIN")
+      _MS_REAL=$(_resolve_symlinks "$_MS_BIN")
     fi
     if [ "${MEMSEARCH_CMD[0]:-}" = "uvx" ]; then
       UPGRADE_CMD="uvx --upgrade --from 'memsearch[onnx]' memsearch --version"

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -33,7 +33,8 @@ if memsearch_available; then
   MODEL=$(_memsearch config get embedding.model 2>/dev/null || echo "")
   MILVUS_URI=$(_memsearch config get milvus.uri 2>/dev/null || echo "")
   # "memsearch, version 0.1.10" → "0.1.10"
-  VERSION=$(_memsearch --version 2>/dev/null | sed 's/.*version //' || echo "")
+  VERSION=$(_installed_version_from_dist_info)
+  [ -n "$VERSION" ] || VERSION=$(_memsearch --version 2>/dev/null | sed 's/.*version //' || echo "")
 fi
 
 # Determine required API key for the configured provider
@@ -61,11 +62,11 @@ if [ -n "$REQUIRED_KEY" ] && [ -z "${!REQUIRED_KEY:-}" ]; then
   fi
 fi
 
-# Check PyPI for newer version (2s timeout, non-blocking on failure)
+# Check PyPI for a newer version. The lookup is cached, so a slow or
+# unreachable index does not delay every session start.
 UPDATE_HINT=""
 if [ -n "$VERSION" ]; then
-  _PYPI_JSON=$(curl -s --max-time 2 https://pypi.org/pypi/memsearch/json 2>/dev/null || true)
-  LATEST=$(_json_val "$_PYPI_JSON" "info.version" "")
+  LATEST=$(_pypi_latest_version)
   if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
     # Detect install method to suggest the right upgrade command.
     _MS_BIN=$(command -v memsearch 2>/dev/null || echo "")

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -920,3 +920,45 @@ exit 0
     # The update hint survives the cache round trip.
     for run in (first, second):
         assert "UPDATE: v2.0.0 available" in json.loads(run.stdout)["systemMessage"]
+
+
+def test_claude_session_start_caches_failed_pypi_lookup(tmp_path: Path) -> None:
+    """A failed lookup is cached too, so an offline machine stops retrying."""
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    (home / ".memsearch").mkdir(parents=True)
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".memsearch").mkdir()
+    call_log = tmp_path / "memsearch-calls.txt"
+    curl_log = tmp_path / "curl-calls.txt"
+
+    fake_bin = _install_layout(tmp_path / "opt", "1.0.0")
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"tiny"},"milvus":{"uri":"/tmp/x.db"}}'
+  exit 0
+fi
+exit 0
+""",
+    )
+    # Stand in for an unreachable index: no output, non-zero exit.
+    _write_executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash\nprintf 'called\\n' >> "$CURL_CALL_LOG"\nexit 6\n""",
+    )
+
+    env = _session_start_env(tmp_path, home, fake_bin, call_log)
+    env["CURL_CALL_LOG"] = str(curl_log)
+
+    first = subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env, check=True)
+    second = subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env, check=True)
+
+    cache = home / ".memsearch" / ".pypi-latest"
+    assert curl_log.read_text(encoding="utf-8").count("called") == 1
+    assert cache.exists() and cache.read_text(encoding="utf-8") == ""
+    # No latest version known, so no hint is claimed either way.
+    for run in (first, second):
+        assert "UPDATE:" not in json.loads(run.stdout)["systemMessage"]

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 
 def _write_executable(path: Path, source: str) -> None:
@@ -880,6 +883,122 @@ exit 0
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "[memsearch v1.2.3]" in status
     assert "--version" in calls
+
+
+def _write_bsd_readlink_shim(shim_dir: Path) -> None:
+    """Shadow readlink with a macOS-like implementation that rejects -f."""
+    real_readlink = shutil.which("readlink")
+    assert real_readlink is not None
+    _write_executable(
+        shim_dir / "readlink",
+        f"""#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "-f" ]; then
+    echo "readlink: illegal option -- f" >&2
+    exit 1
+  fi
+done
+exec "{real_readlink}" "$@"
+""",
+    )
+
+
+@pytest.mark.parametrize(
+    "common_sh",
+    ["plugins/claude-code/hooks/common.sh", "plugins/codex/hooks/common.sh"],
+    ids=["claude-code", "codex"],
+)
+def test_dist_info_version_resolves_symlinked_bin_without_gnu_readlink(
+    tmp_path: Path, common_sh: str
+) -> None:
+    """A symlinked entry point (uv tool / pipx layout) must resolve to its
+    install tree even where readlink lacks -f (BSD readlink on macOS)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    install_bin = _install_layout(tmp_path / "opt", "9.9.9")
+    _write_executable(install_bin / "memsearch", "#!/usr/bin/env bash\nexit 0\n")
+
+    # ~/.local/bin/memsearch -> ../opt/bin/memsearch, a relative target like
+    # the ones uv writes.
+    link_bin = tmp_path / "links"
+    link_bin.mkdir()
+    (link_bin / "memsearch").symlink_to(Path("..") / "opt" / "bin" / "memsearch")
+
+    shim_bin = tmp_path / "shims"
+    shim_bin.mkdir()
+    _write_bsd_readlink_shim(shim_bin)
+
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1" < /dev/null && _installed_version_from_dist_info', "bash", common_sh],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{shim_bin}:{link_bin}:{os.environ['PATH']}",
+            "MEMSEARCH_DISABLE": "",
+        },
+        check=True,
+    )
+
+    assert result.stdout == "9.9.9"
+
+
+def test_claude_session_start_resolves_symlinked_bin_without_gnu_readlink(tmp_path: Path) -> None:
+    """The full SessionStart path works through a symlinked uv tool install
+    without GNU readlink: version comes from dist-info (no --version call) and
+    the update hint recognizes the uv/tools layout behind the symlink."""
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    (home / ".memsearch").mkdir(parents=True)
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".memsearch").mkdir()
+    call_log = tmp_path / "memsearch-calls.txt"
+
+    install_bin = _install_layout(tmp_path / "share" / "uv" / "tools" / "memsearch", "9.9.9")
+    _write_executable(
+        install_bin / "memsearch",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"tiny"},"milvus":{"uri":"/tmp/x.db"}}'
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.0.0-should-not-be-used"
+  exit 0
+fi
+exit 0
+""",
+    )
+
+    link_bin = tmp_path / "local-bin"
+    link_bin.mkdir()
+    (link_bin / "memsearch").symlink_to(
+        Path("..") / "share" / "uv" / "tools" / "memsearch" / "bin" / "memsearch"
+    )
+
+    fake_bin = tmp_path / "shims"
+    fake_bin.mkdir()
+    _write_bsd_readlink_shim(fake_bin)
+    _write_executable(fake_bin / "curl", """#!/usr/bin/env bash\necho '{"info":{"version":"9.9.10"}}'\n""")
+
+    env = _session_start_env(tmp_path, home, fake_bin, call_log)
+    env["PATH"] = f"{link_bin}:{env['PATH']}"
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "[memsearch v9.9.9]" in status
+    assert "--version" not in calls
+    assert "uv tool upgrade memsearch" in status
 
 
 def test_claude_session_start_caches_pypi_lookup(tmp_path: Path) -> None:

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -908,9 +908,7 @@ exec "{real_readlink}" "$@"
     ["plugins/claude-code/hooks/common.sh", "plugins/codex/hooks/common.sh"],
     ids=["claude-code", "codex"],
 )
-def test_dist_info_version_resolves_symlinked_bin_without_gnu_readlink(
-    tmp_path: Path, common_sh: str
-) -> None:
+def test_dist_info_version_resolves_symlinked_bin_without_gnu_readlink(tmp_path: Path, common_sh: str) -> None:
     """A symlinked entry point (uv tool / pipx layout) must resolve to its
     install tree even where readlink lacks -f (BSD readlink on macOS)."""
     home = tmp_path / "home"
@@ -974,9 +972,7 @@ exit 0
 
     link_bin = tmp_path / "local-bin"
     link_bin.mkdir()
-    (link_bin / "memsearch").symlink_to(
-        Path("..") / "share" / "uv" / "tools" / "memsearch" / "bin" / "memsearch"
-    )
+    (link_bin / "memsearch").symlink_to(Path("..") / "share" / "uv" / "tools" / "memsearch" / "bin" / "memsearch")
 
     fake_bin = tmp_path / "shims"
     fake_bin.mkdir()

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -775,3 +775,148 @@ def test_claude_stop_hook_avoids_empty_array_expansion_under_nounset() -> None:
 
     assert '"${CLAUDE_SAFE_MODE_ARGS[@]}"' not in source
     assert "CLAUDE_SAFE_MODE_ARG" in source
+
+
+def _install_layout(root: Path, version: str) -> Path:
+    """Create a uv/pipx-style install tree and return its bin directory."""
+    bin_dir = root / "bin"
+    site = root / "lib" / "python3.14" / "site-packages"
+    bin_dir.mkdir(parents=True)
+    site.mkdir(parents=True)
+    (site / f"memsearch-{version}.dist-info").mkdir()
+    return bin_dir
+
+
+def _session_start_env(tmp_path: Path, home: Path, fake_bin: Path, call_log: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(tmp_path / ".memsearch"),
+        "MEMSEARCH_NO_WATCH": "1",
+        "MEMSEARCH_CALL_LOG": str(call_log),
+    }
+
+
+def test_claude_session_start_reads_version_from_dist_info(tmp_path: Path) -> None:
+    """The status version comes from dist-info, without a second CLI start."""
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    (home / ".memsearch").mkdir(parents=True)
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".memsearch").mkdir()
+    call_log = tmp_path / "memsearch-calls.txt"
+
+    fake_bin = _install_layout(tmp_path / "opt", "9.9.9")
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"tiny"},"milvus":{"uri":"/tmp/x.db"}}'
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 0.0.0-should-not-be-used"
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(fake_bin / "curl", """#!/usr/bin/env bash\necho '{"info":{"version":"9.9.9"}}'\n""")
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=_session_start_env(tmp_path, home, fake_bin, call_log),
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "[memsearch v9.9.9]" in status
+    assert "--version" not in calls
+
+
+def test_claude_session_start_falls_back_to_cli_version_without_dist_info(tmp_path: Path) -> None:
+    """Layouts with no discoverable dist-info still report a version."""
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    (home / ".memsearch").mkdir(parents=True)
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".memsearch").mkdir()
+    call_log = tmp_path / "memsearch-calls.txt"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"tiny"},"milvus":{"uri":"/tmp/x.db"}}'
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  echo "memsearch, version 1.2.3"
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(fake_bin / "curl", """#!/usr/bin/env bash\necho '{"info":{"version":"1.2.3"}}'\n""")
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=_session_start_env(tmp_path, home, fake_bin, call_log),
+        check=True,
+    )
+
+    status = json.loads(result.stdout)["systemMessage"]
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "[memsearch v1.2.3]" in status
+    assert "--version" in calls
+
+
+def test_claude_session_start_caches_pypi_lookup(tmp_path: Path) -> None:
+    """PyPI is queried on the first start and served from cache on the next."""
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    (home / ".memsearch").mkdir(parents=True)
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".memsearch").mkdir()
+    call_log = tmp_path / "memsearch-calls.txt"
+    curl_log = tmp_path / "curl-calls.txt"
+
+    fake_bin = _install_layout(tmp_path / "opt", "1.0.0")
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MEMSEARCH_CALL_LOG"
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"tiny"},"milvus":{"uri":"/tmp/x.db"}}'
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash\nprintf 'called\\n' >> "$CURL_CALL_LOG"\necho '{"info":{"version":"2.0.0"}}'\n""",
+    )
+
+    env = _session_start_env(tmp_path, home, fake_bin, call_log)
+    env["CURL_CALL_LOG"] = str(curl_log)
+
+    first = subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env, check=True)
+    second = subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env, check=True)
+
+    assert curl_log.read_text(encoding="utf-8").count("called") == 1
+    assert (home / ".memsearch" / ".pypi-latest").read_text(encoding="utf-8") == "2.0.0"
+    # The update hint survives the cache round trip.
+    for run in (first, second):
+        assert "UPDATE: v2.0.0 available" in json.loads(run.stdout)["systemMessage"]


### PR DESCRIPTION
## Summary

- Resolve the installed version from its `dist-info` directory name instead of a separate `memsearch --version` call, which spawned a second Python interpreter purely to render the status line. Falls back to the CLI when no dist-info is discoverable (uvx, editable installs).
- Cache the PyPI latest-version lookup for 24h, so the update hint still appears but a slow or unreachable PyPI no longer blocks every session start.
- Both `plugins/claude-code` and `plugins/codex` carried the same two patterns, so both are updated; the two helpers are added to each `hooks/common.sh`.

## Why

`SessionStart` hooks block the session from starting, so their cost is paid on every launch. Measured across 50 recent sessions on one machine, this hook was the largest single contributor of the several that run:

| hook | median | p95 | max |
| --- | --- | --- | --- |
| memsearch `session-start.sh` | **1213ms** | **3315ms** | **5965ms** |
| next largest hook in the same sessions | 234ms | 726ms | 1280ms |

Breaking the median down against a warm macOS install:

| step | cost | note |
| --- | --- | --- |
| `config list --resolved --json-output` | 0.32s | needed — this loads the config |
| `memsearch --version` | 0.33s | second interpreter start, display string only |
| `curl pypi.org/pypi/memsearch/json` | 0.12s warm, **2.0s on timeout** | answer changes at most daily |

0.32 + 0.33 + 0.12 ≈ 0.77s, which accounts for the observed 1.21s median once bash startup and `stop_watch` are included. The tail is the curl hitting its 2s ceiling plus cold interpreter starts.

After the change, version resolution measured 0.33s → 0.01s returning the same value (verified against the CLI), and PyPI is contacted once per day rather than once per session. That puts the expected median near 0.77s and removes the 2s timeout from the tail on cached runs. The remaining `config list` start is inherent — the hook genuinely needs the resolved config.

This only moves *blocking* work. The background index spawned further down was already non-blocking and is untouched, as is the update hint's content and format.

## Test plan

- [x] `pytest tests/test_claude_hooks.py` — 16 passed
- [x] Full suite `pytest` — 290 passed, 7 skipped
- [x] New `test_claude_session_start_reads_version_from_dist_info` — status version comes from dist-info and `--version` is never invoked
- [x] New `test_claude_session_start_falls_back_to_cli_version_without_dist_info` — layouts without a discoverable dist-info still report a version via the CLI
- [x] New `test_claude_session_start_caches_pypi_lookup` — curl runs once across two starts, the cache file is written, and the update hint survives the cache round trip
- [x] Regression check: reverting the version hunk alone fails `test_claude_session_start_reads_version_from_dist_info`
- [x] `bash -n` clean on all four modified shell files
