### PR TITLE
feat: add OrcaRouter embedding provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Markdown files → Scanner → Chunker → Embedder → MilvusStore
 - **`core.py`** — `MemSearch` class: the public Python API that orchestrates everything. Entry point for `index()`, `search()`, `compact()`, `watch()`.
 - **`store.py`** — `MilvusStore`: Milvus wrapper handling collection creation, upsert, hybrid search (dense cosine + BM25 sparse + RRF reranking), and cleanup. The `chunk_hash` (composite ID of source+lines+content+model) is the VARCHAR primary key.
 - **`chunker.py`** — Splits markdown by headings into `Chunk` dataclasses. SHA-256 content hash enables dedup. `compute_chunk_id()` generates composite IDs matching OpenClaw's format.
-- **`embeddings/__init__.py`** — `EmbeddingProvider` protocol + lazy-loading factory (`get_provider()`). Providers: openai (default), google, voyage, jina, mistral, ollama, local, onnx.
+- **`embeddings/__init__.py`** — `EmbeddingProvider` protocol + lazy-loading factory (`get_provider()`). Providers: openai (default), orcarouter, google, voyage, jina, mistral, ollama, local, onnx.
 - **`scanner.py`** — Walks directories to find `.md`/`.markdown` files, returns `ScannedFile` list.
 - **`config.py`** — Layered TOML config: dataclass defaults → `~/.memsearch/config.toml` → `.memsearch.toml` → CLI flags.
 - **`cli.py`** — Click CLI wrapping the Python API. All commands resolve config via `resolve_config()` then instantiate `MemSearch`.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Defaults to **ONNX bge-m3** — runs locally on CPU, no API key, no cost. On fir
 ```bash
 memsearch config set embedding.provider onnx     # default — local, free
 memsearch config set embedding.provider openai   # needs OPENAI_API_KEY
+memsearch config set embedding.provider orcarouter  # needs ORCAROUTER_API_KEY
 memsearch config set embedding.provider ollama   # local, any model
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,7 +80,7 @@ Writing to: /home/user/.memsearch/config.toml
   Collection name [memsearch_chunks]:
 
 -- Embedding --
-  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
+  Provider (openai/orcarouter/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
   Model (empty for provider default) []:
 
 -- Chunking --

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -513,7 +513,7 @@ Writing to: /home/user/.memsearch/config.toml
   Collection name [memsearch_chunks]:
 
 ── Embedding ──
-  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
+  Provider (openai/orcarouter/google/voyage/jina/mistral/ollama/local/onnx) [openai]:
   Model (empty for provider default) []:
 
 ── Chunking ──

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -74,6 +74,7 @@ memsearch index docs/ --exclude 'generated/**' --exclude '*.draft.md'
 |----------|---------|---------|-------|
 | **onnx** (default) | `pip install memsearch[onnx]` | No | Local, free, ~100MB model download |
 | openai | `pip install memsearch[openai]` | `OPENAI_API_KEY` | Best quality |
+| orcarouter | `pip install memsearch` | `ORCAROUTER_API_KEY` | OpenAI-compatible routing gateway |
 | google | `pip install memsearch[google]` | `GOOGLE_API_KEY` | Gemini embeddings |
 | voyage | `pip install memsearch[voyage]` | `VOYAGE_API_KEY` | High quality |
 | jina | `pip install memsearch[jina]` | `JINA_API_KEY` | jina-embeddings-v4, multilingual, long context |

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1010,6 +1010,7 @@ def config_init(project: bool) -> None:
     result["embedding"] = {}
     _embedding_defaults = {
         "openai": "text-embedding-3-small",
+        "orcarouter": "openai/text-embedding-3-small",
         "google": "gemini-embedding-001",
         "voyage": "voyage-3-lite",
         "jina": "jina-embeddings-v4",
@@ -1019,7 +1020,7 @@ def config_init(project: bool) -> None:
         "onnx": "gpahal/bge-m3-onnx-int8",
     }
     result["embedding"]["provider"] = click.prompt(
-        "  Provider (openai/google/voyage/jina/mistral/ollama/local/onnx)",
+        "  Provider (openai/orcarouter/google/voyage/jina/mistral/ollama/local/onnx)",
         default=current.embedding.provider,
     )
     _emb_provider = result["embedding"]["provider"]

--- a/src/memsearch/embeddings/__init__.py
+++ b/src/memsearch/embeddings/__init__.py
@@ -24,6 +24,7 @@ class EmbeddingProvider(Protocol):
 # Provider registry: name -> (module_path, class_name)
 _PROVIDERS: dict[str, tuple[str, str]] = {
     "openai": ("memsearch.embeddings.openai", "OpenAIEmbedding"),
+    "orcarouter": ("memsearch.embeddings.orcarouter", "OrcaRouterEmbedding"),
     "google": ("memsearch.embeddings.google", "GoogleEmbedding"),
     "voyage": ("memsearch.embeddings.voyage", "VoyageEmbedding"),
     "jina": ("memsearch.embeddings.jina", "JinaEmbedding"),
@@ -37,6 +38,7 @@ _PROVIDERS: dict[str, tuple[str, str]] = {
 # Kept here so callers can resolve the effective model without importing heavy deps.
 DEFAULT_MODELS: dict[str, str] = {
     "openai": "text-embedding-3-small",
+    "orcarouter": "openai/text-embedding-3-small",
     "google": "gemini-embedding-001",
     "voyage": "voyage-3-lite",
     "jina": "jina-embeddings-v4",
@@ -48,6 +50,7 @@ DEFAULT_MODELS: dict[str, str] = {
 
 _INSTALL_HINTS: dict[str, str] = {
     "openai": "pip install memsearch  (or: uv add memsearch)",
+    "orcarouter": "pip install memsearch  (or: uv add memsearch)",
     "google": 'pip install "memsearch[google]"  (or: uv add "memsearch[google]")',
     "voyage": 'pip install "memsearch[voyage]"  (or: uv add "memsearch[voyage]")',
     "jina": 'pip install "memsearch[jina]"  (or: uv add "memsearch[jina]")',
@@ -71,16 +74,18 @@ def get_provider(
     Parameters
     ----------
     name:
-        One of "openai", "google", "voyage", "ollama", "local", "onnx".
+        One of "openai", "orcarouter", "google", "voyage", "ollama", "local", "onnx".
     model:
         Override the default model for the provider.
     batch_size:
         Maximum number of texts per embedding API call.
         ``0`` means use the provider's built-in default.
     base_url:
-        Override the API base URL (currently only used by the openai provider).
+        Override the API base URL (currently only used by the openai and
+        orcarouter providers).
     api_key:
-        Override the API key (currently only used by the openai provider).
+        Override the API key (currently only used by the openai and
+        orcarouter providers).
     """
     if name not in _PROVIDERS:
         raise ValueError(f"Unknown embedding provider {name!r}. Available: {', '.join(sorted(_PROVIDERS))}")
@@ -100,7 +105,7 @@ def get_provider(
         kwargs["model"] = model
     if batch_size > 0:
         kwargs["batch_size"] = batch_size
-    if name == "openai":
+    if name in ("openai", "orcarouter"):
         if base_url:
             kwargs["base_url"] = base_url
         if api_key:

--- a/src/memsearch/embeddings/orcarouter.py
+++ b/src/memsearch/embeddings/orcarouter.py
@@ -1,0 +1,93 @@
+"""OrcaRouter embedding provider.
+
+Requires: ``pip install memsearch`` (openai is included by default)
+Environment variables:
+    ORCAROUTER_API_KEY  — required
+    ORCAROUTER_BASE_URL — optional, override API base URL
+
+OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible model routing
+gateway. Model IDs are namespaced (e.g. ``openai/text-embedding-3-small``);
+bare IDs such as ``text-embedding-3-small`` are not routable and return 503.
+The default base URL is ``https://api.orcarouter.ai/v1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+
+# Known output dimensions for OrcaRouter-routable embedding models.
+_KNOWN_DIMENSIONS: dict[str, int] = {
+    "openai/text-embedding-3-small": 1536,
+    "openai/text-embedding-3-large": 3072,
+}
+
+
+class OrcaRouterEmbedding:
+    """OrcaRouter embedding provider (OpenAI-compatible endpoint)."""
+
+    # OpenAI-compatible gateways cap total tokens per embedding request.
+    # A lower batch size avoids hitting that limit with large chunks.
+    _DEFAULT_BATCH_SIZE = 256
+
+    def __init__(
+        self,
+        model: str = "openai/text-embedding-3-small",
+        *,
+        batch_size: int = 0,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        import openai
+
+        self._api_key = api_key or os.environ.get("ORCAROUTER_API_KEY")
+        if not self._api_key:
+            raise RuntimeError("ORCAROUTER_API_KEY is required for the OrcaRouter embedding provider")
+
+        # Explicit params take priority over environment variables.
+        effective_base_url = base_url or os.environ.get("ORCAROUTER_BASE_URL") or _DEFAULT_BASE_URL
+        client_kwargs: dict = {
+            "api_key": self._api_key,
+            "base_url": effective_base_url,
+        }
+        self._client = openai.AsyncOpenAI(**client_kwargs)
+        self._model = model
+        self._dimension = _detect_dimension(model, client_kwargs)
+        self._batch_size = batch_size if batch_size > 0 else self._DEFAULT_BATCH_SIZE
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        from .utils import batched_embed
+
+        return await batched_embed(texts, self._embed_batch, self._batch_size)
+
+    async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        resp = await self._client.embeddings.create(input=texts, model=self._model, encoding_format="float")
+        return [item.embedding for item in resp.data]
+
+
+def _detect_dimension(model: str, client_kwargs: dict) -> int:
+    """Return the embedding dimension for *model*.
+
+    Uses a lookup table for well-known models.  For unknown models
+    (e.g. custom models via ORCAROUTER_BASE_URL), a trial embed is performed.
+    """
+    if model in _KNOWN_DIMENSIONS:
+        return _KNOWN_DIMENSIONS[model]
+    import openai
+
+    sync_client = openai.OpenAI(**client_kwargs)
+    trial = sync_client.embeddings.create(input=["dim"], model=model, encoding_format="float")
+    return len(trial.data[0].embedding)

--- a/tests/test_embeddings_orcarouter.py
+++ b/tests/test_embeddings_orcarouter.py
@@ -1,0 +1,56 @@
+"""Integration tests for OrcaRouter embedding provider.
+
+These tests require ORCAROUTER_API_KEY to be set.
+They are skipped if the key is not available.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("ORCAROUTER_API_KEY"),
+    reason="ORCAROUTER_API_KEY not set",
+)
+
+
+@pytest.fixture
+def provider():
+    from memsearch.embeddings.orcarouter import OrcaRouterEmbedding
+
+    return OrcaRouterEmbedding()
+
+
+@pytest.mark.asyncio
+async def test_embed_single(provider):
+    results = await provider.embed(["Hello world"])
+    assert len(results) == 1
+    assert len(results[0]) == provider.dimension
+    assert all(isinstance(v, float) for v in results[0])
+
+
+@pytest.mark.asyncio
+async def test_embed_batch(provider):
+    texts = ["First text", "Second text", "Third text"]
+    results = await provider.embed(texts)
+    assert len(results) == 3
+    for emb in results:
+        assert len(emb) == provider.dimension
+
+
+@pytest.mark.asyncio
+async def test_embed_deterministic(provider):
+    text = "Deterministic embedding test"
+    r1 = await provider.embed([text])
+    r2 = await provider.embed([text])
+    # External providers can return tiny float-level differences while still
+    # being effectively deterministic for indexing and search.
+    assert r1[0][:5] == pytest.approx(r2[0][:5], abs=1e-4)
+
+
+def test_model_name(provider):
+    assert provider.model_name == "openai/text-embedding-3-small"
+
+
+def test_dimension(provider):
+    assert provider.dimension == 1536


### PR DESCRIPTION
## Add OrcaRouter embedding provider

This registers [OrcaRouter](https://www.orcarouter.ai) as a named embedding provider in the provider registry, mirroring the existing `openai` provider. Instead of pointing the generic OpenAI provider at a custom `base_url`, users can set `embedding.provider = "orcarouter"` directly.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

I'm an engineer on the OrcaRouter team.

### Files changed
- `src/memsearch/embeddings/orcarouter.py` (new) — `OrcaRouterEmbedding`, OpenAI-compatible, default base URL `https://api.orcarouter.ai/v1`, default model `openai/text-embedding-3-small`, key read from `ORCAROUTER_API_KEY` (override base URL via `ORCAROUTER_BASE_URL`).
- `src/memsearch/embeddings/__init__.py` — registered `orcarouter` in `_PROVIDERS`, `DEFAULT_MODELS`, `_INSTALL_HINTS`, and in the `base_url`/`api_key` pass-through of `get_provider()`.
- `src/memsearch/cli.py` — `config init` now lists `orcarouter` with its default model.
- `tests/test_embeddings_orcarouter.py` (new) — mirrors `test_embeddings_openai.py` (skipped without `ORCAROUTER_API_KEY`).
- Docs: provider table in `docs/home/configuration.md`, config-init prompt output in `docs/cli.md` and `docs/getting-started.md`, README config example, and the provider list in `CLAUDE.md`.

### Notes
- OrcaRouter model IDs are namespaced (e.g. `openai/text-embedding-3-small`); bare IDs like `text-embedding-3-small` return `503 model_not_found`, so the provider defaults to the namespaced form.
- The `openai` SDK is already a base dependency, so no new extras are required.

### Verification
- `ruff check` and `ruff format --check` pass on all touched files.
- `tests/test_embeddings_orcarouter.py` passes (5/5) against the live endpoint.
- The config/CLI/embedding test subset shows no regressions; the only failures are pre-existing Windows/Milvus-Lite environment issues present on `main` as well.
