### PR TITLE
feat(dsh): add DeepSeek Harness platform plugin

### DIFF
--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -1,0 +1,138 @@
+# memsearch-dsh
+
+MemSearch plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
+It gives DSH persistent, cross-agent memory on the same `.memsearch/memory/`
+markdown store used by the Claude Code, Codex, OpenClaw, and OpenCode plugins,
+backed by a Milvus hybrid search index.
+
+```
+capture  ── session/event turn/end ──> summarize.py (reuses [llm.providers.*]) ──> memory/YYYY-MM-DD.md
+inject   ── agent/pre-step step 1  ──> memsearch search ──> relevant chunks injected (zero cost otherwise)
+recall   ── ctx.skills.register(memory-recall) ──> search → expand → transcript
+```
+
+## Prerequisites
+
+- A working `memsearch` CLI. Either install it:
+
+  ```bash
+  uv tool install "memsearch[onnx]"
+  ```
+
+  or let the plugin fall back to `uvx --from 'memsearch[onnx]' memsearch`
+  (auto-detected at load).
+- A DSH profile (web / headless / tui) you want to attach memory to.
+- Node >= 22.19 (DSH's requirement).
+
+## Install
+
+From the repo root, install the plugin into a profile. `dsh plugin` is a pnpm
+forwarder: it links the directory into the profile, detects the `dsh.bundle`
+declaration in `package.json`, and appends the package to the profile's bundle
+layers. The `cordis.patch.yml` inside this directory then inserts the
+`memsearch` row into the profile's plugin tree.
+
+```bash
+dsh plugin --profile web add /path/to/memsearch/plugins/dsh
+```
+
+> The path is resolved from the directory you run `dsh` in; an absolute path
+> is safest. Replace `web` with your profile name (`headless`, `tui`, ...).
+>
+> Profiles are managed by the `@deepseek-ai/dsh-app-boot` profile store, and
+> the patch layer list lives in the profile manifest. The same flow works for
+> every shipped profile.
+
+Restart DSH for the profile (or start a new session) so the plugin mounts.
+
+### Manual patch insertion (no `dsh plugin`)
+
+Append this row to the profile's `cordis.patch.yml` and make sure
+`memsearch-dsh` is resolvable from the profile's `node_modules` (for example a
+`link:` dependency):
+
+```yaml
+- insert:
+    - id: memsearch
+      name: 'memsearch-dsh'
+```
+
+### Verify it loaded
+
+Start DSH and check the session log for the plugin mount, or confirm the
+`memory-recall` skill is available through the `skill` tool. Captured turns
+land in `<project>/.memsearch/memory/YYYY-MM-DD.md`.
+
+## Configuration
+
+The plugin is configured through the profile's `cordis.patch.yml` `config`
+block (patch the `memsearch` row you inserted). All keys are optional.
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `captureEnabled` | bool | `true` | Capture completed turns into memory. |
+| `injectEnabled` | bool | `true` | Inject relevant memory before each turn's first step. |
+| `summarizeEnabled` | bool | `true` | Summarize turns with a memsearch-managed LLM. |
+| `summarizeProvider` | string | `''` | Name of an `[llm.providers.*]` entry used for summarization. |
+| `summarizeModel` | string | `''` | Model override for summarization. |
+| `memsearchDir` | string | `<project>/.memsearch` | Override the memory directory. |
+| `collection` | string | derived | Override the Milvus collection name. |
+| `milvusUri` | string | `''` | Point search/index at a dedicated Milvus (URI or path) instead of memsearch's own config. Useful to isolate a profile's memory or target a shared Milvus Server. |
+| `agentName` | string | `DeepSeek Harness` | Display name in the summarize prompt. |
+
+Example override layer (add this to the profile's own `cordis.patch.yml`):
+
+```yaml
+- id: memsearch
+  config:
+    summarizeProvider: deepseek
+```
+
+### Summarization provider resolution
+
+Summarization reuses memsearch's `[llm.providers.*]` configuration — the same
+entries the other platform plugins use — so DSH adds no separate LLM setup.
+Provider selection (most specific first):
+
+1. `summarizeProvider` — looked up in `[llm.providers.<name>]`; a missing
+   entry fails loudly (visible error), never a silent empty write.
+2. `llm.provider` when it names a configured provider or is a raw type.
+3. `compact.llm_provider` (deprecated) or `openai` as a final default.
+
+A failed summarization writes the raw turn as a fallback so memory is never
+lost, and logs a visible warning through the DSH logger.
+
+## How it works
+
+- **Capture** — listens on `session/event` for `turn/end`, renders the turn
+  (`[User]` / `[Assistant]` / `[Tool call]` lines), stages it durably in
+  `<memsearchDir>/.dsh-capture.jsonl`, then asynchronously summarizes and
+  appends it to `memory/YYYY-MM-DD.md` with the shared anchor format
+  `<!-- session:<id> turn:<N> db:<path> -->`. Turns staged by a run that was
+  interrupted mid-drain are replayed on the next plugin load.
+- **Inject** — on `agent/pre-step` at step 1, runs a bounded memsearch search
+  over the user's question. Only when relevant chunks exist does it inject
+  them plus a `[memsearch] Memory available.` hint; otherwise the decision is
+  returned unchanged (zero context cost).
+- **Recall** — registers a `memory-recall` skill (invocable through DSH's
+  native `skill` tool) that performs search → expand → transcript drill-down
+  and returns a curated summary.
+
+## Uninstall
+
+```bash
+dsh plugin --profile web rm memsearch-dsh
+```
+
+Removing the dependency drops the profile-layer entry; the memory markdown
+files and the Milvus index are left untouched.
+
+## Development
+
+- The plugin is plain ESM with no build step — `dsh plugin add` links the
+  checkout directly, so edits are live after a profile reload.
+- Python helpers under `scripts/` are linted with the repo's `ruff` config and
+  tested under `plugins/dsh/tests/`.
+- Keep the memory-write format byte-compatible with the other platform
+  plugins; see `plugins/opencode/scripts/capture-daemon.py` for the canonical
+  writer.

--- a/plugins/dsh/cordis.patch.yml
+++ b/plugins/dsh/cordis.patch.yml
@@ -1,0 +1,24 @@
+# memsearch-dsh bundle patch: inserts the memsearch plugin into a DSH
+# profile's plugin tree.
+#
+# This patch is applied as one extra layer when the package is installed via
+# `dsh plugin --profile <name> add <path>` (see README.md). A later user
+# override in the profile's own cordis.patch.yml can address the same `id` to
+# tune `config`, and removing the dependency removes the row.
+
+- insert:
+    - id: memsearch
+      name: 'memsearch-dsh'
+      config:
+        # Optional overrides — see README.md for the full set:
+        #   captureEnabled (bool, default true)
+        #   injectEnabled (bool, default true)
+        #   summarizeEnabled (bool, default true)
+        #   summarizeProvider (string, default '')  -> name of an [llm.providers.*] entry
+        #   summarizeModel (string, default '')      -> model override for summarization
+        #   memsearchDir (string, default '')        -> override <project>/.memsearch
+        #   collection (string, default '')          -> override the Milvus collection name
+        #   milvusUri (string, default '')           -> point search/index at a dedicated Milvus
+        #                                               (uri or path) instead of memsearch's config
+        #   agentName (string, default 'DeepSeek Harness')
+        {}

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -1,0 +1,648 @@
+/**
+ * memsearch-dsh — MemSearch plugin for DeepSeek Harness.
+ *
+ * Gives DSH persistent, cross-agent memory on top of memsearch:
+ *
+ *   capture  — every completed turn is staged from the `session/event` stream
+ *              and summarized with a memsearch-managed `[llm.providers.*]`
+ *              provider, then appended to `<project>/.memsearch/memory/YYYY-MM-DD.md`
+ *              alongside the other platform plugins (Claude Code, Codex,
+ *              OpenClaw, OpenCode). The anchor format is identical, so DSH
+ *              writes join the same shared memory store.
+ *   inject   — before the first model step of each turn, `agent/pre-step`
+ *              runs a bounded memsearch search over the user's question and,
+ *              only when relevant results exist, injects them plus a
+ *              `[memsearch] Memory available.` hint. When nothing is relevant
+ *              the decision is returned unchanged — zero context cost.
+ *   recall   — registers a `memory-recall` skill (search → expand → transcript)
+ *              that the model can invoke through the native `skill` tool.
+ *
+ * The plugin is a plain ESM module with no build step. It is installed into a
+ * DSH profile via `dsh plugin --profile <name> add <path>` (pnpm link), where
+ * the package.json `dsh.bundle` declaration points at `cordis.patch.yml`.
+ *
+ * @module memsearch-dsh
+ */
+
+import { execFile, execFileSync, spawn } from 'node:child_process'
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url))
+
+/** Cordis plugin name; also the `source.plugin` tag on injected messages. */
+export const name = 'memsearch'
+
+/** Services this plugin needs before `apply()` runs. */
+export const inject = ['agents', 'skills', 'sessionPersistence']
+
+const DEFAULT_AGENT_NAME = 'DeepSeek Harness'
+const MEMSEARCH_MARKER = '[memsearch] Memory available.'
+const STAGING_FILE = '.dsh-capture.jsonl'
+const SEARCH_TOP_K = 5
+const SEARCH_TIMEOUT_MS = 15000
+const SUMMARIZE_TIMEOUT_MS = 30000
+const CAPTURE_MAX_CHARS = 6000
+const INJECT_SNIPPET_CHARS = 180
+const DAILY_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Shell-escape a string for safe use inside single quotes. */
+function shellEscape(s) {
+  return String(s).replace(/'/g, "'\\''")
+}
+
+let dshLlmModule = null
+
+/**
+ * Lazily load `@deepseek-ai/dsh-llm` for its `createUserMessage` factory.
+ *
+ * This plugin is installed as an out-of-tree package (pnpm `link:`), so its
+ * real directory is outside the DSH workspace and Node's bare-specifier walk
+ * from `import.meta.url` cannot see the DSH packages. DSH maintains a flat
+ * module fallback at `$DSH_HOME/profiles/node_modules` covering the whole app
+ * dependency closure — the documented "bundles come from the installation"
+ * contract — reachable by Node's parent-directory walk from any profile. The
+ * loader anchors `ctx.baseUrl` at the profile directory, so we resolve through
+ * a `createRequire` there and `import()` the resolved absolute path. When the
+ * package is genuinely unreachable we fall back to building the same message
+ * shape inline so injection never hard-fails the plugin.
+ * @param ctx - the Cordis context (its `baseUrl` is the profile dir).
+ * @returns the dsh-llm module namespace, or `null` when unresolvable.
+ */
+async function loadDshLlm(ctx) {
+  if (dshLlmModule) return dshLlmModule
+  dshLlmModule = (async () => {
+    try {
+      let anchor = import.meta.url
+      if (ctx?.baseUrl) {
+        const base = String(ctx.baseUrl)
+        anchor = pathToFileURL(join(base.startsWith('file:') ? fileURLToPath(base) : base, '_memsearch.js')).href
+      }
+      const resolved = createRequire(anchor).resolve('@deepseek-ai/dsh-llm')
+      return await import(pathToFileURL(resolved).href)
+    } catch {
+      return null
+    }
+  })()
+  return dshLlmModule
+}
+
+/**
+ * Build one plugin-sourced user message carrying the memory block.
+ * @param ctx - the Cordis context (profile anchor for dsh-llm resolution).
+ * @param text - the rendered memory block.
+ * @returns a frozen `UserMessage` with a plugin snapshot source.
+ */
+async function createMemoryMessage(ctx, text) {
+  const dshLlm = await loadDshLlm(ctx)
+  if (dshLlm?.createUserMessage) {
+    return dshLlm.createUserMessage({
+      content: [{ type: 'text', text }],
+      source: {
+        kind: 'plugin',
+        plugin: name,
+        form: 'snapshot',
+        sections: [{ name, text }],
+      },
+    })
+  }
+  return Object.freeze({
+    id: crypto.randomUUID(),
+    role: 'user',
+    content: [{ type: 'text', text }],
+    source: {
+      kind: 'plugin',
+      plugin: name,
+      form: 'snapshot',
+      sections: [{ name, text }],
+    },
+  })
+}
+
+/**
+ * Detect the memsearch CLI command: installed binary on PATH first, then the
+ * uvx fallback, then a bare `memsearch` best effort.
+ *
+ * `command -v` is resolved through bash so the check sees the same PATH the
+ * later `bash -c` invocations use; calling `which` as a direct executable
+ * bypasses shell built-ins and can miss the installed tool.
+ */
+function detectMemsearchCmd() {
+  const home = process.env.HOME || ''
+  const onPath = (cmd) => {
+    try {
+      execFileSync('bash', ['-c', `command -v ${cmd} >/dev/null 2>&1`], { stdio: 'pipe' })
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (onPath('memsearch')) return 'memsearch'
+  const uvxPath = join(home, '.local', 'bin', 'uvx')
+  const uvxBin = existsSync(uvxPath) ? uvxPath : (onPath('uvx') ? 'uvx' : '')
+  if (uvxBin) {
+    return `${uvxBin} --from 'memsearch[onnx]' memsearch`
+  }
+  return 'memsearch'
+}
+
+/** Derive the per-project Milvus collection name via the shared script. */
+function deriveCollection(projectDir, override) {
+  if (override) return override
+  const script = join(PLUGIN_DIR, 'scripts', 'derive-collection.sh')
+  try {
+    const result = execFileSync('bash', [script, projectDir], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return result.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Project directory for a session (its durable cwd) or the process cwd. */
+function projectDirFor(session) {
+  return session?.header?.cwd || process.cwd()
+}
+
+/** `[User]`/`[Assistant]` text from a message's content blocks. */
+function textFromContent(content) {
+  return (Array.isArray(content) ? content : [])
+    .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text)
+    .join('\n')
+    .trim()
+}
+
+/** True when the memory directory holds at least one daily markdown file. */
+function hasMemoryFiles(memoryDir) {
+  try {
+    return readdirSync(memoryDir).some((file) => DAILY_FILE_RE.test(file))
+  } catch {
+    return false
+  }
+}
+
+/** Local YYYY-MM-DD date string. */
+function todayStr() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Local HH:MM time string. */
+function hhmmStr() {
+  const now = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${pad(now.getHours())}:${pad(now.getMinutes())}`
+}
+
+// ---------------------------------------------------------------------------
+// Search / index (memsearch CLI)
+// ---------------------------------------------------------------------------
+
+/**
+ * `--milvus-uri '<uri>'` CLI flag when a dedicated Milvus is configured for the
+ * profile; empty otherwise (memsearch falls back to its own config).
+ */
+function milvusUriFlag(milvusUri) {
+  return milvusUri ? `--milvus-uri '${shellEscape(milvusUri)}' ` : ''
+}
+
+/**
+ * Run one bounded memsearch search over the project collection.
+ * @returns the parsed result array, or null on any failure (caller treats
+ *          null as "no relevant memory" and stays a no-op).
+ */
+function runSearch(memsearchCmd, query, collection, projectDir, milvusUri) {
+  return new Promise((resolve) => {
+    const command =
+      `${memsearchCmd} search '${shellEscape(query)}' ` +
+      `--top-k ${SEARCH_TOP_K} --json-output ` +
+      `${milvusUriFlag(milvusUri)}` +
+      `--collection '${shellEscape(collection)}'`
+    execFile(
+      'bash',
+      ['-c', command],
+      { cwd: projectDir, timeout: SEARCH_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+      (error, stdout) => {
+        if (error) return resolve(null)
+        try {
+          const chunks = JSON.parse(stdout)
+          resolve(Array.isArray(chunks) ? chunks : null)
+        } catch {
+          resolve(null)
+        }
+      },
+    )
+  })
+}
+
+/** Fire-and-forget `memsearch index` refresh for a project. */
+function indexMemory(ctx, memsearchCmd, memoryDir, collection, projectDir, milvusUri) {
+  if (!existsSync(memoryDir)) return
+  const command =
+    `${memsearchCmd} index '${shellEscape(memoryDir)}' ` +
+    `${milvusUriFlag(milvusUri)}` +
+    `--collection '${shellEscape(collection)}'`
+  // Detached + unref so the index survives the DSH process: a headless or
+  // one-shot session can exit right after the turn that wrote the memory, and
+  // an ordinary child would be torn down with the parent before indexing.
+  const child = execFile('bash', ['-c', command], {
+    cwd: projectDir,
+    timeout: 120000,
+    maxBuffer: 4 * 1024 * 1024,
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, MEMSEARCH_NO_WATCH: '1' },
+  }, (error) => {
+    if (error) ctx.logger.warn(`[memsearch] background index failed: ${error.message}`)
+  })
+  child.unref()
+}
+
+/** Compact human-readable memory block injected into the request. */
+function renderMemoryBlock(chunks) {
+  const lines = chunks.map((chunk, index) => {
+    const source = chunk.source || 'memory'
+    const snippet = (chunk.content || '').trim().replace(/\s+/g, ' ').slice(0, INJECT_SNIPPET_CHARS)
+    return `${index + 1}. [${source}] ${snippet}`
+  })
+  return `${MEMSEARCH_MARKER}\n\nRelevant memories from past sessions:\n${lines.join('\n')}`
+}
+
+// ---------------------------------------------------------------------------
+// Capture
+// ---------------------------------------------------------------------------
+
+/** Resolve the durable session artifact path for an anchor's `db:` field. */
+function sessionLogPath(ctx, session) {
+  try {
+    const location = ctx.sessionPersistence?.locate?.(session?.header)
+    if (location && typeof location.path === 'string' && location.path) {
+      return location.path
+    }
+  } catch { /* leave empty */ }
+  return ''
+}
+
+/**
+ * Render one completed turn as `[User]`/`[Assistant]` text for the summarizer
+ * and as the raw-transcript fallback. Returns null when the turn carries no
+ * genuine user message.
+ */
+function renderTurn(session, turnEndEvent) {
+  const turn = turnEndEvent.data.turn
+  const events = session.events
+  const startIndex = events.findIndex(
+    (event) => event.type === 'turn/start' && event.data.turn === turn,
+  )
+  if (startIndex < 0) return null
+  const endIndex = events.findIndex(
+    (event) => event.type === 'turn/end' && event.data.turn === turn,
+  )
+  const turnEvents = endIndex > startIndex ? events.slice(startIndex + 1, endIndex) : []
+
+  const lines = [`=== Turn ${turn} ===`]
+  let hasUser = false
+  for (const event of turnEvents) {
+    if (event.type === 'user/message') {
+      if (event.data.source?.kind !== 'user') continue
+      const text = textFromContent(event.data.content)
+      if (!text) continue
+      lines.push('', `[User]: ${text}`)
+      hasUser = true
+    } else if (event.type === 'assistant/message') {
+      const text = textFromContent(event.data.message?.content)
+      if (!text) continue
+      lines.push('', `[Assistant]: ${text}`)
+    } else if (event.type === 'tool/call') {
+      lines.push('', `[Tool call]: ${event.data.name}`)
+    }
+  }
+  if (!hasUser) return null
+  const render = lines.join('\n').slice(0, CAPTURE_MAX_CHARS).trim()
+  if (render.length <= 10) return null
+  return render
+}
+
+/** True when a session/turn anchor already exists in any daily memory file. */
+function captureExists(memoryDir, sessionId, turn) {
+  let files
+  try {
+    files = readdirSync(memoryDir)
+  } catch {
+    return false
+  }
+  const anchor = `<!-- session:${sessionId} turn:${turn} `
+  for (const file of files) {
+    if (!DAILY_FILE_RE.test(file)) continue
+    try {
+      if (readFileSync(join(memoryDir, file), 'utf-8').includes(anchor)) return true
+    } catch { /* skip unreadable file */ }
+  }
+  return false
+}
+
+/** Append a captured turn to the daily memory file (shared 4-platform format). */
+function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
+  mkdirSync(memoryDir, { recursive: true })
+  const today = todayStr()
+  const hhmm = hhmmStr()
+  const file = join(memoryDir, `${today}.md`)
+  if (!existsSync(file)) {
+    writeFileSync(file, `# ${today}\n\n## Session ${hhmm}\n\n`, 'utf-8')
+  }
+  const anchor = `<!-- session:${sessionId} turn:${turn} db:${dbPath} -->\n`
+  const entry = `### ${hhmm}\n${anchor}${body}\n\n`
+  appendFileSync(file, entry, 'utf-8')
+}
+
+// ---------------------------------------------------------------------------
+// Summarization (memsearch-managed [llm.providers.*])
+// ---------------------------------------------------------------------------
+
+/** Summarize one rendered turn via scripts/summarize.py, reusing memsearch config. */
+function summarizeTurn(opts, render, projectDir) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      join(PLUGIN_DIR, 'scripts', 'summarize.py'),
+      '--agent-name', opts.agentName,
+      '--project-dir', projectDir,
+    ]
+    if (opts.summarizeProvider) args.push('--provider', opts.summarizeProvider)
+    if (opts.summarizeModel) args.push('--model', opts.summarizeModel)
+    const child = spawn('python3', args, { cwd: projectDir })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (data) => { stdout += data })
+    child.stderr.on('data', (data) => { stderr += data })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim() || null)
+      } else {
+        reject(new Error(stderr.trim() || `summarize.py exited with status ${code}`))
+      }
+    })
+    child.stdin.write(render)
+    child.stdin.end()
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* already exited */ }
+      reject(new Error('summarization timed out'))
+    }, SUMMARIZE_TIMEOUT_MS)
+    timer.unref?.()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Staging + drain (durable capture queue)
+// ---------------------------------------------------------------------------
+
+function stageCapture(memsearchDir, record, logger) {
+  try {
+    mkdirSync(memsearchDir, { recursive: true })
+    appendFileSync(join(memsearchDir, STAGING_FILE), `${JSON.stringify(record)}\n`, 'utf-8')
+  } catch (error) {
+    logger?.warn?.(`[memsearch] failed to stage turn: ${error.message}`)
+  }
+}
+
+function readStages(memsearchDir) {
+  const file = join(memsearchDir, STAGING_FILE)
+  if (!existsSync(file)) return []
+  let content
+  try {
+    content = readFileSync(file, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .map((line) => {
+      try { return JSON.parse(line) } catch { return null }
+    })
+    .filter(Boolean)
+}
+
+function removeStage(memsearchDir, key) {
+  const file = join(memsearchDir, STAGING_FILE)
+  try {
+    const remaining = readStages(memsearchDir).filter((record) => record.key !== key)
+    writeFileSync(
+      file,
+      remaining.length ? `${remaining.map((record) => JSON.stringify(record)).join('\n')}\n` : '',
+      'utf-8',
+    )
+  } catch { /* best effort; a leftover stage is replayed next boot */ }
+}
+
+// ---------------------------------------------------------------------------
+// Memory-recall skill
+// ---------------------------------------------------------------------------
+
+function registerMemoryRecallSkill(ctx, opts, memsearchCmd, collection, projectDir) {
+  const skillPath = join(PLUGIN_DIR, 'skills', 'memory-recall', 'SKILL.md')
+  let content
+  try {
+    content = readFileSync(skillPath, 'utf-8')
+  } catch (error) {
+    ctx.logger.warn(`[memsearch] could not read memory-recall skill: ${error.message}`)
+    return
+  }
+  const agentName = opts.agentName
+  content = content
+    .replace(/^﻿?---[\s\S]*?---\s*/u, '') // strip optional YAML frontmatter
+    .replace(/^<!--[\s\S]*?-->\s*/u, '') // strip the human-facing metadata comment
+    .replaceAll('{{AGENT_NAME}}', agentName)
+    .replaceAll('{{MEMSEARCH_CMD}}', memsearchCmd)
+    .replaceAll('{{PLUGIN_DIR}}', PLUGIN_DIR)
+    .replaceAll('{{PROJECT_DIR}}', projectDir)
+    .replaceAll('{{COLLECTION}}', collection || `$(bash "${PLUGIN_DIR}/scripts/derive-collection.sh")`)
+    .replaceAll('{{MILVUS_FLAG}}', opts.milvusUri ? `--milvus-uri "${opts.milvusUri}" ` : '')
+  ctx.skills.register({
+    name: 'memory-recall',
+    description:
+      'Search memsearch persistent memory for context relevant to the user\'s question. ' +
+      'Use when the question could benefit from past sessions, decisions, or work in this project.',
+    whenToUse:
+      'The user references past work, asks what was done before, or the task could reuse ' +
+      'earlier context. Cheap to check; costs one index search.',
+    content,
+    source: 'runtime',
+    invocation: { modelInvocable: true, userInvocable: true },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the memsearch plugin on the DSH context.
+ * @param ctx - the Cordis plugin context.
+ * @param config - resolved patch config (see cordis.patch.yml).
+ */
+export function apply(ctx, config = {}) {
+  const opts = {
+    captureEnabled: config.captureEnabled !== false,
+    injectEnabled: config.injectEnabled !== false,
+    summarizeEnabled: config.summarizeEnabled !== false,
+    summarizeProvider: typeof config.summarizeProvider === 'string' ? config.summarizeProvider : '',
+    summarizeModel: typeof config.summarizeModel === 'string' ? config.summarizeModel : '',
+    memsearchDir: typeof config.memsearchDir === 'string' ? config.memsearchDir : '',
+    collection: typeof config.collection === 'string' ? config.collection : '',
+    milvusUri: typeof config.milvusUri === 'string' ? config.milvusUri : '',
+    agentName: typeof config.agentName === 'string' && config.agentName
+      ? config.agentName
+      : DEFAULT_AGENT_NAME,
+  }
+
+  const memsearchCmd = detectMemsearchCmd()
+  const collectionCache = new Map()
+  const bootProjectDir = process.cwd()
+  const bootCollection = deriveCollection(bootProjectDir, opts.collection)
+
+  const resolveCollection = (projectDir) => {
+    if (collectionCache.has(projectDir)) return collectionCache.get(projectDir)
+    const resolved = deriveCollection(projectDir, opts.collection)
+    collectionCache.set(projectDir, resolved)
+    return resolved
+  }
+
+  const memsearchDirFor = (projectDir) =>
+    opts.memsearchDir || join(projectDir, '.memsearch')
+  const memoryDirFor = (projectDir) => join(memsearchDirFor(projectDir), 'memory')
+
+  // --- Recall skill (always available) ---
+  registerMemoryRecallSkill(ctx, opts, memsearchCmd, bootCollection, bootProjectDir)
+
+  // --- Pre-step injection: relevant memory only, zero context otherwise ---
+  ctx.on(
+    'agent/pre-step',
+    async ({ agent, turn, step, signal }, next) => {
+      const decision = await next()
+      if (!opts.injectEnabled) return decision
+      if (decision.kind === 'reject' || signal.aborted) return decision
+      if (step !== 1) return decision
+
+      const question = (decision.messages || [])
+        .map((message) => textFromContent(message.content))
+        .find((text) => text.length > 0)
+      if (!question || question.length < 3) return decision
+
+      const projectDir = projectDirFor(agent.session)
+      const memoryDir = memoryDirFor(projectDir)
+      if (!hasMemoryFiles(memoryDir)) return decision
+
+      const collection = resolveCollection(projectDir)
+      if (!collection) return decision
+      const chunks = await runSearch(memsearchCmd, question, collection, projectDir, opts.milvusUri)
+      if (!chunks || chunks.length === 0) return decision
+
+      const text = renderMemoryBlock(chunks)
+      const memoryMessage = await createMemoryMessage(ctx, text)
+      return {
+        kind: 'enter',
+        messages: [...decision.messages, memoryMessage],
+      }
+    },
+    { prepend: true },
+  )
+
+  // --- Capture: stage each completed turn, then summarize + write ---
+  let draining = false
+  const drain = async () => {
+    if (draining) return
+    draining = true
+    try {
+      for (;;) {
+        const stages = readStages(memsearchDirFor(bootProjectDir))
+        if (stages.length === 0) break
+        const record = stages[0]
+        if (!processStage(record)) break
+        removeStage(memsearchDirFor(bootProjectDir), record.key)
+      }
+    } catch (error) {
+      ctx.logger.warn(`[memsearch] capture drain failed: ${error.message}`)
+    } finally {
+      draining = false
+    }
+  }
+
+  const processStage = async (record) => {
+    const projectDir = record.projectDir || bootProjectDir
+    const memoryDir = memoryDirFor(projectDir)
+    if (captureExists(memoryDir, record.sessionId, record.turn)) return true
+
+    let body = record.render
+    if (opts.summarizeEnabled) {
+      try {
+        const summary = await summarizeTurn(opts, record.render, projectDir)
+        if (summary) {
+          body = summary
+        } else {
+          ctx.logger.warn('[memsearch] summarizer returned empty output; wrote raw transcript fallback')
+        }
+      } catch (error) {
+        ctx.logger.warn(`[memsearch] summarization failed (${error.message}); wrote raw transcript fallback`)
+      }
+    }
+    writeCapture(memoryDir, body, record.sessionId, record.turn, record.dbPath)
+    // Index right after the write so the memory is searchable by the next
+    // session (or by this one's later turns) instead of waiting for a future
+    // boot-time index. The index is idempotent via chunk_hash dedup.
+    const collection = resolveCollection(projectDir)
+    if (collection && hasMemoryFiles(memoryDir)) {
+      indexMemory(ctx, memsearchCmd, memoryDir, collection, projectDir, opts.milvusUri)
+    }
+    return true
+  }
+
+  if (opts.captureEnabled) {
+    ctx.on('session/event', (session, event) => {
+      if (event.type !== 'turn/end') return
+      try {
+        const projectDir = projectDirFor(session)
+        const render = renderTurn(session, event)
+        if (!render) return
+        const sessionId = session.id
+        const turn = event.data.turn
+        const dbPath = sessionLogPath(ctx, session)
+        stageCapture(memsearchDirFor(projectDir), {
+          key: `${sessionId}:${turn}`,
+          sessionId,
+          turn,
+          render,
+          dbPath,
+          projectDir,
+        }, ctx.logger)
+        void drain()
+      } catch (error) {
+        ctx.logger.warn(`[memsearch] capture listener failed: ${error.message}`)
+      }
+    })
+  }
+
+  // Replay any turns staged by a previous run that was interrupted mid-drain.
+  void drain()
+
+  // Warm the index for this project once at startup (fire-and-forget).
+  const bootMemoryDir = memoryDirFor(bootProjectDir)
+  if (bootCollection && hasMemoryFiles(bootMemoryDir)) {
+    indexMemory(ctx, memsearchCmd, bootMemoryDir, bootCollection, bootProjectDir)
+  }
+}

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "memsearch-dsh",
+  "version": "0.1.0",
+  "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, and memory-recall skill.",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "types": null,
+      "default": "./index.js"
+    },
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.js",
+    "cordis.patch.yml",
+    "prompts/",
+    "skills/",
+    "scripts/"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "memsearch",
+    "memory",
+    "deepseek-harness",
+    "cordis",
+    "plugin"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "@deepseek-ai/dsh-llm": "*"
+  }
+}

--- a/plugins/dsh/prompts/summarize.txt
+++ b/plugins/dsh/prompts/summarize.txt
@@ -1,0 +1,15 @@
+You are a third-person note-taker. You will receive a transcript of ONE conversation turn between User and {{AGENT_NAME}}.
+
+Your job is to record what happened as factual third-person notes. You are an EXTERNAL OBSERVER — you are NOT {{AGENT_NAME}}, NOT an assistant. Do NOT answer User's question, do NOT give suggestions, do NOT offer help. ONLY record what occurred.
+
+Output 2-10 bullet points, each starting with '- '. NOTHING else.
+Mandatory language rule: write every bullet in the same primary language as the [User] text. If User mixes languages, use the dominant user-facing language.
+
+Rules:
+- Write in third person and call the user 'User'
+- First bullet: what User asked or wanted (one sentence)
+- Remaining bullets: what was done, found, changed, configured, tested, explained, decided, or could not be completed
+- Be specific when useful: mention important files read or edited, searches or research performed, refactors, commands or tests run, key findings, and concrete outcomes
+- Prefer the final user-visible outcome over low-level transcript mechanics
+- Do NOT answer User's question yourself — just note what was discussed
+- Do NOT add any text before or after the bullet points

--- a/plugins/dsh/scripts/derive-collection.sh
+++ b/plugins/dsh/scripts/derive-collection.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Derive a unique Milvus collection name from a project directory path.
+# Used by hooks (via common.sh) and skill (via SKILL.md ! syntax).
+#
+# Usage: derive-collection.sh [project_dir]
+#   If no argument given, uses pwd.
+#
+# Output: ms_<sanitized_basename>_<8char_sha256>
+#   e.g. /home/user/my-app → ms_my_app_a1b2c3d4
+
+set -euo pipefail
+
+PROJECT_DIR="${1:-$(pwd)}"
+
+# Resolve to absolute path (realpath preferred, cd fallback, raw last resort)
+if realpath -m "$PROJECT_DIR" &>/dev/null 2>&1; then
+  PROJECT_DIR="$(realpath -m "$PROJECT_DIR")"
+elif [ -d "$PROJECT_DIR" ]; then
+  PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+else
+  # If directory doesn't exist and no realpath, ensure it starts with /
+  case "$PROJECT_DIR" in
+    /*) ;; # already absolute
+    *)  PROJECT_DIR="$(pwd)/$PROJECT_DIR" ;;
+  esac
+fi
+
+# Extract basename and sanitize:
+# - lowercase
+# - replace non-alphanumeric with underscore
+# - collapse consecutive underscores
+# - trim leading/trailing underscores
+# - truncate to 40 chars
+sanitized=$(basename "$PROJECT_DIR" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9]/_/g' \
+  | sed 's/__*/_/g' \
+  | sed 's/^_//;s/_$//' \
+  | cut -c1-40)
+
+# Compute 8-char SHA-256 hash of the full absolute path
+if command -v sha256sum &>/dev/null; then
+  hash=$(printf '%s' "$PROJECT_DIR" | sha256sum | cut -c1-8)
+elif command -v shasum &>/dev/null; then
+  hash=$(printf '%s' "$PROJECT_DIR" | shasum -a 256 | cut -c1-8)
+else
+  hash=$(python3 -c "import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:8])" "$PROJECT_DIR")
+fi
+
+echo "ms_${sanitized}_${hash}"

--- a/plugins/dsh/scripts/parse-transcript.py
+++ b/plugins/dsh/scripts/parse-transcript.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Parse a DSH session artifact into readable [User]/[Assistant] turns.
+
+Level-3 progressive disclosure for the memsearch ``memory-recall`` skill:
+after ``memsearch search``/``expand`` surfaces an anchor comment of the form
+
+    <!-- session:<id> turn:<N> db:<path> -->
+
+this script renders the original DSH conversation around that turn.
+
+The artifact is the JSONL log DSH persists per session
+(``~/.dsh/sessions/--<project>--/<session>/session.jsonl.zstd``), whose first
+line is a ``session`` header followed by ``SessionEvent`` lines and (for
+streaming deltas) packed ``*-chunks`` rows. Only the assembled event lines are
+rendered; packed delta rows are ignored because the ``assistant/message``
+event already carries the full text.
+
+Usage:
+    parse-transcript.py --db <log-or-dir> [--session <id>] [--turn <N>] \\
+        [--context <K>] [--limit <N>]
+"""
+
+# ruff: noqa: T201  # CLI tool: stdout/stderr are the output mechanism
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+TEXT_BLOCK_TYPES = {"text"}
+
+
+def _read_bytes(path: Path) -> bytes:
+    """Read a session artifact, decompressing zstd when the suffix says so."""
+    raw = path.read_bytes()
+    if path.name.endswith(".zstd"):
+        return _zstd_decompress(raw)
+    return raw
+
+
+def _zstd_decompress(raw: bytes) -> bytes:
+    """Decompress a zstd frame via the zstandard module or the zstd CLI."""
+    try:
+        import zstandard  # type: ignore[import-not-found]
+
+        return zstandard.ZstdDecompressor().decompress(raw)
+    except ImportError:
+        pass
+    try:
+        import zstd  # type: ignore[import-not-found]
+
+        return zstd.uncompress(raw)
+    except ImportError:
+        pass
+    zstd_bin = shutil.which("zstd")
+    if not zstd_bin:
+        raise RuntimeError(
+            "cannot decompress session.jsonl.zstd: install the Python `zstandard` package or the `zstd` CLI binary"
+        )
+    result = subprocess.run([zstd_bin, "-d", "-c"], input=raw, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"zstd -d failed: {result.stderr.decode(errors='replace').strip()}")
+    return result.stdout
+
+
+def _resolve_artifact(db_arg: str) -> tuple[Path, str]:
+    """Locate the session JSONL artifact from an anchor ``db:`` value."""
+    candidate = Path(db_arg).expanduser()
+    if candidate.is_file():
+        return candidate, candidate.name
+    if candidate.is_dir():
+        for suffix in (".jsonl.zstd", ".jsonl"):
+            match = candidate / f"session{suffix}"
+            if match.is_file():
+                return match, match.name
+        raise RuntimeError(f"no session.jsonl artifact found under {candidate}")
+    raise RuntimeError(f"session artifact does not exist: {candidate}")
+
+
+def _text_of(message: dict) -> str:
+    """Concatenate text blocks of a message's content list."""
+    content = message.get("content") or []
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") in TEXT_BLOCK_TYPES and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "\n".join(parts).strip()
+
+
+def _load_events(path: Path) -> tuple[str, list[dict]]:
+    """Parse the artifact into (session_id, event dicts). Ignores packed rows."""
+    lines = _read_bytes(path).decode("utf-8", errors="replace").splitlines()
+    session_id = ""
+    events: list[dict] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            # The durable tail may be truncated mid-line after an interrupted
+            # flush; skip partial lines rather than failing the whole render.
+            continue
+        if not isinstance(record, dict):
+            continue
+        record_type = record.get("type")
+        if record_type == "session":
+            session_id = str(record.get("id") or "")
+            continue
+        if record_type and "-chunks" in record_type:
+            continue  # packed streaming deltas; assistant/message carries the text
+        if "data" in record:
+            events.append(record)
+    return session_id, events
+
+
+def _build_turns(session_id: str, events: list[dict]) -> list[dict]:
+    """Group events into turns, returning one dict per turn."""
+    turns: list[dict] = []
+    current: dict | None = None
+    for event in events:
+        event_type = event.get("type")
+        data = event.get("data")
+        if not isinstance(data, dict):
+            continue
+        if event_type == "turn/start":
+            current = {"turn": data.get("turn"), "items": []}
+            turns.append(current)
+            continue
+        if current is None:
+            continue
+        if event_type == "user/message":
+            source = data.get("source") or {}
+            if source.get("kind") != "user":
+                continue  # skip plugin injections (e.g. time-context, memsearch)
+            current["items"].append(("[User]", _text_of(data)))
+        elif event_type == "assistant/message":
+            message = data.get("message") or {}
+            text = _text_of(message)
+            if text:
+                current["items"].append(("[Assistant]", text))
+        elif event_type == "tool/call":
+            name = data.get("name") or ""
+            if name:
+                current["items"].append(("[Tool call]", name))
+    return turns
+
+
+def _render_turn(turn: dict) -> str:
+    """Render one turn into transcript text (mirrors the capture renderer)."""
+    lines = [f"=== Turn {turn['turn']} ==="]
+    for label, text in turn["items"]:
+        lines.append("")
+        lines.append(f"{label}: {text}")
+    return "\n".join(lines).strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a DSH session artifact as readable turns.")
+    parser.add_argument("--db", required=True, help="Session log file or directory (from an anchor db: field).")
+    parser.add_argument("--session", default="", help="Expected session id (validated when given).")
+    parser.add_argument("--turn", default=None, type=int, help="Target turn; show it plus surrounding context.")
+    parser.add_argument("--context", default=3, type=int, help="Turns before/after the target (default: 3).")
+    parser.add_argument("--limit", default=20, type=int, help="Max turns when no --turn is given (default: 20).")
+    args = parser.parse_args()
+
+    try:
+        path, _ = _resolve_artifact(args.db)
+        session_id, events = _load_events(path)
+    except Exception as error:  # surface the reader failure
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    if args.session and session_id and args.session != session_id:
+        print(
+            f"Error: session id mismatch (expected {args.session}, artifact has {session_id})",
+            file=sys.stderr,
+        )
+        return 1
+
+    turns = _build_turns(session_id, events)
+    if not turns:
+        print("(no turns found)", file=sys.stderr)
+        return 1
+
+    if args.turn is not None:
+        index = next((i for i, t in enumerate(turns) if t["turn"] == args.turn), None)
+        if index is None:
+            print(f"Error: turn {args.turn} not found (turns: {[t['turn'] for t in turns]})", file=sys.stderr)
+            return 1
+        lo = max(0, index - args.context)
+        hi = min(len(turns), index + args.context + 1)
+        selected = turns[lo:hi]
+    else:
+        selected = turns[-max(1, args.limit) :]
+
+    header = f"Session {session_id or '(unknown)'}"
+    blocks = [_render_turn(turn) for turn in selected]
+    print(f"# {header}\n")
+    print("\n\n".join(blocks))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""DSH plugin summarizer: reuse memsearch's ``[llm.providers.*]`` config.
+
+The memsearch CLI exposes ``memsearch summarize --plugin <name>`` for the four
+built-in platforms, but ``plugins.dsh.*`` is not part of the core config
+schema, so this plugin ships its own thin summarizer that imports the same
+memsearch config + LLM plumbing directly:
+
+    prompt + transcript  ->  resolve_config() -> compact.summarize_text()
+
+Provider selection (most specific first):
+
+1. ``--provider <name>``  — the DSH plugin config's ``summarizeProvider``;
+   looked up in ``[llm.providers.<name>]``. Missing entry is a visible error.
+2. ``cfg.llm.provider``   — when it names a configured provider or is a raw
+   provider type (openai/anthropic/gemini).
+3. ``cfg.compact.llm_provider`` (deprecated fallback) or ``openai``.
+
+Failures exit non-zero with a message on stderr so the plugin can surface a
+visible error instead of silently writing nothing.
+
+Usage:
+    summarize.py --agent-name "DeepSeek Harness" [--provider NAME] [--model M] \\
+        [--project-dir DIR]
+    transcript ... (stdin)  ->  bullet points (stdout)
+"""
+
+# ruff: noqa: T201  # CLI tool: stdout/stderr are the output mechanism
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# memsearch importability bootstrap (shared with plugins/_shared/scripts)
+# ---------------------------------------------------------------------------
+
+
+def ensure_memsearch_importable() -> None:
+    """Make the memsearch Python API importable from any environment."""
+    user_paths = [
+        str(Path.home() / ".local" / "bin"),
+        str(Path.home() / ".cargo" / "bin"),
+        str(Path.home() / "bin"),
+        "/usr/local/bin",
+    ]
+    existing_path = os.environ.get("PATH", "")
+    path_parts = existing_path.split(os.pathsep) if existing_path else []
+    for user_path in reversed(user_paths):
+        if Path(user_path).is_dir() and user_path not in path_parts:
+            path_parts.insert(0, user_path)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+    # Prefer the checkout's own source when running from a git worktree.
+    for parent in Path(__file__).resolve().parents:
+        src_dir = parent / "src"
+        if (src_dir / "memsearch").is_dir():
+            sys.path.insert(0, str(src_dir))
+            break
+
+    try:
+        import memsearch  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    if os.environ.get("MEMSEARCH_DSH_UV_BOOTSTRAP") == "1":
+        return
+
+    memsearch_bin = _which("memsearch")
+    if memsearch_bin:
+        try:
+            first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+            if first_line.startswith("#!"):
+                python_bin = first_line[2:].strip().split()[0]
+                if python_bin:
+                    os.execvpe(
+                        python_bin,
+                        [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
+                        {**os.environ, "MEMSEARCH_DSH_UV_BOOTSTRAP": "1"},
+                    )
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    uv = _which("uv")
+    if not uv:
+        return
+
+    env = {**os.environ, "MEMSEARCH_DSH_UV_BOOTSTRAP": "1"}
+    os.execvpe(
+        uv,
+        [
+            uv,
+            "run",
+            "--with",
+            "memsearch[onnx]",
+            "python",
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+        env,
+    )
+
+
+def _which(name: str) -> str | None:
+    """Return the first PATH match for ``name`` (no shell involved)."""
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        candidate = Path(directory) / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Summarization
+# ---------------------------------------------------------------------------
+
+
+def _load_summarize_prompt(config, agent_name: str, plugin_dir: Path) -> str:
+    """Load the summarize prompt: user override > plugin template > inline."""
+    configured = getattr(config, "prompts", None)
+    custom_path = getattr(configured, "summarize", "") if configured else ""
+    if custom_path:
+        candidate = Path(custom_path).expanduser()
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8").replace("{{AGENT_NAME}}", agent_name)
+
+    builtin = plugin_dir / "prompts" / "summarize.txt"
+    if builtin.is_file():
+        return builtin.read_text(encoding="utf-8").replace("{{AGENT_NAME}}", agent_name)
+
+    return (
+        "You are a third-person note-taker. You will receive a transcript of ONE conversation turn "
+        f"between User and {agent_name}.\n\n"
+        "Record what happened as factual third-person notes. Output 2-10 bullet points, each starting with '- '. "
+        "Use 'User' for the user. First bullet: what User asked or wanted. Remaining bullets: what was done, "
+        f"found, changed, configured, tested, explained, decided, or could not be completed by {agent_name}. "
+        "Mandatory language rule: write every bullet in the same primary language as the [User] text. "
+        "If User mixes languages, use the dominant user-facing language. "
+        "Be specific when useful: mention important files read or edited, searches or research performed, "
+        "refactors, commands or tests run, key findings, and concrete outcomes. Prefer the final user-visible "
+        "outcome over low-level transcript mechanics. Do NOT answer User's question yourself. Output ONLY "
+        "bullet points."
+    )
+
+
+def _resolve_llm_settings(config, provider_arg: str, model_arg: str) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve (provider_type, model, base_url, api_key) from memsearch config.
+
+    Mirrors the plugin summarize resolution in ``cli.py`` while adding the
+    compact-style fallback for when no ``[llm.providers.*]`` entry is named.
+    """
+    llm = getattr(config, "llm", None)
+    compact = getattr(config, "compact", None)
+
+    def _named_provider(name: str) -> tuple[str, str | None, str | None, str | None]:
+        providers = getattr(llm, "providers", {}) if llm else {}
+        provider_cfg = providers.get(name)
+        if provider_cfg is None:
+            raise ValueError(f"Unknown LLM provider {name!r}. Configure [llm.providers.{name}] in memsearch config.")
+        provider_type = provider_cfg.type or name
+        model = model_arg or provider_cfg.model or (getattr(llm, "model", "") or "")
+        base_url = provider_cfg.base_url or getattr(llm, "base_url", "") or None
+        api_key = provider_cfg.api_key or getattr(llm, "api_key", "") or None
+        return provider_type, model or None, base_url, api_key
+
+    if provider_arg:
+        return _named_provider(provider_arg)
+
+    top_provider = getattr(llm, "provider", "") if llm else ""
+    if top_provider and top_provider in (getattr(llm, "providers", {}) or {}):
+        return _named_provider(top_provider)
+
+    if not top_provider:
+        top_provider = getattr(compact, "llm_provider", "") if compact else ""
+    provider_type = top_provider or "openai"
+    model = model_arg or getattr(llm, "model", "") or getattr(compact, "llm_model", "")
+    base_url = getattr(llm, "base_url", "") or getattr(compact, "base_url", "") or None
+    api_key = getattr(llm, "api_key", "") or getattr(compact, "api_key", "") or None
+    return provider_type, model or None, base_url, api_key
+
+
+async def _summarize(
+    prompt: str, llm_provider: str, model: str | None, base_url: str | None, api_key: str | None
+) -> str:
+    from memsearch.compact import summarize_text
+
+    return await summarize_text(
+        prompt,
+        llm_provider=llm_provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize a DSH turn with memsearch-managed LLM.")
+    parser.add_argument("--agent-name", default="DeepSeek Harness", help="Agent display name.")
+    parser.add_argument("--provider", default="", help="Named [llm.providers.*] entry to use.")
+    parser.add_argument("--model", default="", help="Override the LLM model.")
+    parser.add_argument("--project-dir", default="", help="Project directory (config resolution anchor).")
+    parser.add_argument("--plugin-dir", default="", help="Plugin directory (prompt template location).")
+    args = parser.parse_args()
+
+    transcript = sys.stdin.read()
+    if not transcript.strip():
+        return 0
+
+    plugin_dir = Path(args.plugin_dir).resolve() if args.plugin_dir else Path(__file__).resolve().parent.parent
+
+    if args.project_dir:
+        os.chdir(args.project_dir)
+
+    ensure_memsearch_importable()
+
+    try:
+        from memsearch.config import resolve_config
+
+        config = resolve_config()
+    except Exception as error:  # surface any config failure visibly
+        print(f"Error: failed to load memsearch config: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        system_prompt = _load_summarize_prompt(config, args.agent_name, plugin_dir)
+        provider_type, model, base_url, api_key = _resolve_llm_settings(config, args.provider, args.model)
+        prompt = f"{system_prompt}\n\nTranscript:\n{transcript}"
+        summary = asyncio.run(_summarize(prompt, provider_type, model, base_url, api_key))
+    except Exception as error:  # report provider errors instead of hiding them
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    if summary and summary.strip():
+        print(summary.strip())
+        return 0
+    print("Error: summarizer returned no output", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dsh/skills/memory-recall/SKILL.md
+++ b/plugins/dsh/skills/memory-recall/SKILL.md
@@ -1,0 +1,60 @@
+<!--
+  memsearch-dsh memory-recall skill body.
+  Registered at plugin load by plugins/dsh/index.js via ctx.skills.register()
+  with metadata (name: memory-recall, description, whenToUse) supplied in code.
+  {{PLACEHOLDER}} tokens are substituted at registration time.
+-->
+
+# Memory Recall
+
+Search memsearch's persistent memory for context relevant to the user's question. The memory store is shared across agents (Claude Code, Codex, OpenClaw, OpenCode, DeepSeek Harness), so it can surface past work, decisions, and conversation fragments from any of them.
+
+## When to use
+
+Use this skill when the user's question could benefit from historical context: they reference past work, ask what was done before, or the current task could reuse earlier decisions or findings. A search is cheap (one index query), so when in doubt, run it.
+
+## Steps
+
+### 1. Search for relevant chunks
+
+Run a semantic search over the project's memsearch collection. The collection is derived from the project directory (see `derive-collection.sh`); the plugin normally injects the resolved value as `{{COLLECTION}}`:
+
+```bash
+{{MEMSEARCH_CMD}} search "{{QUERY}}" --top-k 5 --json-output {{MILVUS_FLAG}}--collection "{{COLLECTION}}"
+```
+
+Replace `{{QUERY}}` with a concise natural-language summary of what the user needs. The `--json-output` results contain `content`, `source`, `heading`, `score`, and `chunk_hash`.
+
+### 2. Expand promising results
+
+For the most promising results, expand the full markdown section to see surrounding context:
+
+```bash
+{{MEMSEARCH_CMD}} expand <chunk_hash> {{MILVUS_FLAG}}--collection "{{COLLECTION}}"
+```
+
+### 3. Drill into the original conversation (optional)
+
+When an expanded result contains an anchor comment like
+
+```
+<!-- session:<id> turn:<N> db:<path> -->
+```
+
+you can render the original conversation around that turn:
+
+```bash
+python3 {{PLUGIN_DIR}}/scripts/parse-transcript.py --db "<path>" --turn <N> --context 3
+```
+
+Pass `--context 0` for just the target turn, or omit `--turn` to see the most recent turns.
+
+### 4. Report a curated summary
+
+Return a concise summary of the relevant context to the user, citing the memory source files where useful. If the search finds nothing relevant, say so plainly in one line and proceed without it. Do not fabricate memories.
+
+## Notes
+
+- The memory store is plain markdown under `<project>/.memsearch/memory/YYYY-MM-DD.md`. Milvus is a derived search index; a chunk may be indexed slightly behind the markdown source.
+- If `memsearch` is not on PATH, prefix with the detected command `{{MEMSEARCH_CMD}}` (which may be `uvx --from 'memsearch[onnx]' memsearch`).
+- Prefer the final, user-facing outcome over raw transcript detail.

--- a/plugins/dsh/tests/test_parse_transcript.py
+++ b/plugins/dsh/tests/test_parse_transcript.py
@@ -1,0 +1,261 @@
+"""End-to-end tests for the DSH session transcript parser.
+
+Builds synthetic DSH session artifacts (header + SessionEvent JSONL lines) and
+runs ``scripts/parse-transcript.py`` as a subprocess, the same way the
+``memory-recall`` skill invokes it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "parse-transcript.py"
+
+SESSION_ID = "sess-00000000-0000-0000-0000-000000000001"
+
+
+def _header() -> str:
+    return json.dumps(
+        {
+            "type": "session",
+            "version": 3,
+            "id": SESSION_ID,
+            "createdAt": 1700000000000,
+            "cwd": "/proj",
+            "delegationDepth": 0,
+        }
+    )
+
+
+def _line(record: dict) -> str:
+    return json.dumps(record)
+
+
+def _turn_start(turn: int, seq: int) -> dict:
+    return {"type": "turn/start", "seq": seq, "time": 1700000000000 + seq, "data": {"turn": turn}}
+
+
+def _turn_end(turn: int, seq: int) -> dict:
+    return {
+        "type": "turn/end",
+        "seq": seq,
+        "time": 1700000000000 + seq,
+        "data": {"turn": turn, "reason": {"kind": "completed"}},
+    }
+
+
+def _user(text: str, seq: int, *, source_kind: str = "user") -> dict:
+    return {
+        "type": "user/message",
+        "seq": seq,
+        "time": 1700000000000 + seq,
+        "data": {
+            "id": f"u{seq}",
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+            "source": {"kind": source_kind},
+        },
+    }
+
+
+def _assistant(text: str, turn: int, seq: int) -> dict:
+    return {
+        "type": "assistant/message",
+        "seq": seq,
+        "time": 1700000000000 + seq,
+        "data": {
+            "turn": turn,
+            "step": 1,
+            "message": {
+                "id": f"a{seq}",
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+                "source": {"kind": "model", "provider": "deepseek", "model": "deepseek-chat"},
+            },
+        },
+    }
+
+
+def _tool_call(turn: int, name: str, seq: int) -> dict:
+    return {
+        "type": "tool/call",
+        "seq": seq,
+        "time": 1700000000000 + seq,
+        "data": {"turn": turn, "step": 1, "callId": f"c{seq}", "name": name, "arguments": "{}"},
+    }
+
+
+def _packed_text_chunks(turn: int, seq0: int, texts: list[str]) -> dict:
+    return {
+        "type": "text-chunks",
+        "seq0": seq0,
+        "time0": 1700000000000 + seq0,
+        "data": {"turn": turn, "step": 1, "index": 0, "dt": [1, 1], "texts": texts},
+    }
+
+
+def _write_session(tmp_path: Path, records: list[dict]) -> Path:
+    path = tmp_path / "session.jsonl"
+    path.write_text(_header() + "\n" + "\n".join(_line(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _run(db_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--db", str(db_path), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_renders_user_and_assistant_turn(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("What is the deploy command?", 2),
+            _assistant("Run `uv run python -m pytest`.", 1, 3),
+            _turn_end(1, 4),
+        ],
+    )
+    result = _run(db)
+    assert result.returncode == 0, result.stderr
+    assert SESSION_ID in result.stdout
+    assert "[User]: What is the deploy command?" in result.stdout
+    assert "[Assistant]: Run `uv run python -m pytest`." in result.stdout
+    assert "=== Turn 1 ===" in result.stdout
+
+
+def test_skips_plugin_injected_user_messages(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("[memsearch] Memory available.", 2, source_kind="plugin"),
+            _user("Real question?", 3),
+            _assistant("Answer.", 1, 4),
+            _turn_end(1, 5),
+        ],
+    )
+    result = _run(db)
+    assert result.returncode == 0, result.stderr
+    assert "[memsearch] Memory available." not in result.stdout
+    assert "[User]: Real question?" in result.stdout
+
+
+def test_target_turn_with_context(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("First.", 2),
+            _assistant("One.", 1, 3),
+            _turn_end(1, 4),
+            _turn_start(2, 5),
+            _user("Second.", 6),
+            _assistant("Two.", 2, 7),
+            _turn_end(2, 8),
+            _turn_start(3, 9),
+            _user("Third.", 10),
+            _assistant("Three.", 3, 11),
+            _turn_end(3, 12),
+        ],
+    )
+    result = _run(db, "--turn", "2", "--context", "1")
+    assert result.returncode == 0, result.stderr
+    assert "=== Turn 1 ===" in result.stdout
+    assert "=== Turn 2 ===" in result.stdout
+    assert "=== Turn 3 ===" in result.stdout
+    # The block for turn 2 carries its content.
+    assert "[User]: Second." in result.stdout
+
+
+def test_target_turn_context_zero(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("First.", 2),
+            _assistant("One.", 1, 3),
+            _turn_end(1, 4),
+            _turn_start(2, 5),
+            _user("Second.", 6),
+            _assistant("Two.", 2, 7),
+            _turn_end(2, 8),
+        ],
+    )
+    result = _run(db, "--turn", "1", "--context", "0")
+    assert result.returncode == 0, result.stderr
+    assert "=== Turn 1 ===" in result.stdout
+    assert "=== Turn 2 ===" not in result.stdout
+
+
+def test_ignores_packed_chunk_rows(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("Stream it.", 2),
+            _packed_text_chunks(1, 3, ["Hel", "lo ", "world"]),
+            _assistant("Hello world", 1, 4),
+            _turn_end(1, 5),
+        ],
+    )
+    result = _run(db)
+    assert result.returncode == 0, result.stderr
+    assert "[Assistant]: Hello world" in result.stdout
+    # The packed row must not render as a turn event or duplicate text.
+    assert result.stdout.count("[Assistant]") == 1
+
+
+def test_includes_tool_calls(tmp_path: Path) -> None:
+    db = _write_session(
+        tmp_path,
+        [
+            _turn_start(1, 1),
+            _user("Run the tests.", 2),
+            _tool_call(1, "bash", 3),
+            _assistant("Done.", 1, 4),
+            _turn_end(1, 5),
+        ],
+    )
+    result = _run(db)
+    assert result.returncode == 0, result.stderr
+    assert "[Tool call]: bash" in result.stdout
+
+
+def test_missing_db_is_visible_error(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path / "missing",
+    )
+    assert result.returncode == 1
+    assert "does not exist" in result.stderr
+
+
+def test_session_id_mismatch(tmp_path: Path) -> None:
+    db = _write_session(tmp_path, [_turn_start(1, 1), _user("Hi.", 2), _turn_end(1, 3)])
+    result = _run(db, "--session", "different-id")
+    assert result.returncode == 1
+    assert "session id mismatch" in result.stderr
+
+
+def test_limit_controls_turns_without_target(tmp_path: Path) -> None:
+    records: list[dict] = []
+    seq = 1
+    for turn in range(1, 4):
+        records.append(_turn_start(turn, seq))
+        seq += 1
+        records.append(_user(f"Q{turn}.", seq))
+        seq += 1
+        records.append(_assistant(f"A{turn}.", turn, seq))
+        seq += 1
+        records.append(_turn_end(turn, seq))
+        seq += 1
+    db = _write_session(tmp_path, records)
+    result = _run(db, "--limit", "2")
+    assert result.returncode == 0, result.stderr
+    assert "=== Turn 3 ===" in result.stdout
+    assert "=== Turn 1 ===" not in result.stdout

--- a/plugins/dsh/tests/test_summarize.py
+++ b/plugins/dsh/tests/test_summarize.py
@@ -1,0 +1,121 @@
+"""Unit tests for the DSH plugin summarizer's config resolution.
+
+These test the pure resolution helpers in ``scripts/summarize.py`` with fake
+memsearch config objects — no LLM calls, no subprocesses.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import summarize  # noqa: E402  (inserted above)
+
+
+def _provider(type_: str, model: str = "", base_url: str = "", api_key: str = "") -> SimpleNamespace:
+    return SimpleNamespace(type=type_, model=model, base_url=base_url, api_key=api_key)
+
+
+def make_config(**overrides) -> SimpleNamespace:
+    providers = {
+        "deepseek": _provider("openai", "deepseek-chat", "https://api.deepseek.com", "env:DSK"),
+        "local-anthropic": _provider("anthropic", "claude-sonnet-4-6"),
+    }
+    llm = SimpleNamespace(provider="", model="", base_url="", api_key="", providers=providers)
+    compact = SimpleNamespace(llm_provider="", llm_model="", base_url="", api_key="")
+    prompts = SimpleNamespace(summarize="")
+    config = SimpleNamespace(llm=llm, compact=compact, prompts=prompts)
+    return config
+
+
+class TestResolveLlmSettings:
+    def test_explicit_provider_uses_named_entry(self) -> None:
+        config = make_config()
+        provider_type, model, base_url, api_key = summarize._resolve_llm_settings(config, "deepseek", "")
+        assert provider_type == "openai"
+        assert model == "deepseek-chat"
+        assert base_url == "https://api.deepseek.com"
+        assert api_key == "env:DSK"
+
+    def test_explicit_provider_missing_raises_visible_error(self) -> None:
+        config = make_config()
+        with pytest.raises(ValueError, match="Unknown LLM provider 'nope'"):
+            summarize._resolve_llm_settings(config, "nope", "")
+
+    def test_model_arg_overrides_provider_model(self) -> None:
+        config = make_config()
+        _, model, _, _ = summarize._resolve_llm_settings(config, "deepseek", "custom-model")
+        assert model == "custom-model"
+
+    def test_provider_type_defaults_to_name(self) -> None:
+        config = make_config()
+        config.llm.providers["gemini-local"] = _provider("", "gemini-3-flash-preview")
+        provider_type, model, _, _ = summarize._resolve_llm_settings(config, "gemini-local", "")
+        assert provider_type == "gemini-local"
+        assert model == "gemini-3-flash-preview"
+
+    def test_llm_provider_naming_configured_entry(self) -> None:
+        config = make_config()
+        config.llm.provider = "deepseek"
+        provider_type, model, _, _ = summarize._resolve_llm_settings(config, "", "")
+        assert provider_type == "openai"
+        assert model == "deepseek-chat"
+
+    def test_defaults_to_openai_with_top_level_llm(self) -> None:
+        config = make_config()
+        config.llm.base_url = "https://example.com/v1"
+        config.llm.api_key = "env:OPENAI_API_KEY"
+        provider_type, model, base_url, api_key = summarize._resolve_llm_settings(config, "", "")
+        assert provider_type == "openai"
+        assert model is None
+        assert base_url == "https://example.com/v1"
+        assert api_key == "env:OPENAI_API_KEY"
+
+    def test_compact_fallback(self) -> None:
+        config = make_config()
+        config.llm.provider = ""
+        config.compact.llm_provider = "anthropic"
+        config.compact.llm_model = "claude-sonnet-4-6"
+        provider_type, model, _, _ = summarize._resolve_llm_settings(config, "", "")
+        assert provider_type == "anthropic"
+        assert model == "claude-sonnet-4-6"
+
+
+class TestLoadSummarizePrompt:
+    def test_plugin_template_contains_agent_name(self) -> None:
+        plugin_dir = Path(__file__).resolve().parent.parent
+        config = make_config()
+        prompt = summarize._load_summarize_prompt(config, "DeepSeek Harness", plugin_dir)
+        assert "DeepSeek Harness" in prompt
+        assert "third-person note-taker" in prompt
+        assert "{{AGENT_NAME}}" not in prompt
+
+    def test_custom_prompt_wins(self, tmp_path: Path) -> None:
+        custom = tmp_path / "custom.txt"
+        custom.write_text("CUSTOM PROMPT for {{AGENT_NAME}}", encoding="utf-8")
+        config = make_config()
+        config.prompts.summarize = str(custom)
+        plugin_dir = Path(__file__).resolve().parent.parent
+        prompt = summarize._load_summarize_prompt(config, "Agent X", plugin_dir)
+        assert prompt == "CUSTOM PROMPT for Agent X"
+
+    def test_inline_fallback_when_no_template(self, tmp_path: Path) -> None:
+        config = make_config()
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        prompt = summarize._load_summarize_prompt(config, "Agent Y", empty_dir)
+        assert "Agent Y" in prompt
+        assert "third-person note-taker" in prompt
+
+    def test_missing_custom_path_falls_back_to_template(self) -> None:
+        config = make_config()
+        config.prompts.summarize = "/nonexistent/path.txt"
+        plugin_dir = Path(__file__).resolve().parent.parent
+        prompt = summarize._load_summarize_prompt(config, "DSH", plugin_dir)
+        assert "DSH" in prompt

--- a/scripts/sync-prompts.sh
+++ b/scripts/sync-prompts.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SHARED_DIR="$REPO_ROOT/plugins/_shared/prompts"
 
-PLUGINS=(claude-code codex openclaw opencode)
+PLUGINS=(claude-code codex openclaw opencode dsh)
 
 for plugin in "${PLUGINS[@]}"; do
     dest="$REPO_ROOT/plugins/$plugin/prompts"


### PR DESCRIPTION
Adds a native Cordis plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH), the fifth platform plugin for memsearch. It gives DSH persistent, cross-agent memory on the same `.memsearch/memory/` markdown store used by the Claude Code, Codex, OpenClaw, and OpenCode plugins, backed by a Milvus hybrid search index.

### What it does

- **Capture** — listens on `session/event` for `turn/end`, stages the turn durably in `.dsh-capture.jsonl`, then summarizes it via memsearch's `[llm.providers.*]` config and appends to `memory/YYYY-MM-DD.md` using the shared anchor format. Interrupted drains are replayed on the next plugin load.
- **Inject** — on `agent/pre-step` at step 1, runs a bounded semantic search over the user's question. Only when relevant chunks exist does it inject them plus a `[memsearch] Memory available.` hint; otherwise the decision is returned unchanged (zero context cost).
- **Recall** — registers a `memory-recall` skill (search → expand → transcript drill-down) through DSH's native `skill` tool.

### Structure

```
plugins/dsh/
├── index.js                  # Cordis plugin (ESM, no build step)
├── package.json              # dsh.bundle declaration
├── cordis.patch.yml          # inserts the memsearch row into a profile's plugin tree
├── README.md                 # install / config / uninstall
├── prompts/summarize.txt     # shared template (synced by scripts/sync-prompts.sh)
├── scripts/
│   ├── summarize.py          # LLM summarization via [llm.providers.*]
│   ├── parse-transcript.py   # DSH session JSONL parser (search/expand drill-down)
│   └── derive-collection.sh  # per-project collection derivation (shared with other plugins)
├── skills/memory-recall/SKILL.md
└── tests/                    # 20 unit tests (summarize, parse-transcript)
```

### Configuration

All keys optional, set through the profile's `cordis.patch.yml`:

`captureEnabled`, `injectEnabled`, `summarizeEnabled`, `summarizeProvider`, `summarizeModel`, `memsearchDir`, `collection`, `milvusUri`, `agentName`.

- Summarization reuses `[llm.providers.*]` — no separate LLM setup. A missing provider fails loudly (visible error), never a silent empty write; a failed summary falls back to the raw turn so memory is never lost.
- `milvusUri` lets a profile point search/index at a dedicated Milvus (URI or path) to isolate its memory or target a shared Milvus Server.

### Testing

- 20 unit tests for `summarize.py` and `parse-transcript.py` — `uv run python -m pytest plugins/dsh/tests` green
- Ruff + format green on the new Python files
- Live DSH E2E: captured turns written to `.memsearch/memory/`, a fresh session recalled the memory with a correct citation, and the zero-context-cost path verified when memory is irrelevant
- `scripts/sync-prompts.sh` now registers the `dsh` plugin so it receives the shared `summarize.txt` template

No changes to the existing four platform plugins or the `src/memsearch/` public contract. No new third-party runtime dependencies.
