### PR TITLE
fix: decode OpenCode MemSearch output as UTF-8

### DIFF
--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -299,6 +299,8 @@ def get_plugin_summarize_model(memsearch_cmd: str | None = None) -> str:
             [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.model"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             timeout=5,
         )
         return result.stdout.strip()
@@ -315,6 +317,8 @@ def get_plugin_summarize_provider(memsearch_cmd: str | None = None) -> str:
             [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.provider"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             timeout=5,
         )
         return result.stdout.strip()
@@ -331,6 +335,8 @@ def get_plugin_summarize_enabled(memsearch_cmd: str | None = None) -> bool:
             [*split_memsearch_cmd(memsearch_cmd), "config", "get", "plugins.opencode.summarize.enabled"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             timeout=5,
         )
         return result.stdout.strip().lower() != "false"
@@ -362,6 +368,8 @@ def _load_summarize_prompt(agent_name: str, memsearch_cmd: str | None = None) ->
                 [*split_memsearch_cmd(memsearch_cmd), "config", "get", "prompts.summarize"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="strict",
                 timeout=5,
             )
             custom_path = result.stdout.strip()
@@ -408,6 +416,8 @@ def summarize_with_llm(
                 input=turn_text,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="strict",
                 timeout=30,
                 env={**os.environ, "MEMSEARCH_NO_WATCH": "1"},
             )

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -551,11 +551,15 @@ def _is_relative_to(path: Path, root: Path) -> bool:
 
 
 def _run_restricted(argv: list[str], cwd: Path) -> str:
