### PR TITLE
Add MiniMax as a first-class managed LLM provider

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -11,6 +11,7 @@ import click
 
 from .config import (
     GLOBAL_CONFIG_PATH,
+    MINIMAX_DEFAULT_LLM_MODEL,
     PROJECT_CONFIG_PATH,
     ConfigEnvVarError,
     MemSearchConfig,
@@ -1051,12 +1052,13 @@ def config_init(project: bool) -> None:
     click.echo("  Plugin summarization uses plugins.<platform>.summarize.model.")
     _llm_defaults = {
         "openai": "gpt-5-mini",
+        "minimax": MINIMAX_DEFAULT_LLM_MODEL,
         "anthropic": "claude-sonnet-4-6",
         "gemini": "gemini-3-flash-preview",
     }
     result["llm"] = {}
     result["llm"]["provider"] = click.prompt(
-        "  Provider (empty/openai/anthropic/gemini)",
+        "  Provider (empty/openai/anthropic/gemini/minimax)",
         default=current.llm.provider,
     )
     _llm_provider = result["llm"]["provider"]

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -14,9 +14,11 @@ from .config import (
     MINIMAX_DEFAULT_LLM_MODEL,
     PROJECT_CONFIG_PATH,
     ConfigEnvVarError,
+    LLMProviderConfig,
     MemSearchConfig,
     config_to_dict,
     get_config_value,
+    is_minimax_llm_provider,
     load_config_file,
     resolve_config,
     save_config,
@@ -795,8 +797,11 @@ def summarize(plugin: str, agent_name: str) -> None:
 
     provider_cfg = cfg.llm.providers.get(provider_name)
     if provider_cfg is None:
-        click.echo(f"Unknown LLM provider {provider_name!r}. Configure [llm.providers.{provider_name}].", err=True)
-        raise SystemExit(1)
+        if is_minimax_llm_provider(provider_name):
+            provider_cfg = LLMProviderConfig(type=provider_name)
+        else:
+            click.echo(f"Unknown LLM provider {provider_name!r}. Configure [llm.providers.{provider_name}].", err=True)
+            raise SystemExit(1)
 
     provider_type = provider_cfg.type or provider_name
     model = str(summarize_cfg.get("model") or provider_cfg.model or "").strip() or None

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -1,8 +1,9 @@
 """Memory compact — compress and summarize chunks using an LLM.
 
-Supports OpenAI (default), Anthropic, and Gemini as LLM backends.
-API keys are read from environment variables:
+Supports OpenAI (default), OpenAI-compatible, Anthropic, Gemini, and MiniMax as
+LLM backends.  API keys are read from environment variables:
     OPENAI_API_KEY / OPENAI_BASE_URL
+    MINIMAX_API_KEY
     ANTHROPIC_API_KEY
     GOOGLE_API_KEY
 """
@@ -12,7 +13,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from .config import resolve_env_ref
+from .config import resolve_env_ref, resolve_llm_provider_settings
 
 COMPACT_PROMPT = """\
 You are a knowledge compression assistant. Given the following chunks of text \
@@ -42,18 +43,18 @@ async def compact_chunks(
     chunks:
         List of chunk dicts (must contain ``"content"`` key).
     llm_provider:
-        One of ``"openai"``, ``"anthropic"``, ``"gemini"``.
+        One of ``"openai"``, ``"openai-compatible"``, ``"anthropic"``,
+        ``"gemini"``, or ``"minimax"``.
     model:
         Override the default model for the provider.
     prompt_template:
         Custom prompt template.  Must contain ``{chunks}`` placeholder.
         Defaults to the built-in ``COMPACT_PROMPT``.
     base_url:
-        Custom base URL for OpenAI-compatible API endpoints.  Only used
-        when *llm_provider* is ``"openai"``.
+        Custom base URL for OpenAI-compatible and Anthropic API endpoints.
     api_key:
-        API key for the LLM provider.  Only used when *llm_provider* is
-        ``"openai"``.
+        API key for the LLM provider.  Used by the OpenAI-compatible and
+        Anthropic routes.
 
     Returns
     -------
@@ -68,14 +69,18 @@ async def compact_chunks(
         raise ValueError("prompt_template must include the {chunks} placeholder")
     prompt = template.format(chunks=combined)
 
-    if llm_provider == "openai":
+    llm_provider, model, base_url, api_key = resolve_llm_provider_settings(llm_provider, model, base_url, api_key)
+    provider = "openai" if llm_provider == "openai-compatible" else llm_provider
+    if provider == "openai":
         return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
-    elif llm_provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
-    elif llm_provider == "gemini":
+    elif provider == "anthropic":
+        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6", base_url=base_url, api_key=api_key)
+    elif provider == "gemini":
         return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
     else:
-        raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
+        raise ValueError(
+            f"Unknown LLM provider {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini, minimax"
+        )
 
 
 async def summarize_text(
@@ -87,15 +92,16 @@ async def summarize_text(
     api_key: str | None = None,
 ) -> str:
     """Summarize preformatted text with a memsearch-managed LLM provider."""
+    llm_provider, model, base_url, api_key = resolve_llm_provider_settings(llm_provider, model, base_url, api_key)
     provider = "openai" if llm_provider == "openai-compatible" else llm_provider
     if provider == "openai":
         return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
     if provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
+        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6", base_url=base_url, api_key=api_key)
     if provider == "gemini":
         return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
     raise ValueError(
-        f"Unknown LLM provider type {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini"
+        f"Unknown LLM provider type {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini, minimax"
     )
 
 
@@ -117,10 +123,17 @@ async def _compact_openai(prompt: str, model: str, *, base_url: str | None = Non
     return resp.choices[0].message.content or ""
 
 
-async def _compact_anthropic(prompt: str, model: str) -> str:
+async def _compact_anthropic(
+    prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None
+) -> str:
     import anthropic
 
-    client = anthropic.AsyncAnthropic()  # reads ANTHROPIC_API_KEY
+    kwargs: dict = {}
+    if base_url:
+        kwargs["base_url"] = resolve_env_ref(base_url)
+    if api_key:
+        kwargs["api_key"] = resolve_env_ref(api_key)
+    client = anthropic.AsyncAnthropic(**kwargs)  # falls back to ANTHROPIC_API_KEY when api_key is unset
     resp = await client.messages.create(
         model=model,
         max_tokens=4096,

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -250,6 +250,42 @@ _PLUGIN_FIELD_TO_KEY = {
 
 _ENV_PREFIX = "env:"
 
+# -- Built-in MiniMax LLM provider shortcut ---------------------------------
+# MiniMax exposes both an OpenAI-compatible endpoint (``/v1``) and an
+# Anthropic-compatible endpoint (``/anthropic``), each hosted on a global and a
+# China base host.  The ``minimax`` shortcut resolves to the OpenAI-compatible
+# route so it reuses the existing code path while supplying MiniMax defaults and
+# the selected regional endpoint preset.
+MINIMAX_DEFAULT_LLM_MODEL = "MiniMax-M3"
+MINIMAX_LLM_MODELS = ("MiniMax-M3", "MiniMax-M2.7")
+MINIMAX_LLM_PROVIDER_ALIASES = frozenset({"minimax"})
+MINIMAX_API_KEY_ENV_VARS = ("MINIMAX_API_KEY",)
+MINIMAX_BASE_URL_ENV_VARS = ("MINIMAX_API_BASE", "MINIMAX_BASE_URL")
+MINIMAX_REGION_ENV_VARS = ("MINIMAX_REGION", "MINIMAX_API_REGION")
+MINIMAX_DEFAULT_LLM_REGION = "global_en"
+# region -> {"openai": <OpenAI-compatible base>, "anthropic": <Anthropic-compatible base>}
+MINIMAX_LLM_REGION_ENDPOINTS: dict[str, dict[str, str]] = {
+    "global_en": {
+        "openai": "https://api.minimax.io/v1",
+        "anthropic": "https://api.minimax.io/anthropic",
+    },
+    "cn_zh": {
+        "openai": "https://api.minimaxi.com/v1",
+        "anthropic": "https://api.minimaxi.com/anthropic",
+    },
+}
+# Friendly aliases accepted for the region selector.
+_MINIMAX_REGION_ALIASES = {
+    "global_en": "global_en",
+    "global": "global_en",
+    "int": "global_en",
+    "international": "global_en",
+    "cn_zh": "cn_zh",
+    "cn": "cn_zh",
+    "china": "cn_zh",
+}
+MINIMAX_DEFAULT_LLM_BASE_URL = MINIMAX_LLM_REGION_ENDPOINTS[MINIMAX_DEFAULT_LLM_REGION]["openai"]
+
 
 class ConfigEnvVarError(KeyError):
     """Raised when an ``env:VAR_NAME`` reference points at an unset variable.
@@ -275,6 +311,71 @@ def resolve_env_ref(value: str) -> str:
     if env_val is None:
         raise ConfigEnvVarError(f"Environment variable {var_name!r} referenced in config (via {value!r}) is not set")
     return env_val
+
+
+def is_minimax_llm_provider(provider: str | None) -> bool:
+    """Return whether *provider* names the built-in MiniMax LLM shortcut."""
+    return (provider or "").strip().lower() in MINIMAX_LLM_PROVIDER_ALIASES
+
+
+def _first_set_env(names: tuple[str, ...]) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return ""
+
+
+def _first_set_env_ref(names: tuple[str, ...]) -> str:
+    for name in names:
+        if os.environ.get(name):
+            return f"{_ENV_PREFIX}{name}"
+    return f"{_ENV_PREFIX}{names[0]}"
+
+
+def resolve_minimax_region(region: str | None = None) -> str:
+    """Resolve a MiniMax region selector to a canonical region key.
+
+    Accepts the canonical ``global_en`` / ``cn_zh`` keys plus common aliases
+    (``global``, ``cn``, ...).  Falls back to the ``MINIMAX_REGION`` environment
+    variable and finally to the global endpoint.
+    """
+    candidate = (region or _first_set_env(MINIMAX_REGION_ENV_VARS) or MINIMAX_DEFAULT_LLM_REGION).strip().lower()
+    return _MINIMAX_REGION_ALIASES.get(candidate, MINIMAX_DEFAULT_LLM_REGION)
+
+
+def minimax_base_url(region: str | None = None, *, transport: str = "openai") -> str:
+    """Return the MiniMax base URL preset for *region* and *transport*.
+
+    *transport* is ``"openai"`` for the OpenAI-compatible endpoint or
+    ``"anthropic"`` for the Anthropic-compatible endpoint.
+    """
+    endpoints = MINIMAX_LLM_REGION_ENDPOINTS[resolve_minimax_region(region)]
+    return endpoints.get(transport, endpoints["openai"])
+
+
+def resolve_llm_provider_settings(
+    provider: str,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve built-in LLM provider shortcuts to concrete provider settings.
+
+    MiniMax exposes an OpenAI-compatible LLM endpoint, so the shortcut keeps the
+    existing OpenAI-compatible code path while supplying MiniMax defaults and the
+    selected global/CN endpoint preset.  Unknown providers are returned
+    unchanged so explicit provider types keep their current behavior.
+    """
+    normalized = (provider or "").strip()
+    if not is_minimax_llm_provider(normalized):
+        return normalized, model, base_url, api_key
+    return (
+        "openai-compatible",
+        model or MINIMAX_DEFAULT_LLM_MODEL,
+        base_url or _first_set_env(MINIMAX_BASE_URL_ENV_VARS) or minimax_base_url(),
+        api_key or _first_set_env_ref(MINIMAX_API_KEY_ENV_VARS),
+    )
 
 
 def _resolve_env_refs_in_dict(d: dict[str, Any], path: tuple[str, ...] = ()) -> dict[str, Any]:

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -10,7 +10,7 @@ import re
 import shlex
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
@@ -22,7 +22,9 @@ from .config import (
     MemSearchConfig,
     PluginMaintenanceTaskConfig,
     config_to_dict,
+    is_minimax_llm_provider,
     resolve_env_ref,
+    resolve_llm_provider_settings,
 )
 from .io import read_utf8_text_replace
 
@@ -284,9 +286,25 @@ def run_task_llm(ctx: TaskContext, prompt: str, cfg: MemSearchConfig) -> str:
 
     provider_cfg = cfg.llm.providers.get(provider_name)
     if provider_cfg is None:
-        raise RuntimeError(f"Unknown LLM provider {provider_name!r}")
+        if is_minimax_llm_provider(provider_name):
+            provider_cfg = LLMProviderConfig(type=provider_name)
+        else:
+            raise RuntimeError(f"Unknown LLM provider {provider_name!r}")
     provider_type = provider_cfg.type or provider_name
     model = ctx.task_config.model or provider_cfg.model or None
+    provider_type, model, base_url, api_key = resolve_llm_provider_settings(
+        provider_type,
+        model=model,
+        base_url=provider_cfg.base_url or None,
+        api_key=provider_cfg.api_key or None,
+    )
+    provider_cfg = replace(
+        provider_cfg,
+        type=provider_type,
+        model=model or "",
+        base_url=base_url or "",
+        api_key=api_key or "",
+    )
 
     if provider_type in {"openai", "openai-compatible"}:
         return _run_openai_with_tools(ctx, prompt, provider_type, model, provider_cfg)
@@ -389,8 +407,12 @@ def _openai_memory_tool_schema() -> dict[str, Any]:
 def _run_anthropic_with_tools(ctx: TaskContext, prompt: str, model: str | None, provider_cfg: LLMProviderConfig) -> str:
     import anthropic
 
-    api_key = resolve_env_ref(provider_cfg.api_key) if provider_cfg.api_key else None
-    client = anthropic.Anthropic(api_key=api_key) if api_key else anthropic.Anthropic()
+    kwargs: dict[str, str] = {}
+    if provider_cfg.base_url:
+        kwargs["base_url"] = resolve_env_ref(provider_cfg.base_url)
+    if provider_cfg.api_key:
+        kwargs["api_key"] = resolve_env_ref(provider_cfg.api_key)
+    client = anthropic.Anthropic(**kwargs)  # falls back to ANTHROPIC_API_KEY when api_key is unset
     messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
     chosen_model = model or "claude-sonnet-4-6"
     for _ in range(MAX_TOOL_CALLS):

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -68,11 +68,15 @@ async def test_openai_compact_uses_default_temperature(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_compact_chunks_dispatches_to_anthropic(monkeypatch) -> None:
-    captured: dict[str, str] = {}
+    captured: dict[str, str | None] = {}
 
-    async def fake_anthropic(prompt: str, model: str) -> str:
+    async def fake_anthropic(
+        prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None
+    ) -> str:
         captured["prompt"] = prompt
         captured["model"] = model
+        captured["base_url"] = base_url
+        captured["api_key"] = api_key
         return "anthropic-summary"
 
     monkeypatch.setattr(compact_module, "_compact_anthropic", fake_anthropic)
@@ -84,6 +88,8 @@ async def test_compact_chunks_dispatches_to_anthropic(monkeypatch) -> None:
 
     assert result == "anthropic-summary"
     assert captured["model"] == "claude-sonnet-4-6"
+    assert captured["base_url"] is None
+    assert captured["api_key"] is None
     assert "memory chunk" in captured["prompt"]
 
 
@@ -124,3 +130,85 @@ async def test_compact_chunks_rejects_prompt_without_chunks_placeholder() -> Non
 async def test_compact_chunks_rejects_unknown_provider() -> None:
     with pytest.raises(ValueError, match="Unknown LLM provider"):
         await compact_module.compact_chunks([{"content": "x"}], llm_provider="unknown")
+
+
+@pytest.mark.asyncio
+async def test_compact_chunks_dispatches_minimax_to_openai_compatible(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def fake_openai(prompt: str, model: str, *, base_url: str | None = None, api_key: str | None = None) -> str:
+        captured["prompt"] = prompt
+        captured["model"] = model
+        captured["base_url"] = base_url
+        captured["api_key"] = api_key
+        return "minimax-summary"
+
+    for name in ("MINIMAX_REGION", "MINIMAX_API_REGION", "MINIMAX_API_BASE", "MINIMAX_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+    monkeypatch.setattr(compact_module, "_compact_openai", fake_openai)
+
+    result = await compact_module.compact_chunks(
+        [{"content": "minimax memory"}],
+        llm_provider="minimax",
+    )
+
+    assert result == "minimax-summary"
+    assert captured == {
+        "prompt": compact_module.COMPACT_PROMPT.format(chunks="minimax memory"),
+        "model": "MiniMax-M3",
+        "base_url": "https://api.minimax.io/v1",
+        "api_key": "env:MINIMAX_API_KEY",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compact_anthropic_accepts_custom_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            captured["create"] = kwargs
+            return SimpleNamespace(content=[SimpleNamespace(type="text", text="anthropic-summary")])
+
+    class FakeAsyncAnthropic:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.messages = FakeMessages()
+
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(AsyncAnthropic=FakeAsyncAnthropic))
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+
+    result = await compact_module._compact_anthropic(
+        "prompt",
+        "claude-test",
+        base_url="https://api.minimax.io/anthropic",
+        api_key="env:MINIMAX_API_KEY",
+    )
+
+    assert result == "anthropic-summary"
+    assert captured["client_kwargs"] == {
+        "base_url": "https://api.minimax.io/anthropic",
+        "api_key": "minimax-key",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compact_anthropic_falls_back_to_default_credentials(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            return SimpleNamespace(content=[SimpleNamespace(type="text", text="ok")])
+
+    class FakeAsyncAnthropic:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.messages = FakeMessages()
+
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(AsyncAnthropic=FakeAsyncAnthropic))
+
+    result = await compact_module._compact_anthropic("prompt", "claude-test")
+
+    assert result == "ok"
+    assert captured["client_kwargs"] == {}

--- a/tests/test_compact_cli.py
+++ b/tests/test_compact_cli.py
@@ -145,6 +145,46 @@ def test_summarize_uses_named_provider(monkeypatch, tmp_path: Path):
     assert captured["api_key"] == "env:OPENAI_API_KEY"
 
 
+def test_summarize_uses_minimax_shortcut(monkeypatch, tmp_path: Path):
+    cfg_path = tmp_path / "config.toml"
+    save_config(
+        {"plugins": {"codex": {"summarize": {"provider": "minimax"}}}},
+        cfg_path,
+    )
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / "nope.toml")
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+
+    captured = {}
+
+    async def fake_openai(prompt, model, *, base_url=None, api_key=None):
+        captured.update(
+            {
+                "prompt": prompt,
+                "model": model,
+                "base_url": base_url,
+                "api_key": api_key,
+            }
+        )
+        return "- summarized"
+
+    monkeypatch.setattr("memsearch.compact._compact_openai", fake_openai)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["summarize", "--plugin", "codex", "--agent-name", "Codex"],
+        input="[User]: hello\n[Codex]: hi",
+    )
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "- summarized"
+    assert "Transcript:\n[User]: hello" in captured["prompt"]
+    assert captured["model"] == "MiniMax-M3"
+    assert captured["base_url"] == "https://api.minimax.io/v1"
+    assert captured["api_key"] == "env:MINIMAX_API_KEY"
+
+
 def test_summarize_rejects_native_provider(monkeypatch, tmp_path: Path):
     cfg_path = tmp_path / "config.toml"
     save_config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from memsearch.config import (
     load_config_file,
     resolve_config,
     resolve_env_ref,
+    resolve_llm_provider_settings,
     save_config,
     set_config_value,
 )
@@ -656,3 +657,58 @@ def test_dict_to_config_accepts_empty_section_dicts() -> None:
     assert cfg.embedding.provider == "openai"
     assert cfg.milvus.collection == "memsearch_chunks"
     assert cfg.watch.debounce_ms == 1500
+
+
+def _clear_minimax_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("MINIMAX_API_KEY", "MINIMAX_REGION", "MINIMAX_API_REGION", "MINIMAX_API_BASE", "MINIMAX_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_minimax_llm_provider_shortcut_uses_openai_compatible_defaults(monkeypatch: pytest.MonkeyPatch):
+    """The MiniMax shortcut should resolve to the OpenAI-compatible route with global defaults."""
+    _clear_minimax_env(monkeypatch)
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+
+    provider, model, base_url, api_key = resolve_llm_provider_settings("minimax")
+
+    assert provider == "openai-compatible"
+    assert model == "MiniMax-M3"
+    assert base_url == "https://api.minimax.io/v1"
+    assert api_key == "env:MINIMAX_API_KEY"
+
+
+def test_minimax_llm_provider_shortcut_selects_cn_region(monkeypatch: pytest.MonkeyPatch):
+    """MINIMAX_REGION should switch the shortcut to the China endpoint preset."""
+    _clear_minimax_env(monkeypatch)
+    monkeypatch.setenv("MINIMAX_REGION", "cn")
+
+    provider, model, base_url, _ = resolve_llm_provider_settings("minimax")
+
+    assert provider == "openai-compatible"
+    assert model == "MiniMax-M3"
+    assert base_url == "https://api.minimaxi.com/v1"
+
+
+def test_minimax_llm_provider_shortcut_respects_explicit_overrides(monkeypatch: pytest.MonkeyPatch):
+    """Explicit model/base_url/api_key arguments should win over the presets."""
+    _clear_minimax_env(monkeypatch)
+    monkeypatch.setenv("MINIMAX_REGION", "cn")
+
+    provider, model, base_url, api_key = resolve_llm_provider_settings(
+        "minimax",
+        model="MiniMax-M2.7",
+        base_url="https://custom.example/v1",
+        api_key="env:CUSTOM_KEY",
+    )
+
+    assert provider == "openai-compatible"
+    assert model == "MiniMax-M2.7"
+    assert base_url == "https://custom.example/v1"
+    assert api_key == "env:CUSTOM_KEY"
+
+
+def test_resolve_llm_provider_settings_passthrough_for_known_types(monkeypatch: pytest.MonkeyPatch):
+    """Non-shortcut providers should be returned unchanged."""
+    _clear_minimax_env(monkeypatch)
+
+    assert resolve_llm_provider_settings("anthropic", model="claude-test") == ("anthropic", "claude-test", None, None)

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -245,3 +245,87 @@ def test_run_memory_command_allows_transcript_outside_roots(tmp_path: Path) -> N
     # A non-transcript command pointed outside the roots is still rejected.
     rejected = run_memory_command(f"grep foo {tmp_path}/outside.txt", ctx)
     assert "outside allowed memory roots" in rejected
+
+
+def test_maintenance_routes_minimax_shortcut_to_openai_compatible_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    (memory / "2026-05-27.md").write_text("- User discussed MiniMax maintenance.\n", encoding="utf-8")
+
+    cfg = MemSearchConfig()
+    cfg.plugins.codex.project_review.enabled = True
+    cfg.plugins.codex.project_review.provider = "minimax"
+
+    captured = {}
+
+    def fake_openai(ctx, prompt: str, provider_type: str, model: str | None, provider_cfg) -> str:
+        captured["model"] = model
+        captured["provider_type"] = provider_type
+        captured["config_type"] = provider_cfg.type
+        captured["base_url"] = provider_cfg.base_url
+        captured["api_key"] = provider_cfg.api_key
+        return json.dumps({"action": "none", "reason": "ok"})
+
+    for name in ("MINIMAX_REGION", "MINIMAX_API_REGION", "MINIMAX_API_BASE", "MINIMAX_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+    monkeypatch.setattr("memsearch.maintenance._run_openai_with_tools", fake_openai)
+
+    results = run_due_tasks(platform="codex", project_dir=project, cfg=cfg)
+
+    assert results[0].action == "none"
+    assert captured == {
+        "model": "MiniMax-M3",
+        "provider_type": "openai-compatible",
+        "config_type": "openai-compatible",
+        "base_url": "https://api.minimax.io/v1",
+        "api_key": "env:MINIMAX_API_KEY",
+    }
+
+
+def test_anthropic_maintenance_runner_honors_custom_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from memsearch import maintenance as maintenance_module
+
+    captured: dict[str, object] = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured["create"] = kwargs
+            return SimpleNamespace(content=[SimpleNamespace(type="text", text="ok")])
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.messages = FakeMessages()
+
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=FakeAnthropic))
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
+
+    project = tmp_path / "repo"
+    (project / ".memsearch" / "memory").mkdir(parents=True)
+    ctx = TaskContext(
+        platform="codex",
+        task="project_review",
+        task_config=PluginMaintenanceTaskConfig(),
+        project_dir=project,
+        memsearch_dir=project / ".memsearch",
+        input_dir=project / ".memsearch" / "memory",
+        output_file=project / ".memsearch" / "PROJECT.md",
+        input_digest="sha256:test",
+    )
+    provider_cfg = LLMProviderConfig(
+        type="anthropic",
+        base_url="https://api.minimax.io/anthropic",
+        api_key="env:MINIMAX_API_KEY",
+    )
+
+    result = maintenance_module._run_anthropic_with_tools(ctx, "prompt", "claude-test", provider_cfg)
+
+    assert result == "ok"
+    assert captured["client_kwargs"] == {
+        "base_url": "https://api.minimax.io/anthropic",
+        "api_key": "minimax-key",
+    }


### PR DESCRIPTION
Reason: The managed LLM routing had no first-class MiniMax provider, MiniMax-M3 default, or global/CN endpoint presets, and the Anthropic client path could not accept a custom base URL.

## Summary

- Add a `minimax` LLM provider shortcut that resolves to the existing OpenAI-compatible route, defaulting to the `MiniMax-M3` model and the `MINIMAX_API_KEY` credential (with `MiniMax-M2.7` also selectable via `--model` / config).
- Add global/CN endpoint presets — `https://api.minimax.io/v1` (default) and `https://api.minimaxi.com/v1` — selectable with `MINIMAX_REGION` (`global_en` / `cn_zh`, plus `global` / `cn` aliases) and overridable with `MINIMAX_API_BASE` / `MINIMAX_BASE_URL`.
- Let the Anthropic client path accept a custom `base_url` (and API key) in both `memsearch compact` summarization and maintenance task routing, so the MiniMax Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`) can be configured as a named provider.
- Wire the shortcut into `memsearch config init` model defaults and the provider prompt.
- Add focused tests for config resolution (defaults, region selection, explicit overrides, passthrough), compact dispatch, maintenance routing, and the Anthropic base-URL plumbing.

No README/docs/logo changes.

## Validation

- `uv run python -m pytest` — 296 passed, 7 skipped
- `uv run ruff check src/memsearch/config.py src/memsearch/compact.py src/memsearch/maintenance.py src/memsearch/cli.py tests/test_config.py tests/test_compact.py tests/test_maintenance.py`
- `uv run ruff format --check` on the same changed files
