### PR TITLE
fix(claude-code): avoid raw transcript fallback

### DIFF
--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -136,7 +136,7 @@ Step by step:
 
     Raw tool calls, tool outputs, and transient failure details are omitted from summarization input. The assistant's textual response can still mention important files, searches, refactors, findings, and tests, and the summarizer can record those naturally.
 
-4. **Haiku summarization** -- the extracted turn is piped to `claude -p --model haiku` with a system prompt instructing it to write 2-10 third-person bullet points in the same language as the user's message. Set `plugins.claude-code.summarize.model` to override only this native capture model. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name. Empty or `native` keeps the Haiku default. The third-person framing ("User asked about...", "Agent implemented...") makes the summaries more useful as memory entries than first-person notes.
+4. **Haiku summarization** -- a prompt containing the summary instructions and extracted turn is piped to `claude -p --model haiku`. Set `plugins.claude-code.summarize.model` to override only this native capture model. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name. Empty or `native` keeps the Haiku default. The third-person framing ("User asked about...", "Agent implemented...") makes the summaries more useful as memory entries than first-person notes. If the summarizer cannot start, times out, exits unsuccessfully, or returns no text, the hook stores only a short diagnostic marker and retains the transcript anchor for progressive disclosure.
 
 5. **Append with anchors** -- on the first content-bearing Stop for a session, the hook creates the daily file if needed and writes `## Session HH:MM`. Each captured turn is written under a `### HH:MM` heading with an HTML comment anchor. Later Stops in the same session reuse its heading:
     ```markdown
@@ -239,7 +239,7 @@ plugins/claude-code/
 │   ├── session-start.sh         # Start watch + inject cold-start context
 │   ├── user-prompt-submit.sh    # Lightweight systemMessage hint
 │   ├── stop.sh                  # Parse transcript -> summarize -> lazily create heading -> append
-│   ├── parse-transcript.sh      # Deterministic JSONL-to-text parser with truncation
+│   ├── parse-transcript.sh      # Deterministic JSONL-to-text parser
 │   └── session-end.sh           # Stop watch process (cleanup)
 ├── scripts/
 │   └── derive-collection.sh     # Derive per-project collection name from project path

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -181,7 +181,7 @@ Fires after Claude finishes each response. Runs **asynchronously** so it does no
 1. **Guards against recursion.** Checks `stop_hook_active` to prevent infinite loops (since the hook itself calls `claude -p`).
 2. **Validates the transcript.** Skips if the transcript file is missing or has fewer than 3 lines.
 3. **Extracts the last turn.** Calls `parse-transcript.sh` (Python3 inline, no `jq` dependency), which finds the last real user message and extracts User/Assistant text from there to EOF. Skips progress, `file-history-snapshot`, system, thinking blocks, raw tool calls, and raw tool results. Formats output with clear role labels (`[User]`, `[Claude Code]`) so the summarizer works from a clean third-party transcript while still allowing the assistant's text to mention important files, searches, findings, and tests.
-4. **Summarizes with Haiku.** Pipes the parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence` with an external-observer system prompt requesting 2-10 third-person bullet points in the same language as the user's message. To override only this plugin's native summarize model, set `plugins.claude-code.summarize.model`; empty or unset keeps the Haiku default. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name.
+4. **Summarizes with Haiku.** Pipes a prompt containing the summary instructions and parsed turn to `CLAUDECODE= claude -p --model haiku --no-session-persistence`. To override only this plugin's native summarize model, set `plugins.claude-code.summarize.model`; empty or unset keeps the Haiku default. To use a memsearch-managed API provider instead, define `[llm.providers.<name>]` and set `plugins.claude-code.summarize.provider` to that name. Summarizer failures write only a short diagnostic marker; the transcript remains available through the progressive-disclosure anchor without copying its content into memory.
 5. **Appends to the daily log.** On the first content-bearing Stop for a session, creates the daily file if needed and writes `## Session HH:MM`. Every captured turn gets a `### HH:MM` sub-heading with an HTML comment anchor containing the session ID, turn UUID, and transcript path. Later Stops in the same session reuse its existing session heading. The hook then runs `memsearch index` for immediate indexing.
 
 #### SessionEnd
@@ -783,7 +783,7 @@ SessionStart does not create a daily file. If no content-bearing Stop has comple
 - `plugins.claude-code.summarize.enabled` is `false`.
 - The Stop hook timed out or failed; inspect the Claude Code debug log for the hook result.
 
-If the `claude` CLI is unavailable or native summarization returns no text, the hook falls back to the parsed turn instead of skipping the journal write.
+If summarization cannot start, times out, exits unsuccessfully, or returns no text, the hook writes a short diagnostic marker instead of the parsed turn. The entry retains its transcript anchor for progressive disclosure.
 
 ---
 

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -116,16 +116,29 @@ fi
 # summarize model override can replace the model without changing provider
 # routing.
 SUMMARY=""
