### PR TITLE
fix: resolve bash executable path for Windows test subprocess calls

### DIFF
--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -2,8 +2,35 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+
+def _resolve_bash() -> str:
+    """Locate a bash executable usable by subprocess.run.
+
+    On Windows, "bash" alone only resolves via PATH inside a Git Bash
+    session, where Git's usr/bin is on PATH. A plain PowerShell/cmd
+    session doesn't have it on PATH at all, so shutil.which also
+    returns None there. Fall back to deriving Git's install root from
+    the git executable, which is reliably on PATH, and look for
+    bash.exe relative to it.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    git = shutil.which("git")
+    if git:
+        git_root = Path(git).resolve().parent.parent
+        for candidate in ("bin/bash.exe", "usr/bin/bash.exe"):
+            path = git_root / candidate
+            if path.exists():
+                return str(path)
+    return "bash"
+
+
+BASH = _resolve_bash()
 
 
 def _write_executable(path: Path, source: str) -> None:
@@ -40,7 +67,7 @@ def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Pat
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         input="{}",
         capture_output=True,
         text=True,
@@ -93,7 +120,7 @@ echo '{"info":{"version":"0.4.16"}}'
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -182,7 +209,7 @@ exit 0
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -258,7 +285,7 @@ echo '{"info":{"version":"0.4.13"}}'
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -317,7 +344,7 @@ exit 0
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -387,7 +414,7 @@ exit 0
     }
 
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -493,7 +520,7 @@ exit 0
         }
 
         result = subprocess.run(
-            ["bash", str(script)],
+            [BASH, str(script)],
             input=json.dumps({"cwd": str(project)}),
             capture_output=True,
             text=True,
@@ -566,7 +593,7 @@ exit 0
         }
 
         result = subprocess.run(
-            ["bash", str(script)],
+            [BASH, str(script)],
             input=json.dumps({"cwd": str(project)}),
             capture_output=True,
             text=True,
@@ -652,7 +679,7 @@ echo "- User discussed a macOS stop hook regression."
         "CLAUDE_ARGS_FILE": str(claude_args),
     }
     result = subprocess.run(
-        ["bash", str(script)],
+        [BASH, str(script)],
         input=json.dumps({"transcript_path": str(transcript)}),
         capture_output=True,
         text=True,
@@ -737,7 +764,7 @@ esac
 
     def run_stop(transcript: Path) -> None:
         result = subprocess.run(
-            ["bash", str(script)],
+            [BASH, str(script)],
             input=json.dumps({"transcript_path": str(transcript)}),
             capture_output=True,
             text=True,

--- a/tests/test_claude_parse_transcript.py
+++ b/tests/test_claude_parse_transcript.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
+
+
+def _resolve_bash() -> str:
+    """Locate a bash executable usable by subprocess.run.
+
+    See tests/test_claude_hooks.py::_resolve_bash for why "bash" alone
+    is unreliable on Windows outside a Git Bash session.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    git = shutil.which("git")
+    if git:
+        git_root = Path(git).resolve().parent.parent
+        for candidate in ("bin/bash.exe", "usr/bin/bash.exe"):
+            path = git_root / candidate
+            if path.exists():
+                return str(path)
+    return "bash"
+
+
+BASH = _resolve_bash()
 
 SCRIPT = Path("plugins/claude-code/hooks/parse-transcript.sh")
 
