### PR TITLE
fix(store): don't report every local open failure as a version mismatch

### DIFF
--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import sys
 from pathlib import Path
@@ -13,6 +14,39 @@ logger = logging.getLogger(__name__)
 def _escape_filter_value(value: str) -> str:
     """Escape backslashes and double quotes for Milvus filter expressions."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _milvus_lite_major() -> int | None:
+    """Major version of the installed milvus-lite, or None if it cannot be read."""
+    try:
+        return int(importlib.metadata.version("milvus-lite").split(".")[0])
+    except (importlib.metadata.PackageNotFoundError, ValueError):
+        return None
+
+
+def _local_open_error_message(exc: Exception, resolved: str, major: int | None) -> str:
+    """Describe a failed local Milvus Lite open without asserting an unproven cause.
+
+    Milvus Lite 3.x stores a database as a directory, so a plain file under a 3.x
+    runtime is a leftover 2.x database and is safe to diagnose. Every other failure
+    is reported with the underlying error and no remediation that discards data:
+    pymilvus reports a database held by another process as a bare
+    ConnectionConfigException carrying no cause, so the reason is not recoverable
+    here and must not be guessed at.
+    """
+    if major is not None and major >= 3 and Path(resolved).is_file():
+        return (
+            f"This database was created by Milvus Lite 2.x, but Milvus Lite {major}.x is installed "
+            f"and needs a directory, not a file. Move {resolved} aside and rebuild the index with "
+            f"'memsearch index', or use Milvus Server via Docker or Zilliz Cloud instead. "
+            f"Original error: {exc}"
+        )
+    return (
+        f"Could not open the local Milvus database at {resolved}: {exc}. This can happen if another "
+        "process already has the database open, if file permissions are wrong, or if the file is "
+        "damaged. Check the log output above this message; milvus-lite prints the underlying cause "
+        "there. Do not delete the database until you have ruled out the first two causes."
+    )
 
 
 class MilvusStore:
@@ -55,13 +89,7 @@ class MilvusStore:
             self._client = MilvusClient(**connect_kwargs)
         except Exception as exc:
             if is_local:
-                raise RuntimeError(
-                    "Failed to open the local Milvus Lite database. If this database was created "
-                    "with an older Milvus Lite release, it may not be compatible with Milvus Lite "
-                    "3.x. Move the existing .db file aside, then rebuild the index from your "
-                    "source markdown files with 'memsearch index'. Alternatively, use Milvus "
-                    "Server via Docker or Zilliz Cloud."
-                ) from exc
+                raise RuntimeError(_local_open_error_message(exc, resolved, _milvus_lite_major())) from exc
             raise
         self._is_lite = is_local
         self._resolved_uri = resolved

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -45,8 +45,9 @@ def _local_open_error_message(exc: Exception, resolved: str, major: int | None) 
     return (
         f"Could not open the local Milvus database at {resolved}: {exc}. This can happen if another "
         "process already has the database open, if file permissions are wrong, or if the file is "
-        "damaged. Check the log output above this message; milvus-lite prints the underlying cause "
-        "there. Do not delete the database until you have ruled out the first two causes."
+        "damaged. Close other processes using this database and verify that the path is writable. "
+        "If the problem continues, preserve the database and inspect the application logs before "
+        "attempting recovery."
     )
 
 

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -28,18 +28,19 @@ def _local_open_error_message(exc: Exception, resolved: str, major: int | None) 
     """Describe a failed local Milvus Lite open without asserting an unproven cause.
 
     Milvus Lite 3.x stores a database as a directory, so a plain file under a 3.x
