### PR TITLE
fix: tolerate prose around maintenance JSON responses

### DIFF
--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -583,21 +583,21 @@ def _parse_task_response(raw: str) -> dict[str, str]:
         cursor = 0
         while True:
             brace = text.find("{", cursor)
-            if brace < 0:
+            bracket = text.find("[", cursor)
+            starts = [position for position in (brace, bracket) if position >= 0]
+            if not starts:
                 break
+            start = min(starts)
 
             try:
-                candidate, end = decoder.raw_decode(
-                    text,
-                    brace,
-                )
+                candidate, end = decoder.raw_decode(text, start)
             except json.JSONDecodeError:
-                depth = 0
+                stack: list[str] = []
                 in_string = False
                 escaped = False
                 balanced_end: int | None = None
 
-                for index in range(brace, len(text)):
+                for index in range(start, len(text)):
                     char = text[index]
 
                     if in_string:
@@ -611,11 +611,14 @@ def _parse_task_response(raw: str) -> dict[str, str]:
 
                     if char == '"':
                         in_string = True
-                    elif char == "{":
-                        depth += 1
-                    elif char == "}":
-                        depth -= 1
-                        if depth == 0:
+                    elif char in "{[":
+                        stack.append(char)
+                    elif char in "}]":
+                        expected = "{" if char == "}" else "["
+                        if not stack or stack[-1] != expected:
+                            break
+                        stack.pop()
+                        if not stack:
                             balanced_end = index + 1
                             break
 

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -572,10 +572,34 @@ def _parse_task_response(raw: str) -> dict[str, str]:
     match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
     if match:
         text = match.group(1)
+
     try:
         data = json.loads(text)
-    except json.JSONDecodeError as e:
-        raise RuntimeError(f"Maintenance LLM did not return valid JSON: {e}") from e
+    except json.JSONDecodeError as initial_error:
+        decoder = json.JSONDecoder()
+        last_object: dict[str, Any] | None = None
+        last_action_object: dict[str, Any] | None = None
+
+        for brace in re.finditer(r"\{", text):
+            try:
+                candidate, _ = decoder.raw_decode(
+                    text,
+                    brace.start(),
+                )
+            except json.JSONDecodeError:
+                continue
+
+            if not isinstance(candidate, dict):
+                continue
+
+            last_object = candidate
+            if "action" in candidate:
+                last_action_object = candidate
+
+        data = last_action_object or last_object
+        if data is None:
+            raise RuntimeError(f"Maintenance LLM did not return valid JSON: {initial_error}") from initial_error
+
     action = data.get("action")
     if action not in {"none", "replace"}:
         raise RuntimeError("Maintenance LLM action must be 'none' or 'replace'")

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -580,14 +580,52 @@ def _parse_task_response(raw: str) -> dict[str, str]:
         last_object: dict[str, Any] | None = None
         last_action_object: dict[str, Any] | None = None
 
-        for brace in re.finditer(r"\{", text):
+        cursor = 0
+        while True:
+            brace = text.find("{", cursor)
+            if brace < 0:
+                break
+
             try:
-                candidate, _ = decoder.raw_decode(
+                candidate, end = decoder.raw_decode(
                     text,
-                    brace.start(),
+                    brace,
                 )
             except json.JSONDecodeError:
+                depth = 0
+                in_string = False
+                escaped = False
+                balanced_end: int | None = None
+
+                for index in range(brace, len(text)):
+                    char = text[index]
+
+                    if in_string:
+                        if escaped:
+                            escaped = False
+                        elif char == "\\":
+                            escaped = True
+                        elif char == '"':
+                            in_string = False
+                        continue
+
+                    if char == '"':
+                        in_string = True
+                    elif char == "{":
+                        depth += 1
+                    elif char == "}":
+                        depth -= 1
+                        if depth == 0:
+                            balanced_end = index + 1
+                            break
+
+                if balanced_end is None:
+                    break
+
+                cursor = balanced_end
                 continue
+
+            cursor = end
 
             if not isinstance(candidate, dict):
                 continue

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -230,6 +230,34 @@ The expected no-op shape is {"action":"none","reason":"example"}.
     }
 
 