@@ -13,7 +36,7 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
 
 def _run_parse(path: Path) -> str:
     result = subprocess.run(
-        ["bash", str(SCRIPT), str(path)],
+        [BASH, str(SCRIPT), str(path)],
         check=True,
         capture_output=True,
         text=True,

--- a/tests/test_codex_parse_rollout.py
+++ b/tests/test_codex_parse_rollout.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
+
+
+def _resolve_bash() -> str:
+    """Locate a bash executable usable by subprocess.run.
+
+    See tests/test_claude_hooks.py::_resolve_bash for why "bash" alone
+    is unreliable on Windows outside a Git Bash session.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    git = shutil.which("git")
+    if git:
+        git_root = Path(git).resolve().parent.parent
+        for candidate in ("bin/bash.exe", "usr/bin/bash.exe"):
+            path = git_root / candidate
+            if path.exists():
+                return str(path)
+    return "bash"
+
+
+BASH = _resolve_bash()
 
 SCRIPT = Path("plugins/codex/scripts/parse-rollout.sh")
 
@@ -13,7 +36,7 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
 
 def _run_parse(path: Path) -> str:
     result = subprocess.run(
-        ["bash", str(SCRIPT), str(path)],
+        [BASH, str(SCRIPT), str(path)],
         check=True,
         capture_output=True,
         text=True,

--- a/tests/test_codex_stop_hook_utf8.py
+++ b/tests/test_codex_stop_hook_utf8.py
@@ -2,8 +2,31 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+
+def _resolve_bash() -> str:
+    """Locate a bash executable usable by subprocess.run.
+
+    See tests/test_claude_hooks.py::_resolve_bash for why "bash" alone
+    is unreliable on Windows outside a Git Bash session.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    git = shutil.which("git")
+    if git:
+        git_root = Path(git).resolve().parent.parent
+        for candidate in ("bin/bash.exe", "usr/bin/bash.exe"):
+            path = git_root / candidate
+            if path.exists():
+                return str(path)
+    return "bash"
+
+
+BASH = _resolve_bash()
 
 SCRIPT = Path("plugins/codex/hooks/stop.sh")
 
@@ -48,7 +71,7 @@ def test_codex_stop_worker_fallback_summary_preserves_utf8(tmp_path: Path) -> No
         # formatting is exercised even on machines with codex installed.
         "PATH": f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin",
     }
-    subprocess.run(["bash", str(SCRIPT), "--worker", str(work_file)], check=True, env=env)
+    subprocess.run([BASH, str(SCRIPT), "--worker", str(work_file)], check=True, env=env)
 
     content = memory_file.read_text(encoding="utf-8")
     assert "- User asked: как поправить?" in content


### PR DESCRIPTION
Closes #665

### Problem
`subprocess.run(["bash", ...])` only resolves `bash` on Windows when the calling shell already has Git's `usr/bin` on PATH (i.e. inside a Git Bash session itself). A plain PowerShell/cmd session doesn't have it on PATH at all, so the bare string raised `FileNotFoundError: [WinError 2]`.

### Fix
Added a small `_resolve_bash()` helper (duplicated in each affected test file, since this pytest config's import mode doesn't reliably support cross-file imports from `conftest.py`) that:
1. Tries `shutil.which("bash")` first (works on Linux/macOS/Git Bash where it's on PATH).
2. Falls back to deriving Git's install root from the `git` executable (reliably on PATH via `shutil.which("git")`) and checks `bin/bash.exe` / `usr/bin/bash.exe` relative to it.
3. Falls back to the bare `"bash"` string if neither resolves, preserving current behavior everywhere else.

### Verified
Tested on Windows 11 in a plain PowerShell session (not Git Bash) — the actual repro conditions from #665. Diffed the full test suite's failure list before/after:
- **4 tests fixed**, **0 regressions** (`test_claude_hook_memsearch_disable_exits_before_writing_memory`, `test_claude_session_start_does_not_create_journal`, `test_claude_session_start_falls_back_for_older_cli`, `test_session_start_shows_skill_candidate_hint`)

### Note on scope
Some other tests in these same files (`test_codex_parse_rollout.py`, `test_codex_stop_hook_utf8.py`) still fail on Windows for an unrelated reason: the `.sh` scripts they exercise call `python3` internally, and Windows only ships `python.exe` (no `python3` alias), so it falls through to the Microsoft Store app-execution-alias stub. That's a separate, pre-existing issue affecting ~33 files across the plugins — out of scope for this PR, happy to file it separately if useful.