+SUMMARY_STATUS=0
+SUMMARY_FAILURE=""
 SUMMARIZE_PROVIDER=""
 if [ -n "$MEMSEARCH_CMD" ]; then
   SUMMARIZE_PROVIDER=$($MEMSEARCH_CMD config get plugins.claude-code.summarize.provider 2>/dev/null || true)
 fi
 
+_run_summarizer() {
+  if command -v timeout &>/dev/null; then
+    timeout 110 "$@"
+  else
+    perl -e 'alarm shift; exec @ARGV' 110 "$@"
+  fi
+}
+
 if [ -n "$SUMMARIZE_PROVIDER" ] && [ "$SUMMARIZE_PROVIDER" != "native" ] && [ -n "$MEMSEARCH_CMD" ]; then
-  SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 $MEMSEARCH_CMD summarize \
+  set +e
+  SUMMARY=$(printf '%s' "$PARSED" | MEMSEARCH_NO_WATCH=1 _run_summarizer $MEMSEARCH_CMD summarize \
     --plugin claude-code \
     --agent-name "$AGENT_NAME" \
-    2>/dev/null || true)
+    2>/dev/null)
+  SUMMARY_STATUS=$?
+  set -e
 elif command -v claude &>/dev/null; then
   SUMMARIZE_MODEL="haiku"
   if [ -n "$MEMSEARCH_CMD" ]; then
@@ -134,8 +147,8 @@ elif command -v claude &>/dev/null; then
       SUMMARIZE_MODEL="$CONFIG_MODEL"
     fi
   fi
-  # Keep the shared external-observer prompt, but pass it as the primary prompt.
-  # This avoids the stdin + --system-prompt path while preserving summary rules.
+  # Keep the shared external-observer prompt as the primary prompt, but deliver
+  # it over stdin so transcript size never contributes to argv limits.
   LLM_PROMPT="${SYSTEM_PROMPT}
 
 Transcript:
@@ -144,20 +157,32 @@ ${PARSED}"
   if claude --help 2>/dev/null | grep -q -- '--safe-mode'; then
     CLAUDE_SAFE_MODE_ARG="--safe-mode"
   fi
-  SUMMARY=$(MEMSEARCH_NO_WATCH=1 MEMSEARCH_DISABLE=1 CLAUDECODE= claude -p \
+  set +e
+  SUMMARY=$(printf '%s' "$LLM_PROMPT" | MEMSEARCH_NO_WATCH=1 MEMSEARCH_DISABLE=1 CLAUDECODE= _run_summarizer claude -p \
     ${CLAUDE_SAFE_MODE_ARG:+"$CLAUDE_SAFE_MODE_ARG"} \
     --strict-mcp-config \
     --tools "" \
     --model "$SUMMARIZE_MODEL" \
     --no-session-persistence \
     --no-chrome \
-    "$LLM_PROMPT" \
-    2>/dev/null || true)
+    2>/dev/null)
+  SUMMARY_STATUS=$?
+  set -e
+else
+  SUMMARY_FAILURE="summarizer unavailable"
 fi
 
-# If claude is not available or returned empty, fall back to raw parsed output
-if [ -z "$SUMMARY" ]; then
-  SUMMARY="$PARSED"
+if [ -z "$SUMMARY_FAILURE" ] && [ "$SUMMARY_STATUS" -ne 0 ]; then
+  if [ "$SUMMARY_STATUS" -eq 124 ] || [ "$SUMMARY_STATUS" -eq 142 ]; then
+    SUMMARY_FAILURE="summarizer timed out"
+  else
+    SUMMARY_FAILURE="summarizer exited with status $SUMMARY_STATUS"
+  fi
+elif [ -z "$SUMMARY_FAILURE" ] && [ -z "$SUMMARY" ]; then
+  SUMMARY_FAILURE="summarizer returned empty output"
+fi
+if [ -n "$SUMMARY_FAILURE" ]; then
+  SUMMARY="- Memory summary unavailable: ${SUMMARY_FAILURE}; transcript content was omitted. Use the transcript anchor for progressive disclosure."
 fi
 
 # Append under a session heading, writing the heading lazily on the first

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _write_executable(path: Path, source: str) -> None:
     path.write_text(source, encoding="utf-8")
@@ -670,6 +672,142 @@ echo "- User discussed a macOS stop hook regression."
     assert captured_args[:4] == ["-p", "--strict-mcp-config", "--tools", ""]
     assert "--safe-mode" not in captured_args
     assert captured_args[captured_args.index("--model") + 1] == "haiku"