+    text_options = {}
+    if Path(argv[0]).name.lower() in {"memsearch", "memsearch.exe"}:
+        text_options = {"encoding": "utf-8", "errors": "strict"}
     try:
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
+            **text_options,
             cwd=str(cwd),
             env={**os.environ, "MEMSEARCH_NO_WATCH": "1"},
             timeout=15,

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from memsearch import maintenance
 from memsearch.config import LLMProviderConfig, MemSearchConfig, PluginMaintenanceTaskConfig
 from memsearch.maintenance import (
     MAX_PROMPT_CHARS,
@@ -512,3 +514,104 @@ def test_run_memory_command_allows_transcript_outside_roots(tmp_path: Path) -> N
     # A non-transcript command pointed outside the roots is still rejected.
     rejected = run_memory_command(f"grep foo {tmp_path}/outside.txt", ctx)
     assert "outside allowed memory roots" in rejected
+
+
+def test_run_memory_command_decodes_only_memsearch_as_utf8(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "memsearch"
+    stub.write_text(
+        """\
+#!/usr/bin/env python3
+import os
+import sys
+
+sys.stdout.buffer.write("展开结果丁: 中文内容\\n".encode("utf-8"))
+sys.stderr.buffer.write("诊断丁: UTF-8 stderr\\n".encode("utf-8"))
+raise SystemExit(int(os.environ.get("MEMSEARCH_STUB_EXIT", "0")))
+""",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{stub_dir}{os.pathsep}{os.environ['PATH']}")
+    ctx = TaskContext(
+        platform="codex",
+        task="project_review",
+        task_config=PluginMaintenanceTaskConfig(),
+        project_dir=project,
+        memsearch_dir=project / ".memsearch",
+        input_dir=memory,
+        output_file=project / "PROJECT.md",
+        input_digest="sha256:test",
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        subprocess.run(
+            [str(stub), "expand", "deadbeef"],
+            capture_output=True,
+            text=True,
+            encoding="cp1252",
+            errors="strict",
+            check=False,
+        )
+
+    real_run = subprocess.run
+    completed = []
+
+    def cp1252_default(*args, **kwargs):
+        if kwargs.get("text") and "encoding" not in kwargs:
+            kwargs["encoding"] = "cp1252"
+            kwargs["errors"] = "strict"
+        result = real_run(*args, **kwargs)
+        completed.append(result)
+        return result
+
+    monkeypatch.setattr(maintenance.subprocess, "run", cp1252_default)
+
+    assert run_memory_command("memsearch expand deadbeef", ctx) == "展开结果丁: 中文内容"
+    assert completed[-1].stderr == "诊断丁: UTF-8 stderr\n"
+    assert completed[-1].returncode == 0
+
+    monkeypatch.setenv("MEMSEARCH_STUB_EXIT", "7")
+    assert run_memory_command("memsearch transcript outside.jsonl", ctx) == "展开结果丁: 中文内容"
+    assert completed[-1].stderr == "诊断丁: UTF-8 stderr\n"
+    assert completed[-1].returncode == 7
+
+
+def test_run_memory_command_preserves_error_fallback_and_local_command_encoding(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = tmp_path / "repo"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    ctx = TaskContext(
+        platform="codex",
+        task="project_review",
+        task_config=PluginMaintenanceTaskConfig(),
+        project_dir=project,
+        memsearch_dir=project / ".memsearch",
+        input_dir=memory,
+        output_file=project / "PROJECT.md",
+        input_digest="sha256:test",
+    )
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if Path(argv[0]).name.lower() == "memsearch":
+            raise OSError("command failed")
+        return subprocess.CompletedProcess(argv, 0, stdout="local output\n", stderr="")
+
+    monkeypatch.setattr(maintenance.subprocess, "run", fake_run)
+
+    assert run_memory_command("memsearch expand deadbeef", ctx) == "Error: command failed"
+    assert calls[-1][1]["encoding"] == "utf-8"
+    assert calls[-1][1]["errors"] == "strict"
+
+    assert run_memory_command(f"find {memory} -name '*.md'", ctx) == "local output"
+    assert "encoding" not in calls[-1][1]
+    assert "errors" not in calls[-1][1]

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -8,6 +8,8 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 
+import pytest
+
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "plugins" / "opencode" / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR))
 
@@ -50,7 +52,7 @@ def write(stream, value):
 args = sys.argv[1:]
 mode = os.environ.get("MEMSEARCH_STUB_MODE", "success")
 
-write(sys.stderr, "诊断: UTF-8 stderr\\n")
+write(sys.stderr, "诊断丁: UTF-8 stderr\\n")
 if mode == "config-nonzero" and args[:2] == ["config", "get"]:
     raise SystemExit(7)
 
@@ -78,6 +80,22 @@ def _utf8_stub_command(stub: Path) -> str:
     return f'"{sys.executable}" "{stub}"'
 
 
+def _record_subprocess_results_with_cp1252_default(monkeypatch, subprocess_module):
+    real_run = subprocess.run
+    completed = []
+
+    def run(*args, **kwargs):
+        if kwargs.get("text") and "encoding" not in kwargs:
+            kwargs["encoding"] = "cp1252"
+            kwargs["errors"] = "strict"
+        result = real_run(*args, **kwargs)
+        completed.append(result)
+        return result
+
+    monkeypatch.setattr(subprocess_module, "run", run)
+    return completed
+
+
 def test_memsearch_adapter_decodes_utf8_when_locale_is_cp1252(
     tmp_path: Path,
     monkeypatch,
@@ -90,14 +108,28 @@ def test_memsearch_adapter_decodes_utf8_when_locale_is_cp1252(
     _write_utf8_memsearch_stub(stub)
 
     monkeypatch.setenv("MEMSEARCH_STUB_PROMPT_PATH", str(prompt))
-    monkeypatch.setattr(capture_daemon.subprocess, "_text_encoding", lambda: "cp1252")
     command = _utf8_stub_command(stub)
+    argv = [sys.executable, str(stub), "config", "get", "plugins.opencode.summarize.model"]
+
+    with pytest.raises(UnicodeDecodeError):
+        subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="cp1252",
+            errors="strict",
+            check=False,
+        )
+
+    completed = _record_subprocess_results_with_cp1252_default(monkeypatch, capture_daemon.subprocess)
 
     assert capture_daemon.get_plugin_summarize_model(command) == "模型/摘要"
     assert capture_daemon.get_plugin_summarize_provider(command) == "custom-provider"
     assert capture_daemon.get_plugin_summarize_enabled(command) is True
     assert capture_daemon._load_summarize_prompt("OpenCode", command) == "为 OpenCode 生成摘要"
     assert capture_daemon.summarize_with_llm("用户: 请总结", "", command) == "- 摘要包含非 ASCII"
+    assert completed
+    assert all(result.stderr == "诊断丁: UTF-8 stderr\n" for result in completed)
 
 
 def test_memsearch_adapter_preserves_nonzero_fallbacks(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sqlite3
+import subprocess
 import sys
 from contextlib import suppress
 from pathlib import Path
@@ -32,6 +33,101 @@ from opencode_turns import (  # noqa: E402
     save_turn,
     save_turn_state,
 )
+
+
+def _write_utf8_memsearch_stub(path: Path) -> None:
+    path.write_text(
+        """\
+import os
+import sys
+
+
+def write(stream, value):
+    stream.buffer.write(value.encode("utf-8"))
+    stream.buffer.flush()
+
+
+args = sys.argv[1:]
+mode = os.environ.get("MEMSEARCH_STUB_MODE", "success")
+
+write(sys.stderr, "诊断: UTF-8 stderr\\n")
+if mode == "config-nonzero" and args[:2] == ["config", "get"]:
+    raise SystemExit(7)
+
+if args[:2] == ["config", "get"]:
+    values = {
+        "plugins.opencode.summarize.model": "模型/摘要",
+        "plugins.opencode.summarize.provider": "custom-provider",
+        "plugins.opencode.summarize.enabled": "true",
+        "prompts.summarize": os.environ["MEMSEARCH_STUB_PROMPT_PATH"],
+    }
+    write(sys.stdout, values[args[2]] + "\\n")
+elif args and args[0] == "summarize":
+    sys.stdin.buffer.read()
+    if mode == "summarize-nonzero":
+        raise SystemExit(7)
+    write(sys.stdout, "- 摘要包含非 ASCII\\n")
+else:
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+
+
+def _utf8_stub_command(stub: Path) -> str:
+    return f'"{sys.executable}" "{stub}"'
+
+
+def test_memsearch_adapter_decodes_utf8_when_locale_is_cp1252(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    stub = tmp_path / "memsearch-stub.py"
+    prompt_dir = tmp_path / "自定义提示"
+    prompt_dir.mkdir()
+    prompt = prompt_dir / "摘要提示.txt"
+    prompt.write_text("为 {{AGENT_NAME}} 生成摘要", encoding="utf-8")
+    _write_utf8_memsearch_stub(stub)
+
+    monkeypatch.setenv("MEMSEARCH_STUB_PROMPT_PATH", str(prompt))
+    monkeypatch.setattr(capture_daemon.subprocess, "_text_encoding", lambda: "cp1252")
+    command = _utf8_stub_command(stub)
+
+    assert capture_daemon.get_plugin_summarize_model(command) == "模型/摘要"
+    assert capture_daemon.get_plugin_summarize_provider(command) == "custom-provider"
+    assert capture_daemon.get_plugin_summarize_enabled(command) is True
+    assert capture_daemon._load_summarize_prompt("OpenCode", command) == "为 OpenCode 生成摘要"
+    assert capture_daemon.summarize_with_llm("用户: 请总结", "", command) == "- 摘要包含非 ASCII"
+
+
+def test_memsearch_adapter_preserves_nonzero_fallbacks(tmp_path: Path, monkeypatch) -> None:
+    stub = tmp_path / "memsearch-stub.py"
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("unused", encoding="utf-8")
+    _write_utf8_memsearch_stub(stub)
+
+    monkeypatch.setenv("MEMSEARCH_STUB_MODE", "config-nonzero")
+    monkeypatch.setenv("MEMSEARCH_STUB_PROMPT_PATH", str(prompt))
+    command = _utf8_stub_command(stub)
+
+    assert capture_daemon.get_plugin_summarize_model(command) == ""
+    assert capture_daemon.get_plugin_summarize_provider(command) == ""
+    assert capture_daemon.get_plugin_summarize_enabled(command) is True
+
+    monkeypatch.setenv("MEMSEARCH_STUB_MODE", "summarize-nonzero")
+    assert capture_daemon.summarize_with_llm("turn", "", command) is None
+
+
+def test_memsearch_adapter_preserves_timeout_fallbacks(monkeypatch) -> None:
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(capture_daemon.subprocess, "run", timeout)
+
+    assert capture_daemon.get_plugin_summarize_model("memsearch") == ""
+    assert capture_daemon.get_plugin_summarize_provider("memsearch") == ""
+    assert capture_daemon.get_plugin_summarize_enabled("memsearch") is True
+    assert capture_daemon.summarize_with_llm("turn", "", "memsearch") is None
 
 
 def test_opencode_config_resolution_uses_jsonc_and_env_dir_precedence(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- decode MemSearch CLI output explicitly as UTF-8 in the OpenCode Python adapter
- decode restricted `memsearch expand` and `memsearch transcript` output explicitly as UTF-8
- keep strict decoding so invalid protocol bytes are not silently replaced
- add hostile-locale coverage for non-ASCII configuration, prompt paths, summaries, command output, stdout, and stderr
- preserve existing nonzero, timeout, and fallback behavior

## Scope

Only subprocess calls with a proven MemSearch CLI producer are changed. The restricted maintenance runner selects UTF-8 only when the executable basename is `memsearch` or `memsearch.exe`; find, grep, python3, OpenCode, and other external command decoding remains unchanged. Existing TypeScript search and expand paths already specify UTF-8.

## Validation

- Python 3.10 hostile-locale regressions (OpenCode 3 passed; maintenance 4 passed)
- `env -u OPENAI_API_KEY uv run python -m pytest tests/test_opencode_turns.py tests/test_maintenance.py` (52 passed)
- `env -u OPENAI_API_KEY uv run python -m pytest` (341 passed, 7 skipped)
- `uv lock --check`
- `uv run ruff check src/ tests/ plugins/opencode/scripts/capture-daemon.py`
- `uv run ruff format --check src/ tests/ plugins/opencode/scripts/capture-daemon.py`
- `git diff --check`
- `npm test` in `plugins/opencode` (8 passed)