### PR TITLE
fix(opencode): run derive-collection.sh via argv, not a shell string (#681)

### DIFF
--- a/plugins/opencode/derive-collection.test.ts
+++ b/plugins/opencode/derive-collection.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveCollectionNameFromScript } from "./derive-collection.ts";
+
+const SCRIPT_PATH = "/opt/memsearch/scripts/derive-collection.sh";
+
+for (const projectDir of [
+  "/tmp/project",
+  "/tmp/project with spaces",
+  "/tmp/project's",
+  "/tmp/project\"name",
+  String.raw`/tmp/project\segment`,
+  "-leading-dash",
+  "/tmp/项目-α",
+]) {
+  test(`passes the project path as one literal argv entry: ${JSON.stringify(projectDir)}`, () => {
+    const calls: Array<{ file: string; args: string[]; options: unknown }> = [];
+    const result = deriveCollectionNameFromScript(
+      SCRIPT_PATH,
+      projectDir,
+      (file, args, options) => {
+        calls.push({ file, args: [...args], options });
+        return "ms_recorded_12345678\n";
+      }
+    );
+
+    assert.equal(result, "ms_recorded_12345678");
+    assert.deepEqual(calls, [
+      {
+        file: "bash",
+        args: [SCRIPT_PATH, projectDir],
+        options: { encoding: "utf-8", timeout: 5000 },
+      },
+    ]);
+  });
+}
+
+test("returns the existing fallback when collection derivation fails", () => {
+  const result = deriveCollectionNameFromScript(
+    SCRIPT_PATH,
+    "/tmp/project",
+    () => {
+      throw new Error("recorded failure");
+    }
+  );
+
+  assert.equal(result, "ms_opencode_default");
+});

--- a/plugins/opencode/derive-collection.ts
+++ b/plugins/opencode/derive-collection.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process";
+
+type CollectionCommandRunner = (
+  file: string,
+  args: string[],
+  options: { encoding: "utf-8"; timeout: number }
+) => string;
+
+const runCollectionCommand: CollectionCommandRunner = (file, args, options) =>
+  execFileSync(file, args, options);
+
+export function deriveCollectionNameFromScript(
+  script: string,
+  projectDir: string,
+  run: CollectionCommandRunner = runCollectionCommand
+): string {
+  try {
+    return run("bash", [script, projectDir], {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+  } catch {
+    return "ms_opencode_default";
+  }
+}

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -32,6 +32,7 @@ import {
   mergeSystemMemoryContext,
   shellEscape,
 } from "./context.ts";
+import { deriveCollectionNameFromScript } from "./derive-collection.ts";
 
 const PLUGIN_DIR = dirname(realpathSync(fileURLToPath(import.meta.url)));
 
@@ -67,14 +68,7 @@ function detectMemsearchCmd(): string {
 /** Derive a per-project Milvus collection name via the shared script. */
 function deriveCollectionName(projectDir: string): string {
   const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
-  try {
-    return execSync(`bash "${script}" "${projectDir}"`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    }).trim();
-  } catch {
-    return "ms_opencode_default";
-  }
+  return deriveCollectionNameFromScript(script, projectDir);
 }
 
 /**

--- a/plugins/opencode/index.ts
+++ b/plugins/opencode/index.ts
@@ -13,7 +13,7 @@
 
 import type { Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
-import { execSync, exec, spawn, spawnSync } from "node:child_process";
+import { execSync, execFileSync, exec, spawn, spawnSync } from "node:child_process";
 import {
   readFileSync,
   existsSync,
@@ -68,7 +68,7 @@ function detectMemsearchCmd(): string {
 function deriveCollectionName(projectDir: string): string {
   const script = join(PLUGIN_DIR, "scripts", "derive-collection.sh");
   try {
-    return execSync(`bash "${script}" "${projectDir}"`, {
+    return execFileSync("bash", [script, projectDir], {
       encoding: "utf-8",
       timeout: 5000,
     }).trim();

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "context.ts",
+    "derive-collection.ts",
     "index.ts",
     "scripts/*.py",
     "scripts/*.sh",


### PR DESCRIPTION
Fixes the shell injection in the OpenCode plugin reported in #681.

### The change

`plugins/opencode/index.ts:71` built its command by interpolating `projectDir` into a double-quoted shell string:

```ts
execSync(`bash "${script}" "${projectDir}"`, { encoding: "utf-8", timeout: 5000 })
```

On POSIX, `execSync` runs the assembled string through `/bin/sh -c`, so a `$(…)` or backtick anywhere in `projectDir` is command-substituted before `bash` runs — double quotes don't stop command substitution. `projectDir` is the directory OpenCode is opened in (`worktree`/`directory`/`process.cwd()`), and the same value arrives per-tool-call as `context.directory`, so a directory whose *name* contains shell metacharacters gives command execution on session start.

This switches to `execFileSync` with an argv array, so the path is passed as a literal argument with no shell:

```ts
execFileSync("bash", [script, projectDir], { encoding: "utf-8", timeout: 5000 })
```

`execFileSync` returns the same string-with-encoding result, so `.trim()` is unchanged and behaviour is otherwise identical. `execSync` is still used at line 193 (a fixed command with no untrusted input), so it stays in the import.

### Why this form

The other plugins already run this exact script safely without a shell:

- `plugins/dsh/index.js:167` — `execFileSync('bash', [script, projectDir], …)`
- `plugins/openclaw/index.ts:393` — `runCmd(["bash", script, scopeDir])`

So this brings OpenCode in line with its siblings rather than introducing a new pattern.

### Verification

Verified with a standalone differential (`/bin/sh -c` of the old form executes an injected `$(touch …)` in the path; the argv form passes it through as a literal), described in #681. I kept the change to the single line rather than adding a unit test, because `deriveCollectionName` is module-local and testing it would mean exporting it — happy to export it and add a regression test if you'd prefer that shape.