+
+
+def test_claude_stop_hook_sends_large_native_prompt_on_stdin(tmp_path: Path) -> None:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    transcript = tmp_path / "large.jsonl"
+    received = tmp_path / "received.txt"
+    home.mkdir()
+    fake_bin.mkdir()
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "system", "message": {"content": "start"}}),
+                json.dumps({"type": "user", "uuid": "turn-large", "message": {"content": "x" * 200000}}),
+                json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  case "$3" in
+    embedding.provider) echo onnx ;;
+    plugins.claude-code.summarize.enabled) echo true ;;
+    plugins.claude-code.summarize.provider) echo "" ;;
+    plugins.claude-code.summarize.model) echo "" ;;
+    prompts.summarize) echo "" ;;
+  esac
+fi
+if [ "$1" = index ]; then exit 0; fi
+""",
+    )
+    _write_executable(
+        fake_bin / "claude",
+        """#!/usr/bin/env bash
+if [ "${1:-}" = --help ]; then exit 0; fi
+cat > "$CLAUDE_INPUT_FILE"
+echo '- Large turn summarized.'
+""",
+    )
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(Path("plugins/claude-code").resolve()),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "CLAUDE_INPUT_FILE": str(received),
+    }
+    result = subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    assert result.stdout.strip() == "{}"
+    assert len(received.read_text(encoding="utf-8")) > 200000
+    memory_text = next((memsearch_dir / "memory").glob("*.md")).read_text(encoding="utf-8")
+    assert "Large turn summarized." in memory_text
+    assert "x" * 1000 not in memory_text
+
+
+@pytest.mark.parametrize("route", ["native", "provider"])
+@pytest.mark.parametrize("mode", ["missing", "nonzero", "empty", "timeout"])
+def test_claude_stop_hook_failure_never_persists_transcript(tmp_path: Path, route: str, mode: str) -> None:
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    home, fake_bin, memsearch_dir = tmp_path / "home", tmp_path / "bin", tmp_path / ".memsearch"
+    transcript = tmp_path / "session.jsonl"
+    home.mkdir()
+    fake_bin.mkdir()
+    marker = "SECRET-TRANSCRIPT-MARKER"
+    _write_claude_transcript(transcript, turn_uuid="turn-failure")
+    transcript.write_text(
+        transcript.read_text(encoding="utf-8").replace("Summarize this session", marker), encoding="utf-8"
+    )
+    provider = "openai" if route == "provider" else ""
+    provider_mode = mode if route == "provider" else "success"
+    _write_executable(
+        fake_bin / "memsearch",
+        f"""#!/usr/bin/env bash
+if [ "$1" = config ] && [ "$2" = get ]; then
+  case "$3" in
+    embedding.provider) echo onnx ;;
+    plugins.claude-code.summarize.enabled) echo true ;;
+    plugins.claude-code.summarize.provider) echo "{provider}" ;;
+    *) echo "" ;;
+  esac
+fi
+if [ "$1" = index ]; then exit 0; fi
+if [ "$1" = summarize ]; then
+  case "{provider_mode}" in
+    missing) exit 127 ;;
+    nonzero) exit 23 ;;
+    empty) exit 0 ;;
+    timeout) echo should-not-run ;;
+  esac
+fi
+""",
+    )
+    if route == "native" and mode != "missing":
+        body = '#!/usr/bin/env bash\nif [ "${1:-}" = --help ]; then exit 0; fi\n'
+        body += {"nonzero": "exit 23\n", "empty": "exit 0\n", "timeout": "echo should-not-run\n"}[mode]
+        _write_executable(fake_bin / "claude", body)
+    if mode == "timeout":
+        _write_executable(
+            fake_bin / "timeout",
+            '#!/usr/bin/env bash\nif [ "$1" = 110 ]; then exit 124; fi\nshift\nexec "$@"\n',
+        )
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(Path("plugins/claude-code").resolve()),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+    }
+    subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+        timeout=125,
+    )
+    memory_text = next((memsearch_dir / "memory").glob("*.md")).read_text(encoding="utf-8")
+    assert marker not in memory_text
+    assert "transcript content was omitted" in memory_text
+    assert "session:session turn:turn-failure" in memory_text
 
 
 def test_claude_stop_hook_groups_session_headings(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- deliver the Claude Code native summarizer prompt through stdin so large turns do not exceed per-argument limits
- bound native and provider summarizer execution and record a short failure marker for unavailable, timeout, non-zero, or empty results
- preserve transcript anchors for progressive disclosure without persisting unsummarized transcript content
- add regression coverage and update Claude Code documentation

## Verification

- `bash -n plugins/claude-code/hooks/*.sh`
- `uv lock --check`
- `env -u OPENAI_API_KEY uv run python -m pytest` (300 passed, 7 skipped)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mkdocs build --strict`

The isolated interactive Claude Code TUI reached the login selection screen with a fresh temporary HOME, so authenticated write and fresh-session recall could not be completed without using user credentials. No real user memory or credentials were used.

Closes #664
