### PR TITLE
fix: configure CLI streams for UTF-8 output

### DIFF
--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 import click
@@ -168,6 +169,13 @@ def _load_plugin_summarize_prompt(cfg: MemSearchConfig, agent_name: str) -> str:
 # -- Common CLI options --
 
 
+def _configure_cli_streams() -> None:
+    """Configure CLI output streams for reliable Unicode output."""
+    for stream in (sys.stdout, sys.stderr):
+        with suppress(AttributeError, OSError):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def _common_options(f):
     """Shared options for commands that create a MemSearch instance."""
     f = click.option("--provider", "-p", default=None, help="Embedding provider.")(f)
@@ -204,6 +212,7 @@ def _indexing_options(f):
 @click.version_option(package_name="memsearch")
 def cli() -> None:
     """memsearch — semantic memory search for markdown knowledge bases."""
+    _configure_cli_streams()
 
 
 @cli.command()

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -176,6 +176,14 @@ def _configure_cli_streams() -> None:
             stream.reconfigure(encoding="utf-8", errors="replace")
 
 
+class _MemSearchGroup(click.Group):
+    """Configure CLI streams before Click parses arguments or exits eagerly."""
+
+    def main(self, *args, **kwargs):
+        _configure_cli_streams()
+        return super().main(*args, **kwargs)
+
+
 def _common_options(f):
     """Shared options for commands that create a MemSearch instance."""
     f = click.option("--provider", "-p", default=None, help="Embedding provider.")(f)
@@ -208,11 +216,10 @@ def _indexing_options(f):
     return f
 
 
-@click.group()
+@click.group(cls=_MemSearchGroup)
 @click.version_option(package_name="memsearch")
 def cli() -> None:
     """memsearch — semantic memory search for markdown knowledge bases."""
-    _configure_cli_streams()
 
 
 @cli.command()

--- a/tests/test_cli_output_encoding.py
+++ b/tests/test_cli_output_encoding.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import subprocess
 import sys
+from contextlib import suppress
 from types import SimpleNamespace
 
+import click
 import pytest
+from click.testing import CliRunner
 
 from memsearch import cli as cli_module
 
 
-def test_cli_entrypoint_reconfigures_redirected_streams(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--help"],
+        ["--version"],
+        ["--invalid-option"],
+    ],
+)
+def test_cli_reconfigures_streams_before_root_eager_exits(monkeypatch, args) -> None:
     stdout_buffer = io.BytesIO()
     stderr_buffer = io.BytesIO()
 