-    runtime is a leftover 2.x database and is safe to diagnose. Every other failure
-    is reported with the underlying error and no remediation that discards data:
-    pymilvus reports a database held by another process as a bare
+    runtime is a layout mismatch worth reporting, but the path being a file does not
+    prove Milvus Lite 2.x wrote it: a mistyped URI reaches the same branch. Every
+    failure is reported with the underlying error and no remediation that discards
+    data. pymilvus reports a database held by another process as a bare
     ConnectionConfigException carrying no cause, so the reason is not recoverable
     here and must not be guessed at.
     """
     if major is not None and major >= 3 and Path(resolved).is_file():
         return (
-            f"This database was created by Milvus Lite 2.x, but Milvus Lite {major}.x is installed "
-            f"and needs a directory, not a file. Move {resolved} aside and rebuild the index with "
-            f"'memsearch index', or use Milvus Server via Docker or Zilliz Cloud instead. "
-            f"Original error: {exc}"
+            f"Could not open the local Milvus database at {resolved}: {exc}. Milvus Lite {major}.x "
+            f"stores a database as a directory, but this path is a file. If it is a database from "
+            f"Milvus Lite 2.x, move it aside and rebuild the index with 'memsearch index'. "
+            f"Otherwise check the configured URI, or use Milvus Server via Docker or Zilliz Cloud."
         )
     return (
         f"Could not open the local Milvus database at {resolved}: {exc}. This can happen if another "

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,10 +1,12 @@
 """Tests for the Milvus store."""
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from memsearch.store import MilvusStore
+from memsearch.store import MilvusStore, _local_open_error_message
 
 
 @pytest.fixture
@@ -203,3 +205,71 @@ def test_collection_description_empty_by_default(tmp_path: Path):
     info = s._client.describe_collection(s._collection)
     assert info.get("description") == ""
     s.close()
+
+
+def test_open_error_diagnoses_stale_2x_database(tmp_path: Path):
+    """A plain file under a 3.x runtime really is a leftover 2.x database."""
+    db = tmp_path / "old.db"
+    db.write_text("")
+    message = _local_open_error_message(RuntimeError("open failed"), str(db), 3)
+    assert "created by Milvus Lite 2.x" in message
+    assert "Move" in message
+    assert "open failed" in message
+
+
+def test_open_error_keeps_2x_layout_generic(tmp_path: Path):
+    """On a 2.x runtime a plain file is the normal layout, not a stale database."""
+    db = tmp_path / "current.db"
+    db.write_text("")
+    message = _local_open_error_message(RuntimeError("open failed"), str(db), 2)
+    assert "created by Milvus Lite 2.x" not in message
+    assert "Move" not in message
+    assert "open failed" in message
+
+
+def test_open_error_keeps_3x_layout_generic(tmp_path: Path):
+    """A directory is the expected 3.x layout, so nothing is diagnosable."""
+    db = tmp_path / "current.db"
+    db.mkdir()
+    message = _local_open_error_message(RuntimeError("open failed"), str(db), 3)
+    assert "created by Milvus Lite 2.x" not in message
+    assert "Move" not in message
+
+
+def test_open_error_generic_when_version_unknown(tmp_path: Path):
+    """An unreadable milvus-lite version proves nothing about the layout."""
+    db = tmp_path / "old.db"
+    db.write_text("")
+    message = _local_open_error_message(RuntimeError("open failed"), str(db), None)
+    assert "created by Milvus Lite 2.x" not in message
+    assert "Move" not in message
+
+
+_HOLD_DATABASE = """
+import sys
+import time
+
+from pymilvus import MilvusClient
+
+MilvusClient(uri=sys.argv[1])
+print("READY", flush=True)
+time.sleep(30)
+"""
+
+
+def test_concurrent_open_is_not_reported_as_incompatibility(tmp_path: Path):
+    """A database held by another process must not be diagnosed as an
+    incompatible old database, which would advise discarding a working index."""
+    db = str(tmp_path / "busy.db")
+    holder = subprocess.Popen([sys.executable, "-c", _HOLD_DATABASE, db], stdout=subprocess.PIPE, text=True)
+    try:
+        assert holder.stdout.readline().strip() == "READY"
+        with pytest.raises(RuntimeError) as excinfo:
+            MilvusStore(uri=db, dimension=4)
+        message = str(excinfo.value)
+        assert "another process already has the database open" in message
+        assert "created by Milvus Lite 2.x" not in message
+        assert "Move" not in message
+    finally:
+        holder.kill()
+        holder.wait(timeout=30)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -257,6 +257,16 @@ def test_open_error_generic_when_version_unknown(tmp_path: Path):
     assert "move it aside" not in message
 
 
+def test_open_error_is_actionable_without_visible_logs(tmp_path: Path):
+    """Library and plugin callers may redirect or suppress dependency logs."""
+    db = tmp_path / "current.db"
+    message = _local_open_error_message(RuntimeError("open failed"), str(db), 3)
+    assert "Close other processes" in message
+    assert "verify that the path is writable" in message
+    assert "preserve the database" in message
+    assert "log output above" not in message
+
+
 _HOLD_DATABASE = """
 import pathlib
 import sys

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -207,23 +208,34 @@ def test_collection_description_empty_by_default(tmp_path: Path):
     s.close()
 
 