+def test_parse_task_response_preserves_outer_action_with_nested_object() -> None:
+    raw = (
+        json.dumps(
+            {
+                "action": "replace",
+                "reason": "durable update",
+                "content": "# Project Memory",
+                "meta": {"action": "none"},
+            }
+        )
+        + "\n\nDone."
+    )
+
+    parsed = _parse_task_response(raw)
+
+    assert parsed["action"] == "replace"
+
+
+def test_parse_task_response_rejects_truncated_outer_with_nested_action() -> None:
+    raw = '## Result\n{"action":"replace","meta":{"action":"none"},"content":"# Project Memory'
+
+    with pytest.raises(
+        RuntimeError,
+        match="did not return valid JSON",
+    ):
+        _parse_task_response(raw)
+
+
 def test_parse_task_response_preserves_braces_inside_content() -> None:
     raw = (
         json.dumps(

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -295,6 +295,26 @@ def test_parse_task_response_rejects_invalid_action() -> None:
         _parse_task_response(raw)
 
 
+def test_parse_task_response_rejects_nested_action_inside_non_dict() -> None:
+    raw = '[{"action":"none"}] trailing prose'
+
+    with pytest.raises(
+        RuntimeError,
+        match="did not return valid JSON",
+    ):
+        _parse_task_response(raw)
+
+
+def test_parse_task_response_rejects_truncated_non_dict_with_nested_action() -> None:
+    raw = '[{"action":"none"}'
+
+    with pytest.raises(
+        RuntimeError,
+        match="did not return valid JSON",
+    ):
+        _parse_task_response(raw)
+
+
 def test_openai_maintenance_uses_default_temperature(tmp_path: Path, monkeypatch) -> None:
     from memsearch import maintenance as maintenance_module
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -13,6 +13,7 @@ from memsearch.maintenance import (
     MAX_PROMPT_CHARS,
     TaskContext,
     _build_prompt,
+    _parse_task_response,
     _read_recent_journals,
     run_due_tasks,
     run_memory_command,
@@ -152,6 +153,118 @@ def test_newest_entries_within_oversized_journal_survive(
     assert "EARLIEST_ENTRY_MARKER" not in journals
     assert "[older journal entries truncated]" in journals
     assert len(journals) <= budget
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"action":"none","reason":"ok"}',
+        '```json\n{"action":"none","reason":"ok"}\n```',
+    ],
+)
+def test_parse_task_response_preserves_supported_json_formats(raw: str) -> None:
+    assert _parse_task_response(raw) == {
+        "action": "none",
+        "reason": "ok",
+    }
+
+
+def test_parse_task_response_accepts_reasoning_before_json() -> None:
+    raw = """\
+## Reasoning
+The recent journals do not add durable project state.
+
+## Result
+{"action":"none","reason":"No durable change."}
+"""
+
+    assert _parse_task_response(raw) == {
+        "action": "none",
+        "reason": "No durable change.",
+    }
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        '"',
+        "\n\nDone.",
+    ],
+)
+def test_parse_task_response_accepts_trailing_text_after_json(
+    suffix: str,
+) -> None:
+    raw = '{"action":"none","reason":"ok"}' + suffix
+
+    assert _parse_task_response(raw) == {
+        "action": "none",
+        "reason": "ok",
+    }
+
+
+def test_parse_task_response_skips_invalid_braces_before_result() -> None:
+    raw = """\
+Reasoning mentioned {not valid JSON}.
+
+{"action":"none","reason":"ok"}
+"""
+
+    assert _parse_task_response(raw) == {
+        "action": "none",
+        "reason": "ok",
+    }
+
+
+def test_parse_task_response_prefers_final_maintenance_object() -> None:
+    raw = """\
+The expected no-op shape is {"action":"none","reason":"example"}.
+
+## Result
+{"action":"replace","reason":"durable update","content":"# Project Memory"}
+"""
+
+    assert _parse_task_response(raw) == {
+        "action": "replace",
+        "reason": "durable update",
+        "content": "# Project Memory",
+    }
+
+
+def test_parse_task_response_preserves_braces_inside_content() -> None:
+    raw = (
+        json.dumps(
+            {
+                "action": "replace",
+                "reason": "durable update",
+                "content": "# Project Memory\n\nUse {braces} safely.",
+            }
+        )
+        + "\n\nDone."
+    )
+
+    parsed = _parse_task_response(raw)
+
+    assert parsed["content"] == "# Project Memory\n\nUse {braces} safely."
+
+
+def test_parse_task_response_rejects_truncated_json() -> None:
+    raw = '## Result\n{"action":"replace","content":"# Project Memory'
+
+    with pytest.raises(
+        RuntimeError,
+        match="did not return valid JSON",
+    ):
+        _parse_task_response(raw)
+
+
+def test_parse_task_response_rejects_invalid_action() -> None:
+    raw = '{"action":"append","reason":"unsupported"}'
+
+    with pytest.raises(
+        RuntimeError,
+        match="action must be 'none' or 'replace'",
+    ):
+        _parse_task_response(raw)
 
 
 def test_openai_maintenance_uses_default_temperature(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #668.

Maintenance tasks currently expect the complete LLM response to be valid JSON, apart from the existing fenced JSON handling. Some OpenAI-compatible providers return an otherwise valid maintenance result with leading reasoning or trailing text, causing `_parse_task_response` to reject the response.

This change makes maintenance response parsing tolerant of surrounding prose while preserving the existing validation and failure behavior.

## Changes

* Preserve support for plain JSON and fenced JSON responses
* Use `json.JSONDecoder().raw_decode()` to locate complete JSON objects within mixed text
* Prefer the final complete object containing a maintenance `action`
* Continue validating that `action` is either `none` or `replace`
* Ignore unrelated or invalid brace sequences before the actual result
* Preserve nested braces inside JSON string values
* Continue rejecting genuinely malformed or truncated JSON
* Avoid provider-specific parsing or silent fallback to `action: none`

## Tests

Added regression coverage for:

* [x] Existing plain JSON responses
* [x] Existing fenced JSON responses
* [x] Reasoning text before a valid maintenance result
* [x] Trailing text or an extra quote after a complete JSON object
* [x] Invalid brace sequences before the actual result
* [x] Multiple JSON objects where the final object is the maintenance result
* [x] Braces inside replacement content
* [x] Truncated JSON remaining an explicit error
* [x] Unsupported maintenance actions remaining an explicit error

## Validation

Focused parser tests:

```text
uv run python -m pytest tests/test_maintenance.py -k "parse_task_response" -v
```

Maintenance tests excluding the existing Windows path-handling failure:

```text
uv run python -m pytest tests/test_maintenance.py -k "not run_memory_command_allows_transcript_outside_roots" -v
```

Code quality checks:

```text
uv run ruff check src/memsearch/maintenance.py tests/test_maintenance.py
uv run ruff format --check src/memsearch/maintenance.py tests/test_maintenance.py
```

The full test suite was also executed on Windows:

```text
264 passed, 7 skipped, 29 failed, 8 errors
```

The remaining failures and errors are outside the changed response-parsing code paths and fall into Windows-specific or environment-sensitive areas, including:

* Bash-based Claude Code and Codex hook execution
* Windows symlink privilege requirements
* Windows path normalization and home-directory behavior
* The existing maintenance command path test
* Milvus Lite, which does not provide Windows wheels

The focused response parsing tests and the remaining maintenance tests pass locally.

## Scope

This PR intentionally remains limited to provider-agnostic response parsing.

It does not add:

* Configurable `max_tokens`
* `response_format`
* Provider-specific `extra_body` parameters
* Automatic retries
* Silent fallback to `action: none`

Those changes can be considered separately without expanding this focused parsing fix.