@@ -26,20 +38,37 @@ def test_cli_entrypoint_reconfigures_redirected_streams(monkeypatch) -> None:
         errors="strict",
     )
 
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    with suppress(click.UsageError):
+        cli_module.cli.main(args=args, prog_name="memsearch", standalone_mode=False)
+
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert stderr.encoding.lower().replace("_", "-") == "utf-8"
+    assert stdout.errors == "replace"
+    assert stderr.errors == "replace"
+
+    stdout.flush()
+    stderr.flush()
+    stdout_buffer.getvalue().decode("utf-8")
+    stderr_buffer.getvalue().decode("utf-8")
+
+
+def test_cli_streams_replace_surrogates(monkeypatch) -> None:
+    stdout_buffer = io.BytesIO()
+    stderr_buffer = io.BytesIO()
+
+    stdout = io.TextIOWrapper(stdout_buffer, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(stderr_buffer, encoding="cp1252", errors="strict")
+
     monkeypatch.setattr(
         cli_module,
         "sys",
         SimpleNamespace(stdout=stdout, stderr=stderr),
     )
 
-    callback = cli_module.cli.callback
-    assert callback is not None
-    callback()
-
-    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
-    assert stderr.encoding.lower().replace("_", "-") == "utf-8"
-    assert stdout.errors == "replace"
-    assert stderr.errors == "replace"
+    cli_module._configure_cli_streams()
 
     stdout.write(f"Amyloid-β clearance {chr(0xDCFF)}\n")
     stderr.write(f"Heading: 非拉丁字符 {chr(0xDCFF)}\n")
@@ -76,6 +105,31 @@ def test_configure_cli_streams_ignores_unsupported_streams(
     cli_module._configure_cli_streams()
 
 
+def test_click_runner_capture_remains_supported() -> None:
+    result = CliRunner().invoke(cli_module.cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert "version" in result.output
+
+
+def test_import_does_not_reconfigure_streams() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            ("import sys; before = sys.stdout.encoding; import memsearch.cli; print(before, sys.stdout.encoding)"),
+        ],
+        env={
+            **os.environ,
+            "PYTHONIOENCODING": "cp1252:strict",
+        },
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr.decode("cp1252", "replace")
+    assert proc.stdout.decode("cp1252").strip() == "cp1252 cp1252"
+
+
 def test_redirected_output_survives_a_legacy_code_page(tmp_path) -> None:
     (tmp_path / ".memsearch.toml").write_text(
         '[index]\nnotes_dir = "/tmp/amyloid-β-notes"\n',
@@ -90,6 +144,7 @@ def test_redirected_output_survives_a_legacy_code_page(tmp_path) -> None:
             "config",
             "list",
             "--project",
+            "--json-output",
         ],
         cwd=tmp_path,
         env={
@@ -100,4 +155,6 @@ def test_redirected_output_survives_a_legacy_code_page(tmp_path) -> None:
     )
 
     assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
-    assert "amyloid-β-notes" in proc.stdout.decode("utf-8")
+    output = proc.stdout.decode("utf-8")
+    assert "amyloid-β-notes" in output
+    assert isinstance(json.loads(output), dict)

--- a/tests/test_cli_output_encoding.py
+++ b/tests/test_cli_output_encoding.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import io
+import os
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -71,3 +74,30 @@ def test_configure_cli_streams_ignores_unsupported_streams(
     )
 
     cli_module._configure_cli_streams()
+
+
+def test_redirected_output_survives_a_legacy_code_page(tmp_path) -> None:
+    (tmp_path / ".memsearch.toml").write_text(
+        '[index]\nnotes_dir = "/tmp/amyloid-β-notes"\n',
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "memsearch",
+            "config",
+            "list",
+            "--project",
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONIOENCODING": "cp1252",
+        },
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    assert "amyloid-β-notes" in proc.stdout.decode("utf-8")

--- a/tests/test_cli_output_encoding.py
+++ b/tests/test_cli_output_encoding.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from memsearch import cli as cli_module
+
+
+def test_cli_entrypoint_reconfigures_redirected_streams(monkeypatch) -> None:
+    stdout_buffer = io.BytesIO()
+    stderr_buffer = io.BytesIO()
+
+    stdout = io.TextIOWrapper(
+        stdout_buffer,
+        encoding="cp1252",
+        errors="strict",
+    )
+    stderr = io.TextIOWrapper(
+        stderr_buffer,
+        encoding="cp1252",
+        errors="strict",
+    )
+
+    monkeypatch.setattr(
+        cli_module,
+        "sys",
+        SimpleNamespace(stdout=stdout, stderr=stderr),
+    )
+
+    callback = cli_module.cli.callback
+    assert callback is not None
+    callback()
+
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert stderr.encoding.lower().replace("_", "-") == "utf-8"
+    assert stdout.errors == "replace"
+    assert stderr.errors == "replace"
+
+    stdout.write(f"Amyloid-β clearance {chr(0xDCFF)}\n")
+    stderr.write(f"Heading: 非拉丁字符 {chr(0xDCFF)}\n")
+    stdout.flush()
+    stderr.flush()
+
+    stdout_text = stdout_buffer.getvalue().decode("utf-8")
+    stderr_text = stderr_buffer.getvalue().decode("utf-8")
+
+    assert "Amyloid-β clearance" in stdout_text
+    assert "Heading: 非拉丁字符" in stderr_text
+    assert "?" in stdout_text
+    assert "?" in stderr_text
+
+
+@pytest.mark.parametrize("exception_type", [AttributeError, OSError])
+def test_configure_cli_streams_ignores_unsupported_streams(
+    monkeypatch,
+    exception_type,
+) -> None:
+    class UnsupportedStream:
+        def reconfigure(self, **_kwargs) -> None:
+            raise exception_type()
+
+    monkeypatch.setattr(
+        cli_module,
+        "sys",
+        SimpleNamespace(
+            stdout=UnsupportedStream(),
+            stderr=UnsupportedStream(),
+        ),
+    )
+
+    cli_module._configure_cli_streams()


### PR DESCRIPTION
## Summary

* configure stdout and stderr as UTF-8 once at the shared CLI entry point
* use `errors='replace'` to prevent surrogate-escaped text from raising another encoding exception
* preserve compatibility with streams that do not support `reconfigure`
* add platform-independent regression tests using cp1252-backed redirected streams

## Context

On Windows, redirected CLI output can use the active ANSI code page instead of the UTF-8 console stream. As identified by @Haifischfutter, this can cause `memsearch search` and `memsearch expand` to terminate with `UnicodeEncodeError` after already writing partial output.

This implementation follows the stream-level approach suggested in the issue. The configuration is applied once at the shared Click entry point rather than changing individual `click.echo` call sites.

## Implementation

* add `_configure_cli_streams`
* call it from the root `cli` callback
* configure stdout and stderr with UTF-8 and replacement error handling
* suppress `AttributeError` and `OSError` for unsupported stream wrappers
* add regression coverage for cp1252 redirected streams and unsupported streams

## Test plan

* [x] `uv run python -m pytest tests/test_cli_output_encoding.py -v`
* [x] CLI configuration, error-handling, and help tests
* [x] `uv run ruff check src/ tests/`
* [x] `uv run ruff format --check src/ tests/`
* [x] full test suite executed locally

The targeted encoding tests and existing CLI tests pass. The remaining local full-suite failures are unrelated Windows environment limitations involving Milvus Lite, Bash hook execution, symlink permissions, and platform-specific path handling.

Closes #659