-def test_open_error_diagnoses_stale_2x_database(tmp_path: Path):
-    """A plain file under a 3.x runtime really is a leftover 2.x database."""
+def test_open_error_reports_file_where_directory_expected(tmp_path: Path):
+    """Under a 3.x runtime a plain file is a real layout mismatch worth reporting."""
     db = tmp_path / "old.db"
     db.write_text("")
     message = _local_open_error_message(RuntimeError("open failed"), str(db), 3)
-    assert "created by Milvus Lite 2.x" in message
-    assert "Move" in message
+    assert "but this path is a file" in message
     assert "open failed" in message
 
 
+def test_open_error_does_not_assert_the_file_is_a_2x_database(tmp_path: Path):
+    """The path being a file does not prove Milvus Lite 2.x wrote it. A mistyped
+    URI pointing at any unrelated file reaches this branch, so the legacy database
+    must be offered as one possibility, never stated as fact."""
+    unrelated = tmp_path / "notes.txt"
+    unrelated.write_text("not a database")
+    message = _local_open_error_message(RuntimeError("open failed"), str(unrelated), 3)
+    assert "If it is a database from Milvus Lite 2.x" in message
+    assert "was created by Milvus Lite 2.x" not in message
+    assert "check the configured URI" in message
+
+
 def test_open_error_keeps_2x_layout_generic(tmp_path: Path):
-    """On a 2.x runtime a plain file is the normal layout, not a stale database."""
+    """On a 2.x runtime a plain file is the normal layout, not a mismatch."""
     db = tmp_path / "current.db"
     db.write_text("")
     message = _local_open_error_message(RuntimeError("open failed"), str(db), 2)
-    assert "created by Milvus Lite 2.x" not in message
-    assert "Move" not in message
+    assert "but this path is a file" not in message
+    assert "move it aside" not in message
     assert "open failed" in message
 
 
@@ -232,8 +244,8 @@ def test_open_error_keeps_3x_layout_generic(tmp_path: Path):
     db = tmp_path / "current.db"
     db.mkdir()
     message = _local_open_error_message(RuntimeError("open failed"), str(db), 3)
-    assert "created by Milvus Lite 2.x" not in message
-    assert "Move" not in message
+    assert "but this path is a file" not in message
+    assert "move it aside" not in message
 
 
 def test_open_error_generic_when_version_unknown(tmp_path: Path):
@@ -241,35 +253,63 @@ def test_open_error_generic_when_version_unknown(tmp_path: Path):
     db = tmp_path / "old.db"
     db.write_text("")
     message = _local_open_error_message(RuntimeError("open failed"), str(db), None)
-    assert "created by Milvus Lite 2.x" not in message
-    assert "Move" not in message
+    assert "but this path is a file" not in message
+    assert "move it aside" not in message
 
 
 _HOLD_DATABASE = """
+import pathlib
 import sys
 import time
 
 from pymilvus import MilvusClient
 
 MilvusClient(uri=sys.argv[1])
-print("READY", flush=True)
+pathlib.Path(sys.argv[2]).write_text("ready")
 time.sleep(30)
 """
