### PR TITLE
fix(skills): preserve newest journals in distill prompts

### DIFF
--- a/src/memsearch/skills.py
+++ b/src/memsearch/skills.py
@@ -154,7 +154,14 @@ def _build_distill_prompt(
         template = template.replace(marker, value)
 
     existing_block = _render_existing_block(skills_root(ctx.memsearch_dir), existing)
-    journals = _read_recent_journals(ctx.input_dir)
+    journal_budget = max(
+        0,
+        MAX_PROMPT_CHARS - len(template) - len(existing_block) - 512,
+    )
+    journals = _read_recent_journals(
+        ctx.input_dir,
+        budget=journal_budget,
+    )
     prompt = f"""{template}
 
 ## Existing skills (you may revise these)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -77,6 +78,45 @@ def test_distill_creates_candidate_and_commits(tmp_path: Path) -> None:
         check=True,
     )
     assert "distill" in log.stdout
+
+
+def test_distill_prompt_preserves_newest_journal_when_corpus_exceeds_budget(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+
+    oldest = memory / "2026-07-30.md"
+    newest = memory / "2026-07-31.md"
+    oldest.write_text(
+        "OLDEST_JOURNAL_MARKER\n" + "x" * (skills_mod.MAX_PROMPT_CHARS + 1_000),
+        encoding="utf-8",
+    )
+    newest.write_text("NEWEST_JOURNAL_MARKER\n", encoding="utf-8")
+    os.utime(oldest, (100, 100))
+    os.utime(newest, (200, 200))
+
+    ctx = skills_mod.TaskContext(
+        platform="codex",
+        task=skills_mod.TASK,
+        task_config=skills_mod.PluginMemoryToSkillConfig(),
+        project_dir=project,
+        memsearch_dir=project / ".memsearch",
+        input_dir=memory,
+        output_file=project / ".memsearch" / "skill-candidates",
+        input_digest="sha256:test",
+    )
+
+    prompt = skills_mod._build_distill_prompt(
+        ctx,
+        min_occurrences=3,
+        existing=[],
+        cfg=MemSearchConfig(),
+    )
+
+    assert "NEWEST_JOURNAL_MARKER" in prompt
+    assert "OLDEST_JOURNAL_MARKER" not in prompt
+    assert "[older journal entries truncated]" in prompt
+    assert len(prompt) <= skills_mod.MAX_PROMPT_CHARS
 
 
 def test_render_skill_md_has_only_standard_frontmatter() -> None:


### PR DESCRIPTION
## Summary

- Reserve distillation prompt capacity for recent journals after accounting for the template and existing skill context.
- Reuse the journal tail-budget behavior already used by project and user maintenance prompts.
- Add regression coverage for an oversized older journal followed by a newer journal.

## Why

`memory_to_skill` selected the 12 most recent journal files in chronological order, appended them to the prompt, and then kept only the first 80,000 characters. When the selected corpus exceeded that limit, older entries consumed the available space and the newest journals were silently excluded.

The shared journal reader now supports preserving the newest tail within a caller-provided budget, but the distillation prompt did not pass that budget. This change applies the same budgeting strategy so recent workflows remain visible while the complete prompt stays within the configured limit.

## Validation

- `uv run pytest tests/test_skills.py -v` — 23 passed
- `uv run pytest tests/test_maintenance.py -v` — 12 passed
- `env -u OPENAI_API_KEY uv run pytest` — 291 passed, 7 skipped
- `uv run ruff check src/memsearch/skills.py tests/test_skills.py`
- `uv run ruff format --check src/memsearch/skills.py tests/test_skills.py`
- Verified against the current project journal corpus: the prompt remains below 80,000 characters and includes the newest selected journal.
