### PR TITLE
fix: preserve newest journal entries within prompt budget

### DIFF
--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -227,7 +227,14 @@ def _build_prompt(ctx: TaskContext, cfg: MemSearchConfig) -> str:
         template = template.replace(marker, value)
 
     existing = ctx.output_file.read_text(encoding="utf-8") if ctx.output_file.is_file() else ""
-    journals = _read_recent_journals(ctx.input_dir)
+    journal_budget = max(
+        0,
+        MAX_PROMPT_CHARS - len(template) - len(existing) - 512,
+    )
+    journals = _read_recent_journals(
+        ctx.input_dir,
+        budget=journal_budget,
+    )
     prompt = f"""{template}
 
 ## Existing output file
@@ -261,15 +268,30 @@ def _load_prompt_template(task: str, cfg: MemSearchConfig) -> str:
         return f.read()
 
 
-def _read_recent_journals(input_dir: Path, max_files: int = 12) -> str:
+def _read_recent_journals(
+    input_dir: Path,
+    max_files: int = 12,
+    budget: int | None = None,
+) -> str:
     if not input_dir.is_dir():
         return ""
     chunks: list[str] = []
-    files = sorted((p for p in input_dir.rglob("*.md") if p.is_file()), key=lambda p: p.stat().st_mtime)[-max_files:]
+    files = sorted(
+        (p for p in input_dir.rglob("*.md") if p.is_file()),
+        key=lambda p: p.stat().st_mtime,
+    )[-max_files:]
     for path in files:
         with contextlib.suppress(OSError):
             chunks.append(f"\n<!-- source:{path} -->\n{read_utf8_text_replace(path)}")
-    return "\n".join(chunks)
+    text = "\n".join(chunks)
+    if budget is None or len(text) <= budget:
+        return text
+    if budget <= 0:
+        return ""
+    marker = "[older journal entries truncated]\n"
+    if budget <= len(marker):
+        return text[-budget:]
+    return marker + text[-(budget - len(marker)) :]
 
 
 def run_task_llm(ctx: TaskContext, prompt: str, cfg: MemSearchConfig) -> str:

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,7 +9,15 @@ from types import SimpleNamespace
 import pytest
 
 from memsearch.config import LLMProviderConfig, MemSearchConfig, PluginMaintenanceTaskConfig
-from memsearch.maintenance import TaskContext, _read_recent_journals, run_due_tasks, run_memory_command, run_task_llm
+from memsearch.maintenance import (
+    MAX_PROMPT_CHARS,
+    TaskContext,
+    _build_prompt,
+    _read_recent_journals,
+    run_due_tasks,
+    run_memory_command,
+    run_task_llm,
+)
 
 
 def test_maintenance_routes_gemini_provider_to_tool_runner(tmp_path: Path, monkeypatch) -> None:
@@ -46,6 +55,103 @@ def test_read_recent_journals_replaces_invalid_utf8_bytes(tmp_path: Path) -> Non
 
     assert "<!-- source:" in journals
     assert "broken \ufffd byte" in journals
+
+
+def test_read_recent_journals_respects_max_files(tmp_path: Path) -> None:
+    memory = tmp_path / "memory"
+    memory.mkdir()
+
+    oldest = memory / "2026-07-25.md"
+    middle = memory / "2026-07-26.md"
+    newest = memory / "2026-07-27.md"
+
+    oldest.write_text("OLDEST_JOURNAL_MARKER\n", encoding="utf-8")
+    middle.write_text("MIDDLE_JOURNAL_MARKER\n", encoding="utf-8")
+    newest.write_text("NEWEST_JOURNAL_MARKER\n", encoding="utf-8")
+
+    os.utime(oldest, (100, 100))
+    os.utime(middle, (200, 200))
+    os.utime(newest, (300, 300))
+
+    journals = _read_recent_journals(memory, max_files=2)
+
+    assert "NEWEST_JOURNAL_MARKER" in journals
+    assert "MIDDLE_JOURNAL_MARKER" in journals
+    assert "OLDEST_JOURNAL_MARKER" not in journals
+    assert journals.index("MIDDLE_JOURNAL_MARKER") < journals.index("NEWEST_JOURNAL_MARKER")
+
+
+def test_build_prompt_preserves_newest_journal_when_corpus_exceeds_budget(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+
+    oldest = memory / "2026-07-26.md"
+    newest = memory / "2026-07-27.md"
+
+    oldest.write_text(
+        "OLDEST_JOURNAL_MARKER\n" + "x" * (MAX_PROMPT_CHARS + 1_000),
+        encoding="utf-8",
+    )
+    newest.write_text(
+        "NEWEST_JOURNAL_MARKER\n",
+        encoding="utf-8",
+    )
+
+    os.utime(oldest, (100, 100))
+    os.utime(newest, (200, 200))
+
+    monkeypatch.setattr(
+        "memsearch.maintenance._load_prompt_template",
+        lambda task, cfg: "Maintenance prompt",
+    )
+
+    ctx = TaskContext(
+        platform="claude-code",
+        task="project_review",
+        task_config=PluginMaintenanceTaskConfig(),
+        project_dir=project,
+        memsearch_dir=project / ".memsearch",
+        input_dir=memory,
+        output_file=project / ".memsearch" / "PROJECT.md",
+        input_digest="sha256:test",
+    )
+
+    prompt = _build_prompt(ctx, MemSearchConfig())
+
+    assert "NEWEST_JOURNAL_MARKER" in prompt
+    assert "OLDEST_JOURNAL_MARKER" not in prompt
+    assert "[older journal entries truncated]" in prompt
+    assert len(prompt) <= MAX_PROMPT_CHARS
+
+
+def test_newest_entries_within_oversized_journal_survive(
+    tmp_path: Path,
+) -> None:
+    memory = tmp_path / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+
+    journal = memory / "2026-07-28.md"
+    journal.write_text(
+        "### 09:00\nEARLIEST_ENTRY_MARKER\n" + "filler\n" * 1_000 + "### 23:00\nLATEST_ENTRY_MARKER\n",
+        encoding="utf-8",
+    )
+
+    os.utime(journal, (200, 200))
+
+    budget = 512
+    journals = _read_recent_journals(
+        memory,
+        budget=budget,
+    )
+
+    assert "LATEST_ENTRY_MARKER" in journals
+    assert "EARLIEST_ENTRY_MARKER" not in journals
+    assert "[older journal entries truncated]" in journals
+    assert len(journals) <= budget
 
 
 def test_openai_maintenance_uses_default_temperature(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #653.

Maintenance prompts currently concatenate the selected journal files chronologically and then truncate the complete prompt from the head. When the journal corpus exceeds `MAX_PROMPT_CHARS`, this removes the newest journals. The same issue also occurs within a single oversized journal, where the earliest entries consume the available prompt budget and the latest entries are excluded.

This change adds an optional journal-specific character budget and preserves the tail of the journal block when that budget is exceeded.

## Changes

- Add an optional `budget` parameter to `_read_recent_journals`
- Keep the existing chronological file ordering and `max_files` selection behavior
- Preserve the newest journal content by truncating the oldest part of the combined journal block
- Reserve prompt capacity for the template, existing output, and surrounding prompt structure
- Add a truncation marker when older journal entries are removed
- Handle zero and very small budgets without exceeding the assigned limit

## Tests

Added regression coverage for:

- Selecting only the most recent files while preserving chronological order
- Preserving the newest journal when the combined corpus exceeds the prompt budget
- Preserving the latest entry within a single oversized journal
- Keeping the truncated journal block within its assigned budget

Commands run:

```text
uv run python -m pytest tests/test_maintenance.py -k "respects_max_files or corpus_exceeds_budget or oversized_journal" -v
uv run python -m pytest tests/test_maintenance.py -k "not run_memory_command_allows_transcript_outside_roots" -v
uv run ruff check src/memsearch/maintenance.py tests/test_maintenance.py
uv run ruff format --check src/memsearch/maintenance.py tests/test_maintenance.py

## Test plan

- [x] Focused journal-budget regression tests pass
- [x] Maintenance tests pass except the pre-existing Windows path test
- [x] Ruff lint passes for the changed files
- [x] Ruff format check passes for the changed files