+
+_HOLD_TIMEOUT_S = 60
+
+
+def _wait_until_held(holder: subprocess.Popen, ready: Path) -> None:
+    """Block until the child has the database open, or fail with its stderr.
+
+    A readiness read with no bound can hang the whole suite if the child stalls,
+    so this polls a marker file against a deadline and surfaces the child's own
+    output when it dies early or never gets there.
+    """
+    deadline = time.monotonic() + _HOLD_TIMEOUT_S
+    while not ready.exists():
+        if holder.poll() is not None:
+            _, err = holder.communicate()
+            raise AssertionError(f"holder exited with {holder.returncode} before opening the database: {err.strip()}")
+        if time.monotonic() > deadline:
+            holder.kill()
+            _, err = holder.communicate()
+            raise AssertionError(f"holder did not open the database within {_HOLD_TIMEOUT_S}s: {err.strip()}")
+        time.sleep(0.05)
 
 
 def test_concurrent_open_is_not_reported_as_incompatibility(tmp_path: Path):
     """A database held by another process must not be diagnosed as an
     incompatible old database, which would advise discarding a working index."""
     db = str(tmp_path / "busy.db")
-    holder = subprocess.Popen([sys.executable, "-c", _HOLD_DATABASE, db], stdout=subprocess.PIPE, text=True)
+    ready = tmp_path / "holder.ready"
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _HOLD_DATABASE, db, str(ready)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     try:
-        assert holder.stdout.readline().strip() == "READY"
+        _wait_until_held(holder, ready)
         with pytest.raises(RuntimeError) as excinfo:
             MilvusStore(uri=db, dimension=4)
         message = str(excinfo.value)
         assert "another process already has the database open" in message
-        assert "created by Milvus Lite 2.x" not in message
-        assert "Move" not in message
+        assert "but this path is a file" not in message
+        assert "move it aside" not in message
     finally:
         holder.kill()
         holder.wait(timeout=30)


### PR DESCRIPTION
Closes #652

## Problem

On a local URI, `MilvusStore.__init__` catches every exception from `MilvusClient(...)` and re-raises the same message: your database is from an older Milvus Lite, move it aside and rebuild. One common way to hit that path is another process having the database open. So a lock that clears by itself gets reported as a permanent format problem, and the advice throws away a working index.

## Why not just read `__cause__`

That was my first attempt too, and it doesn't work. I held a database open in one process and opened it from another, on milvus-lite 2.5.1 and 3.1.1. Both raise `ConnectionConfigException(code=1, "Open local milvus failed")` with `__cause__` and `__context__` set to `None`, and `DataDirLockedError` never appears in the traceback. milvus-lite does report the reason, but it prints it to stderr ("Open ... failed, the file has been opened by another program" on 2.5.1) instead of chaining it into the exception.

The file-versus-directory check in the issue has a similar catch. On 2.5.1 a healthy database is a single file, so using it unconditionally would show the "outdated, delete it" message to every 2.5.1 user with an unrelated error. It only means something on 3.x, so it is gated on the installed major version.

## Change

Keep the old message for the one case that is provable: milvus-lite 3.x installed and the path is a plain file. Everything else reports the real error and the possible causes without picking one, and does not tell you to delete anything.

No lock probe. It would need milvus-lite's private lock file, which differs by version (`fcntl.lockf` on a `.<name>.lock` sibling in 2.5.1, `fcntl.flock` on `LOCK` in 3.1.1), and probing the 2.x one can drop a lock this process is holding, since POSIX record locks release on any close. stderr already says it.

## Testing

Four unit tests for the branches, including the 2.5.1 plain-file case. One test holds the database open in a subprocess and checks the error does not tell you to move the database aside. It fails on the current message and passes with this change.

296 passed, 7 skipped. `ruff check` and `ruff format --check` both clean.
