### PR TITLE
feat(dsh): auto summarize mode aligned with other platform plugins

### DIFF
--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -156,8 +156,8 @@ through the DSH logger.
   `<!-- session:<id> turn:<N> db:<path> -->`. The project directory comes from
   `session.header.cwd`, so a long-lived web surface captures every project it
   hosts, not just the process's boot directory. Turns are serialized (LLM
-  summarize calls never overlap) and `captureExists` dedup makes each turn
-  idempotent across restarts — there is no staging queue to drain or lose.
+  summarize calls never overlap) and `captureExists` dedup keeps each turn
+  idempotent if its event replays.
 - **Inject** — on `agent/pre-step` at step 1, runs a bounded memsearch search
   over the user's question. Only when relevant chunks exist does it inject
   them plus a `[memsearch] Memory available.` hint; otherwise the decision is

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -6,7 +6,7 @@ markdown store used by the Claude Code, Codex, OpenClaw, and OpenCode plugins,
 backed by a Milvus hybrid search index.
 
 ```
-capture  ── session/event turn/end ──> summarize.py (reuses [llm.providers.*]) ──> memory/YYYY-MM-DD.md
+capture  ── session/event turn/end ──> summarize (dsh-headless agent default, or custom-llm) ──> memory/YYYY-MM-DD.md
 inject   ── agent/pre-step step 1  ──> memsearch search ──> relevant chunks injected (zero cost otherwise)
 recall   ── ctx.skills.register(memory-recall) ──> search → expand → transcript
 ```
@@ -72,44 +72,93 @@ block (patch the `memsearch` row you inserted). All keys are optional.
 | --- | --- | --- | --- |
 | `captureEnabled` | bool | `true` | Capture completed turns into memory. |
 | `injectEnabled` | bool | `true` | Inject relevant memory before each turn's first step. |
-| `summarizeEnabled` | bool | `true` | Summarize turns with a memsearch-managed LLM. |
-| `summarizeProvider` | string | `''` | Name of an `[llm.providers.*]` entry used for summarization. |
-| `summarizeModel` | string | `''` | Model override for summarization. |
-| `memsearchDir` | string | `<project>/.memsearch` | Override the memory directory. |
-| `collection` | string | derived | Override the Milvus collection name. |
-| `milvusUri` | string | `''` | Point search/index at a dedicated Milvus (URI or path) instead of memsearch's own config. Useful to isolate a profile's memory or target a shared Milvus Server. |
-| `agentName` | string | `DeepSeek Harness` | Display name in the summarize prompt. |
+| `summarizeEnabled` | bool | `true` | Summarize turns before writing (on failure a short unavailable note is written, never a raw dump). |
+| `summarizeMode` | string | `auto` | Summarizer backend. `auto` (default) mirrors the other platform plugins: if `[plugins.dsh.summarize] provider` is set in memsearch config, it uses `custom-llm`; otherwise `dsh-headless` (zero-config DSH agent). Explicit `dsh-headless` / `custom-llm` pin the backend. |
+
+Everything else — provider/model, Milvus, collection, memory dir — comes from
+**memsearch config / environment**, exactly like the other platform plugins
+(no per-plugin config fields):
+
+- **Summarize provider/model** → `[plugins.dsh.summarize] provider` / `model`
+  in `~/.memsearch/config.toml` (or `[llm.providers.*]`; see the
+  `custom-llm` section below).
+- **Milvus** → `[milvus] uri` in memsearch config.
+- **Collection** → derived from the project path (`derive-collection.sh`),
+  or `--collection` passed to the memsearch CLI.
+- **Memory dir** → `MEMSEARCH_DIR` env (explicit → global scope), else
+  `<project>/.memsearch`.
 
 Example override layer (add this to the profile's own `cordis.patch.yml`):
 
 ```yaml
 - id: memsearch
   config:
-    summarizeProvider: deepseek
+    summarizeMode: dsh-headless   # pin the headless backend (default is auto)
 ```
 
-### Summarization provider resolution
+### Summarization modes
 
-Summarization reuses memsearch's `[llm.providers.*]` configuration — the same
-entries the other platform plugins use — so DSH adds no separate LLM setup.
-Provider selection (most specific first):
+Two backends are available, selected by `summarizeMode` — the same
+"configured choice" the Claude Code / Codex / OpenClaw / OpenCode plugins
+offer (each can summarize with their own LLM or a headless agent + small
+model). The default (`auto`) matches theirs: configure a provider and you get
+a direct LLM call; configure nothing and you get a headless agent.
 
-1. `summarizeProvider` — looked up in `[llm.providers.<name>]`; a missing
-   entry fails loudly (visible error), never a silent empty write.
-2. `llm.provider` when it names a configured provider or is a raw type.
-3. `compact.llm_provider` (deprecated) or `openai` as a final default.
+- **`auto`** (default) — mirrors the other platform plugins:
+  - if `[plugins.dsh.summarize] provider` is set in memsearch config
+    (`~/.memsearch/config.toml`, same place the other plugins read), use
+    `custom-llm` with that provider/model;
+  - otherwise use `dsh-headless` (zero-config DSH agent).
+  This means the plugin behaves like the other four: **configure a provider
+  → direct LLM; configure nothing → headless**.
+- **`dsh-headless`** — boots a one-shot DSH headless agent
+  (`dsh --profile headless "<summarize task>"`) to write the notes, mirroring
+  how the other plugins reuse their own agent's headless mode. Zero-config for
+  anyone already using DSH: the sub-agent's model is the deployment's
+  `agent-default-model` — the user layer of `~/.dsh/settings.yaml` (the same
+  selection the Web UI model settings write) wins over any patch, so **the
+  `[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
+  model in DSH settings (`agent-default-model:` in `~/.dsh/settings.yaml`, or
+  the Web UI model picker) instead. The boot is asynchronous and fire-and-forget,
+  so the few seconds of headless startup never block the conversation. Requires
+  `dsh` on PATH or `DSH_CLI` set to the CLI
+  entry. The sub-agent is booted with `MEMSEARCH_DSH_SUMMARIZE=1`; the plugin
+  checks that flag and stays inert (no capture / inject / skill) inside the
+  summarizer, so the summarizer's own session is never re-captured in a loop.
+- **`custom-llm`** — `scripts/summarize.py` imports memsearch's
+  `[llm.providers.*]` config and calls the LLM directly. Lightweight: one
+  python process, no DSH boot, no extra CLI dependency. Choose this when you
+  want a specific small model (e.g. an official `deepseek-v4-flash` key in
+  memsearch config) without booting an agent. Provider selection
+  (most specific first):
+  1. `[plugins.dsh.summarize] provider` (or the `summarizeProvider` CLI
+     argument summarize.py receives from it) — looked up in
+     `[llm.providers.<name>]`; a missing entry fails loudly (visible error),
+     never a silent empty write.
+  2. `llm.provider` when it names a configured provider or is a raw type.
+  3. `compact.llm_provider` (deprecated) or `openai` as a final default.
 
-A failed summarization writes the raw turn as a fallback so memory is never
-lost, and logs a visible warning through the DSH logger.
+There is **no automatic fallback between modes**: the backend you configure
+(or auto resolves) is the backend used. If it fails (missing dsh CLI, bad
+provider config), a short unavailable note is written with the reason — the
+plugin never silently switches to an LLM you did not configure.
+
+A failed summarization writes a short unavailable note (mirroring Claude
+Code's behavior — memory stays clean, the transcript anchor keeps the raw
+content reachable for progressive disclosure), and logs a visible warning
+through the DSH logger.
 
 ## How it works
 
 - **Capture** — listens on `session/event` for `turn/end`, renders the turn
-  (`[User]` / `[Assistant]` / `[Tool call]` lines), stages it durably in
-  `<memsearchDir>/.dsh-capture.jsonl`, then asynchronously summarizes and
-  appends it to `memory/YYYY-MM-DD.md` with the shared anchor format
-  `<!-- session:<id> turn:<N> db:<path> -->`. Turns staged by a run that was
-  interrupted mid-drain are replayed on the next plugin load.
+  (`[User]` / `[Assistant]` / `[Tool call]` lines), then fire-and-forget
+  summarizes (if enabled) and appends it to the **session's own**
+  `memory/YYYY-MM-DD.md` with the shared anchor format
+  `<!-- session:<id> turn:<N> db:<path> -->`. The project directory comes from
+  `session.header.cwd`, so a long-lived web surface captures every project it
+  hosts, not just the process's boot directory. Turns are serialized (LLM
+  summarize calls never overlap) and `captureExists` dedup makes each turn
+  idempotent across restarts — there is no staging queue to drain or lose.
 - **Inject** — on `agent/pre-step` at step 1, runs a bounded memsearch search
   over the user's question. Only when relevant chunks exist does it inject
   them plus a `[memsearch] Memory available.` hint; otherwise the decision is

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -13,37 +13,36 @@ recall   ── ctx.skills.register(memory-recall) ──> search → expand →
 
 ## Prerequisites
 
-- A working `memsearch` CLI. Either install it:
+- Install memsearch:
 
   ```bash
   uv tool install "memsearch[onnx]"
   ```
 
-  or let the plugin fall back to `uvx --from 'memsearch[onnx]' memsearch`
-  (auto-detected at load).
 - A DSH profile (web / headless / tui) you want to attach memory to.
 - Node >= 22.19 (DSH's requirement).
 
 ## Install
 
-From the repo root, install the plugin into a profile. `dsh plugin` is a pnpm
-forwarder: it links the directory into the profile, detects the `dsh.bundle`
-declaration in `package.json`, and appends the package to the profile's bundle
-layers. The `cordis.patch.yml` inside this directory then inserts the
-`memsearch` row into the profile's plugin tree.
+### From npm (recommended, once published)
+
+```bash
+dsh plugin --profile web add @zilliz/memsearch-dsh
+```
+
+### From source (development)
 
 ```bash
 dsh plugin --profile web add /path/to/memsearch/plugins/dsh
 ```
 
-> The path is resolved from the directory you run `dsh` in; an absolute path
-> is safest. Replace `web` with your profile name (`headless`, `tui`, ...).
+> `dsh plugin` is a pnpm forwarder: it links the package into the profile,
+> detects the `dsh.bundle` declaration in `package.json`, and appends it to
+> the profile's bundle layers. `cordis.patch.yml` inside the package then
+> inserts the `memsearch` row into the profile's plugin tree.
 >
-> Profiles are managed by the `@deepseek-ai/dsh-app-boot` profile store, and
-> the patch layer list lives in the profile manifest. The same flow works for
-> every shipped profile.
-
-Restart DSH for the profile (or start a new session) so the plugin mounts.
+> Replace `web` with your profile name (`headless`, `tui`, ...), and restart
+> DSH for the profile (or start a new session) so the plugin mounts.
 
 ### Manual patch insertion (no `dsh plugin`)
 

--- a/plugins/dsh/cordis.patch.yml
+++ b/plugins/dsh/cordis.patch.yml
@@ -10,15 +10,22 @@
     - id: memsearch
       name: 'memsearch-dsh'
       config:
-        # Optional overrides — see README.md for the full set:
-        #   captureEnabled (bool, default true)
-        #   injectEnabled (bool, default true)
-        #   summarizeEnabled (bool, default true)
-        #   summarizeProvider (string, default '')  -> name of an [llm.providers.*] entry
-        #   summarizeModel (string, default '')      -> model override for summarization
-        #   memsearchDir (string, default '')        -> override <project>/.memsearch
-        #   collection (string, default '')          -> override the Milvus collection name
-        #   milvusUri (string, default '')           -> point search/index at a dedicated Milvus
-        #                                               (uri or path) instead of memsearch's config
-        #   agentName (string, default 'DeepSeek Harness')
+        # Optional overrides — see README.md for the full set. Everything else
+        # (summarize provider/model, Milvus, collection, memory dir) comes from
+        # memsearch config / environment, mirroring the other platform plugins.
+        #   captureEnabled (bool, default true)   — capture completed turns
+        #   injectEnabled (bool, default true)    — inject relevant memory
+        #   summarizeEnabled (bool, default true) — summarize turns before writing
+        #   summarizeMode (string, default 'auto')
+        #       -> 'auto'         if [plugins.dsh.summarize] provider is set in
+        #                          memsearch config → custom-llm, else
+        #                          dsh-headless (zero-config)
+        #       -> 'dsh-headless' one-shot dsh headless agent; the model is the
+        #                          user's DSH default from settings.yaml
+        #                          `agent-default-model`. Missing CLI fails
+        #                          visibly (unavailable note), never a silent
+        #                          switch to another backend.
+        #       -> 'custom-llm'   reuse memsearch [llm.providers.*] (lightweight
+        #                          direct LLM call; provider/model from
+        #                          [plugins.dsh.summarize] in memsearch config)
         {}

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -3,12 +3,16 @@
  *
  * Gives DSH persistent, cross-agent memory on top of memsearch:
  *
- *   capture  — every completed turn is staged from the `session/event` stream
- *              and summarized with a memsearch-managed `[llm.providers.*]`
- *              provider, then appended to `<project>/.memsearch/memory/YYYY-MM-DD.md`
- *              alongside the other platform plugins (Claude Code, Codex,
- *              OpenClaw, OpenCode). The anchor format is identical, so DSH
- *              writes join the same shared memory store.
+ *   capture  — every completed turn from the `session/event` stream is
+ *              summarized (memsearch-managed `[llm.providers.*]` or a one-shot
+ *              DSH headless agent, see `summarizeMode`) and appended to
+ *              `<project>/.memsearch/memory/YYYY-MM-DD.md` alongside the other
+ *              platform plugins (Claude Code, Codex, OpenClaw, OpenCode). The
+ *              anchor format is identical, so DSH writes join the same shared
+ *              memory store. Processing is fire-and-forget: each turn is
+ *              summarized and written asynchronously, serialized so LLM calls
+ *              never overlap, with `captureExists` dedup so a turn is recorded
+ *              exactly once even across restarts.
  *   inject   — before the first model step of each turn, `agent/pre-step`
  *              runs a bounded memsearch search over the user's question and,
  *              only when relevant results exist, injects them plus a
@@ -47,7 +51,6 @@ export const inject = ['agents', 'skills', 'sessionPersistence']
 
 const DEFAULT_AGENT_NAME = 'DeepSeek Harness'
 const MEMSEARCH_MARKER = '[memsearch] Memory available.'
-const STAGING_FILE = '.dsh-capture.jsonl'
 const SEARCH_TOP_K = 5
 const SEARCH_TIMEOUT_MS = 15000
 const SUMMARIZE_TIMEOUT_MS = 30000
@@ -175,9 +178,73 @@ function deriveCollection(projectDir, override) {
   }
 }
 
+/**
+ * Read a dotted value from the memsearch config (e.g. `plugins.dsh.summarize.provider`).
+ *
+ * Tolerant of older memsearch installs that predate the `dsh` plugin section:
+ * a missing key, missing binary, or any failure returns `null` (treated as
+ * "not configured") instead of throwing — so the plugin never breaks on a
+ * user's existing memsearch version.
+ */
+function readMemsearchConfigValue(memsearchCmd, key) {
+  try {
+    // memsearchCmd may be a full command line (e.g. `uvx --from 'memsearch[onnx]' memsearch`),
+    // so route through bash rather than execFileSync's single executable.
+    const result = execFileSync('bash', ['-c', `${memsearchCmd} config get '${key}'`], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return result.trim() || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the effective summarization backend for `summarizeMode`.
+ *
+ * - explicit `custom-llm` / `dsh-headless` pin the backend;
+ * - unset (auto) mirrors the other platform plugins: if the user configured a
+ *   provider under `[plugins.dsh.summarize]` (memsearch config), use the
+ *   lightweight `custom-llm` route; otherwise fall back to `dsh-headless`
+ *   (zero-config DSH agent).
+ *
+ * Returns `{ mode, provider, model }` where provider/model carry the
+ * memsearch-config values when auto resolved them.
+ */
+function resolveSummarizeMode(memsearchCmd, opts, config) {
+  if (opts.summarizeMode === 'custom-llm' || opts.summarizeMode === 'dsh-headless') {
+    return {
+      mode: opts.summarizeMode,
+      provider: opts.summarizeProvider,
+      model: opts.summarizeModel,
+    }
+  }
+  // auto: consult memsearch config [plugins.dsh.summarize], aligned with the
+  // other platform plugins. Tolerate missing section / older memsearch.
+  const provider = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.provider')
+  if (provider) {
+    const model = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.model') || ''
+    const enabled = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.enabled')
+    if (enabled === null || enabled === 'true') {
+      return { mode: 'custom-llm', provider, model }
+    }
+  }
+  return { mode: 'dsh-headless', provider: opts.summarizeProvider, model: opts.summarizeModel }
+}
+
 /** Project directory for a session (its durable cwd) or the process cwd. */
 function projectDirFor(session) {
   return session?.header?.cwd || process.cwd()
+}
+
+/**
+ * Memory directory for a project. `MEMSEARCH_DIR` (explicit → global scope)
+ * wins, mirroring the other platform plugins; otherwise `<project>/.memsearch`.
+ */
+function memsearchDirFor(projectDir) {
+  return process.env.MEMSEARCH_DIR || join(projectDir, '.memsearch')
 }
 
 /** `[User]`/`[Assistant]` text from a message's content blocks. */
@@ -301,8 +368,8 @@ function sessionLogPath(ctx, session) {
 
 /**
  * Render one completed turn as `[User]`/`[Assistant]` text for the summarizer
- * and as the raw-transcript fallback. Returns null when the turn carries no
- * genuine user message.
+ * (and as the raw body when summarization is disabled). Returns null when the
+ * turn carries no genuine user message.
  */
 function renderTurn(session, turnEndEvent) {
   const turn = turnEndEvent.data.turn
@@ -372,11 +439,17 @@ function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
 }
 
 // ---------------------------------------------------------------------------
-// Summarization (memsearch-managed [llm.providers.*])
+// Summarization (two modes, selected by `summarizeMode`)
 // ---------------------------------------------------------------------------
 
-/** Summarize one rendered turn via scripts/summarize.py, reusing memsearch config. */
-function summarizeTurn(opts, render, projectDir) {
+/**
+ * Summarize one rendered turn via scripts/summarize.py — the memsearch-managed
+ * `[llm.providers.*]` route (the `custom-llm` mode). Lightweight: a single
+ * python process, no DSH boot. Model/provider come from memsearch config
+ * (`[plugins.dsh.summarize]` → `[llm.providers.*]`), resolved by
+ * `resolveSummarizeMode` into `opts.summarizeProvider` / `opts.summarizeModel`.
+ */
+function summarizeCustomLlm(opts, render, projectDir) {
   return new Promise((resolve, reject) => {
     const args = [
       join(PLUGIN_DIR, 'scripts', 'summarize.py'),
@@ -408,46 +481,125 @@ function summarizeTurn(opts, render, projectDir) {
   })
 }
 
-// ---------------------------------------------------------------------------
-// Staging + drain (durable capture queue)
-// ---------------------------------------------------------------------------
-
-function stageCapture(memsearchDir, record, logger) {
-  try {
-    mkdirSync(memsearchDir, { recursive: true })
-    appendFileSync(join(memsearchDir, STAGING_FILE), `${JSON.stringify(record)}\n`, 'utf-8')
-  } catch (error) {
-    logger?.warn?.(`[memsearch] failed to stage turn: ${error.message}`)
+/**
+ * Resolve the dsh CLI command for one-shot headless summarization.
+ *
+ * `dsh` may not be on PATH (it is a pnpm-installed workspace bin). We check
+ * PATH first, then `DSH_CLI` as an explicit override, then the pnpm global
+ * bin directory. Returns the command as an argv array (`[cmd, ...args]`),
+ * or null when not found. The array form is required because `DSH_CLI` may
+ * be an interpreter invocation (e.g. `node /path/to/bin.js`), which `spawn`
+ * cannot treat as a single executable.
+ */
+function detectDshCmd() {
+  const onPath = (cmd) => {
+    try {
+      execFileSync('bash', ['-c', `command -v ${cmd} >/dev/null 2>&1`], { stdio: 'pipe' })
+      return true
+    } catch {
+      return false
+    }
   }
+  if (onPath('dsh')) return ['dsh']
+  const fromEnv = process.env.DSH_CLI
+  if (fromEnv) return fromEnv.split(/\s+/).filter(Boolean)
+  const home = process.env.HOME || ''
+  const pnpmBin = join(home, '.local', 'share', 'pnpm')
+  if (existsSync(join(pnpmBin, 'dsh'))) return [join(pnpmBin, 'dsh')]
+  return null
 }
 
-function readStages(memsearchDir) {
-  const file = join(memsearchDir, STAGING_FILE)
-  if (!existsSync(file)) return []
-  let content
-  try {
-    content = readFileSync(file, 'utf-8')
-  } catch {
-    return []
-  }
-  return content
-    .split('\n')
-    .map((line) => {
-      try { return JSON.parse(line) } catch { return null }
+/**
+ * Summarize one rendered turn by booting a one-shot DSH headless agent
+ * (`dsh --profile headless`), mirroring how the Claude Code / Codex / OpenCode
+ * plugins reuse their own agent's headless mode with a small model.
+ *
+ * The headless profile is the same one the user already has; the plugin does
+ * not manage its bundles. The sub-agent's model is the deployment's
+ * `agent-default-model` — which the user layer of `~/.dsh/settings.yaml`
+ * (`agent-default-model:` section, the same selection the Web UI models
+ * settings writes) overrides with highest priority. A `--patch` overlay on
+ * `agent-default-model` sits below the user layer and is silently ignored
+ * when the user document sets the section, so this mode intentionally does
+ * NOT patch the model: the model is whatever the user configured in DSH
+ * (Web UI model picker → `settings.yaml`). The `[plugins.dsh.summarize]`
+ * provider/model therefore apply only to the `custom-llm` mode
+ * (see `summarizeCustomLlm`).
+ *
+ * Recursion guard: the sub-agent is booted with `MEMSEARCH_DSH_SUMMARIZE=1`.
+ * This plugin checks that flag in `apply()` and, when set, skips capture,
+ * injection, and skill registration — so the summarizer's own session never
+ * gets re-captured and re-summarized in an infinite loop.
+ */
+function summarizeHeadless(ctx, opts, render, projectDir) {
+  return new Promise((resolve, reject) => {
+    const dshCmd = detectDshCmd()
+    if (!dshCmd) {
+      reject(new Error('dsh CLI not found; set DSH_CLI or install dsh on PATH for summarizeMode=dsh-headless'))
+      return
+    }
+    const promptFile = join(PLUGIN_DIR, 'prompts', 'summarize.txt')
+    let systemPrompt
+    try {
+      systemPrompt = readFileSync(promptFile, 'utf-8').replaceAll('{{AGENT_NAME}}', opts.agentName)
+    } catch {
+      systemPrompt = `You are a third-person note-taker for {{AGENT_NAME}}. Record the following transcript as 2-10 bullet points in the same language as the [User] text. Output ONLY bullet points.`.replaceAll('{{AGENT_NAME}}', opts.agentName)
+    }
+    const task = `${systemPrompt}\n\nTranscript:\n${render}`
+
+    const args = ['--profile', 'headless', task]
+
+    const child = spawn(dshCmd[0], [...dshCmd.slice(1), ...args], {
+      cwd: projectDir,
+      env: { ...process.env, MEMSEARCH_DSH_SUMMARIZE: '1' },
     })
-    .filter(Boolean)
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (data) => { stdout += data })
+    child.stderr.on('data', (data) => { stderr += data })
+    child.on('error', (error) => {
+      reject(error)
+    })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim() || null)
+      } else {
+        reject(new Error(stderr.trim() || `dsh headless summarize exited with status ${code}`))
+      }
+    })
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* already exited */ }
+      reject(new Error('dsh headless summarization timed out'))
+    }, SUMMARIZE_TIMEOUT_MS)
+    timer.unref?.()
+  })
 }
 
-function removeStage(memsearchDir, key) {
-  const file = join(memsearchDir, STAGING_FILE)
-  try {
-    const remaining = readStages(memsearchDir).filter((record) => record.key !== key)
-    writeFileSync(
-      file,
-      remaining.length ? `${remaining.map((record) => JSON.stringify(record)).join('\n')}\n` : '',
-      'utf-8',
-    )
-  } catch { /* best effort; a leftover stage is replayed next boot */ }
+/**
+ * Run the configured summarizer for one turn.
+ *
+ * `opts.summarizeMode` is normally resolved by `apply()` via
+ * `resolveSummarizeMode` (auto → custom-llm when a `[plugins.dsh.summarize]`
+ * provider is configured, else dsh-headless). When called directly with an
+ * unset mode (tests, external callers), the same auto resolution is applied
+ * here. There is deliberately NO automatic fallback between modes: whichever
+ * backend is resolved either produces a summary or fails visibly (the caller
+ * writes the unavailable note) — a silent switch to an unconfigured LLM would
+ * be worse than an honest failure.
+ * @returns the summary text, or null when the summarizer produced nothing.
+ */
+async function summarizeTurn(ctx, opts, render, projectDir) {
+  let { summarizeMode, summarizeProvider, summarizeModel } = opts
+  if (summarizeMode !== 'custom-llm' && summarizeMode !== 'dsh-headless') {
+    const resolved = resolveSummarizeMode(detectMemsearchCmd(), opts, {})
+    summarizeMode = resolved.mode
+    summarizeProvider = resolved.provider || summarizeProvider
+    summarizeModel = resolved.model || summarizeModel
+  }
+  if (summarizeMode === 'custom-llm') {
+    return await summarizeCustomLlm({ ...opts, summarizeMode, summarizeProvider, summarizeModel }, render, projectDir)
+  }
+  return await summarizeHeadless(ctx, { ...opts, summarizeMode, summarizeProvider, summarizeModel }, render, projectDir)
 }
 
 // ---------------------------------------------------------------------------
@@ -497,35 +649,51 @@ function registerMemoryRecallSkill(ctx, opts, memsearchCmd, collection, projectD
  * @param config - resolved patch config (see cordis.patch.yml).
  */
 export function apply(ctx, config = {}) {
+  // Recursion guard: when DSH booted this plugin as the summarizer's own
+  // headless sub-agent (`summarizeMode: dsh-headless` sets this flag), stay
+  // inert — no capture, no injection, no skill. Otherwise the summarizer's
+  // session would itself be captured and re-summarized forever.
+  if (process.env.MEMSEARCH_DSH_SUMMARIZE === '1') {
+    ctx.logger?.debug?.('[memsearch] summarize sub-agent: plugin inert')
+    return
+  }
+
   const opts = {
     captureEnabled: config.captureEnabled !== false,
     injectEnabled: config.injectEnabled !== false,
     summarizeEnabled: config.summarizeEnabled !== false,
-    summarizeProvider: typeof config.summarizeProvider === 'string' ? config.summarizeProvider : '',
-    summarizeModel: typeof config.summarizeModel === 'string' ? config.summarizeModel : '',
-    memsearchDir: typeof config.memsearchDir === 'string' ? config.memsearchDir : '',
-    collection: typeof config.collection === 'string' ? config.collection : '',
-    milvusUri: typeof config.milvusUri === 'string' ? config.milvusUri : '',
-    agentName: typeof config.agentName === 'string' && config.agentName
-      ? config.agentName
-      : DEFAULT_AGENT_NAME,
+    summarizeMode: config.summarizeMode,
   }
 
   const memsearchCmd = detectMemsearchCmd()
+  // Resolve the effective summarize backend now: explicit summarizeMode wins;
+  // otherwise (auto) mirror the other plugins — a configured
+  // [plugins.dsh.summarize] provider selects custom-llm, else dsh-headless.
+  const resolvedSummarize = resolveSummarizeMode(memsearchCmd, opts, config)
+  opts.summarizeMode = resolvedSummarize.mode
+  if (resolvedSummarize.provider) opts.summarizeProvider = resolvedSummarize.provider
+  if (resolvedSummarize.model) opts.summarizeModel = resolvedSummarize.model
+  // Everything below comes from memsearch config / environment, mirroring the
+  // other platform plugins (no per-plugin config fields):
+  //   - memory dir:   MEMSEARCH_DIR env (explicit → global scope), else <project>/.memsearch
+  //   - collection:   derived from the project path (derive-collection.sh)
+  //   - milvus:       memsearch config [milvus] uri (CLI reads it; we only
+  //                   surface it for the skill's MILVUS_FLAG)
+  //   - agent name:   fixed display name
+  opts.agentName = DEFAULT_AGENT_NAME
+  opts.milvusUri = readMemsearchConfigValue(memsearchCmd, 'milvus.uri') || ''
+  const memoryDirFor = (projectDir) => join(memsearchDirFor(projectDir), 'memory')
+
   const collectionCache = new Map()
   const bootProjectDir = process.cwd()
-  const bootCollection = deriveCollection(bootProjectDir, opts.collection)
+  const bootCollection = deriveCollection(bootProjectDir, '')
 
   const resolveCollection = (projectDir) => {
     if (collectionCache.has(projectDir)) return collectionCache.get(projectDir)
-    const resolved = deriveCollection(projectDir, opts.collection)
+    const resolved = deriveCollection(projectDir, '')
     collectionCache.set(projectDir, resolved)
     return resolved
   }
-
-  const memsearchDirFor = (projectDir) =>
-    opts.memsearchDir || join(projectDir, '.memsearch')
-  const memoryDirFor = (projectDir) => join(memsearchDirFor(projectDir), 'memory')
 
   // --- Recall skill (always available) ---
   registerMemoryRecallSkill(ctx, opts, memsearchCmd, bootCollection, bootProjectDir)
@@ -563,45 +731,46 @@ export function apply(ctx, config = {}) {
     { prepend: true },
   )
 
-  // --- Capture: stage each completed turn, then summarize + write ---
-  let draining = false
-  const drain = async () => {
-    if (draining) return
-    draining = true
-    try {
-      for (;;) {
-        const stages = readStages(memsearchDirFor(bootProjectDir))
-        if (stages.length === 0) break
-        const record = stages[0]
-        if (!processStage(record)) break
-        removeStage(memsearchDirFor(bootProjectDir), record.key)
-      }
-    } catch (error) {
-      ctx.logger.warn(`[memsearch] capture drain failed: ${error.message}`)
-    } finally {
-      draining = false
-    }
+  // --- Capture: summarize + write each completed turn, fire-and-forget ---
+  // Each turn is processed against its *own* project directory (from
+  // `session.header.cwd`), which on a long-lived web surface is not
+  // necessarily `process.cwd()` — the boot directory. Turns are serialized
+  // through a promise chain so LLM summarize calls never overlap. The
+  // `captureExists` dedup makes a turn idempotent even if its event replays
+  // after a restart — nothing is lost in a queue, and nothing needs draining.
+  let captureChain = Promise.resolve()
+  const enqueueCapture = (work) => {
+    captureChain = captureChain
+      .then(work)
+      .catch((error) => ctx.logger.warn(`[memsearch] capture failed: ${error.message}`))
   }
 
-  const processStage = async (record) => {
-    const projectDir = record.projectDir || bootProjectDir
+  const processTurn = async (session, turnEndEvent) => {
+    const projectDir = projectDirFor(session)
+    const render = renderTurn(session, turnEndEvent)
+    if (!render) return
+    const sessionId = session.id
+    const turn = turnEndEvent.data.turn
+    const dbPath = sessionLogPath(ctx, session)
     const memoryDir = memoryDirFor(projectDir)
-    if (captureExists(memoryDir, record.sessionId, record.turn)) return true
+    if (captureExists(memoryDir, sessionId, turn)) return
 
-    let body = record.render
+    let body = render
     if (opts.summarizeEnabled) {
       try {
-        const summary = await summarizeTurn(opts, record.render, projectDir)
+        const summary = await summarizeTurn(ctx, opts, render, projectDir)
         if (summary) {
           body = summary
         } else {
-          ctx.logger.warn('[memsearch] summarizer returned empty output; wrote raw transcript fallback')
+          ctx.logger.warn('[memsearch] summarizer returned empty output; wrote unavailable note')
+          body = '- Memory summary unavailable: summarizer returned empty output. Use the transcript anchor for progressive disclosure.'
         }
       } catch (error) {
-        ctx.logger.warn(`[memsearch] summarization failed (${error.message}); wrote raw transcript fallback`)
+        ctx.logger.warn(`[memsearch] summarization failed (${error.message}); wrote unavailable note`)
+        body = `- Memory summary unavailable: ${error.message}; transcript content was omitted. Use the transcript anchor for progressive disclosure.`
       }
     }
-    writeCapture(memoryDir, body, record.sessionId, record.turn, record.dbPath)
+    writeCapture(memoryDir, body, sessionId, turn, dbPath)
     // Index right after the write so the memory is searchable by the next
     // session (or by this one's later turns) instead of waiting for a future
     // boot-time index. The index is idempotent via chunk_hash dedup.
@@ -609,36 +778,18 @@ export function apply(ctx, config = {}) {
     if (collection && hasMemoryFiles(memoryDir)) {
       indexMemory(ctx, memsearchCmd, memoryDir, collection, projectDir, opts.milvusUri)
     }
-    return true
   }
 
   if (opts.captureEnabled) {
     ctx.on('session/event', (session, event) => {
       if (event.type !== 'turn/end') return
       try {
-        const projectDir = projectDirFor(session)
-        const render = renderTurn(session, event)
-        if (!render) return
-        const sessionId = session.id
-        const turn = event.data.turn
-        const dbPath = sessionLogPath(ctx, session)
-        stageCapture(memsearchDirFor(projectDir), {
-          key: `${sessionId}:${turn}`,
-          sessionId,
-          turn,
-          render,
-          dbPath,
-          projectDir,
-        }, ctx.logger)
-        void drain()
+        enqueueCapture(() => processTurn(session, event))
       } catch (error) {
         ctx.logger.warn(`[memsearch] capture listener failed: ${error.message}`)
       }
     })
   }
-
-  // Replay any turns staged by a previous run that was interrupted mid-drain.
-  void drain()
 
   // Warm the index for this project once at startup (fire-and-forget).
   const bootMemoryDir = memoryDirFor(bootProjectDir)
@@ -646,3 +797,34 @@ export function apply(ctx, config = {}) {
     indexMemory(ctx, memsearchCmd, bootMemoryDir, bootCollection, bootProjectDir)
   }
 }
+
+// ---------------------------------------------------------------------------
+// Exports for tests / external use
+// ---------------------------------------------------------------------------
+
+/** Detect the dsh CLI command used by `summarizeMode: dsh-headless`. */
+export { detectDshCmd }
+
+/** One-shot DSH-headless summarizer (see README "dsh-headless" mode). */
+export { summarizeHeadless }
+
+/** Summarize one rendered turn with the configured backend. */
+export { summarizeTurn }
+
+/** Resolve the effective summarize backend (auto → config-driven). */
+export { resolveSummarizeMode }
+
+/** Read a dotted memsearch config value (tolerant of missing sections). */
+export { readMemsearchConfigValue }
+
+/** Render one turn's events into the shared transcript format. */
+export { renderTurn }
+
+/** True when a session/turn anchor already exists in the memory dir. */
+export { captureExists }
+
+/** Append a captured turn to the daily memory file (shared format). */
+export { writeCapture }
+
+/** Memory dir for a project (MEMSEARCH_DIR env override, else <project>/.memsearch). */
+export { memsearchDirFor }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -186,6 +186,13 @@ function deriveCollection(projectDir, override) {
  * "not configured") instead of throwing — so the plugin never breaks on a
  * user's existing memsearch version.
  */
+/**
+ * Read a dotted memsearch config value. Returns `{ ok, value }` so callers can
+ * tell "successfully read and the value is empty" from "the command failed or
+ * timed out". A failure must not be mistaken for an authoritative "not
+ * configured": a slow/absent memsearch (e.g. first uvx run) would otherwise
+ * silently flip auto mode to the wrong backend.
+ */
 function readMemsearchConfigValue(memsearchCmd, key) {
   try {
     // memsearchCmd may be a full command line (e.g. `uvx --from 'memsearch[onnx]' memsearch`),
@@ -195,9 +202,9 @@ function readMemsearchConfigValue(memsearchCmd, key) {
       timeout: 5000,
       stdio: ['ignore', 'pipe', 'ignore'],
     })
-    return result.trim() || null
+    return { ok: true, value: result.trim() || null }
   } catch {
-    return null
+    return { ok: false, value: null }
   }
 }
 
@@ -210,10 +217,15 @@ function readMemsearchConfigValue(memsearchCmd, key) {
  *   lightweight `custom-llm` route; otherwise fall back to `dsh-headless`
  *   (zero-config DSH agent).
  *
+ * A read failure of `[plugins.dsh.summarize]` is NOT treated as "not
+ * configured": it is logged (via `logger`) and falls back to `dsh-headless`
+ * rather than silently picking a backend the user may not have intended.
+ * An unknown explicit mode is also logged and treated as auto.
+ *
  * Returns `{ mode, provider, model }` where provider/model carry the
  * memsearch-config values when auto resolved them.
  */
-function resolveSummarizeMode(memsearchCmd, opts, config) {
+function resolveSummarizeMode(memsearchCmd, opts, config, logger) {
   if (opts.summarizeMode === 'custom-llm' || opts.summarizeMode === 'dsh-headless') {
     return {
       mode: opts.summarizeMode,
@@ -221,14 +233,23 @@ function resolveSummarizeMode(memsearchCmd, opts, config) {
       model: opts.summarizeModel,
     }
   }
+  if (opts.summarizeMode !== undefined && opts.summarizeMode !== 'auto') {
+    logger?.warn?.(`[memsearch] unknown summarizeMode '${opts.summarizeMode}'; treating as auto`)
+  }
   // auto: consult memsearch config [plugins.dsh.summarize], aligned with the
   // other platform plugins. Tolerate missing section / older memsearch.
   const provider = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.provider')
-  if (provider) {
-    const model = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.model') || ''
+  if (!provider.ok) {
+    logger?.warn?.(
+      '[memsearch] could not read [plugins.dsh.summarize] provider from memsearch config; using dsh-headless',
+    )
+    return { mode: 'dsh-headless', provider: opts.summarizeProvider, model: opts.summarizeModel }
+  }
+  if (provider.value) {
+    const model = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.model')
     const enabled = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.summarize.enabled')
-    if (enabled === null || enabled === 'true') {
-      return { mode: 'custom-llm', provider, model }
+    if (enabled.ok && (enabled.value === null || enabled.value === 'true')) {
+      return { mode: 'custom-llm', provider: provider.value, model: model.ok ? model.value || '' : '' }
     }
   }
   return { mode: 'dsh-headless', provider: opts.summarizeProvider, model: opts.summarizeModel }
@@ -591,7 +612,7 @@ function summarizeHeadless(ctx, opts, render, projectDir) {
 async function summarizeTurn(ctx, opts, render, projectDir) {
   let { summarizeMode, summarizeProvider, summarizeModel } = opts
   if (summarizeMode !== 'custom-llm' && summarizeMode !== 'dsh-headless') {
-    const resolved = resolveSummarizeMode(detectMemsearchCmd(), opts, {})
+    const resolved = resolveSummarizeMode(detectMemsearchCmd(), opts, {}, ctx.logger)
     summarizeMode = resolved.mode
     summarizeProvider = resolved.provider || summarizeProvider
     summarizeModel = resolved.model || summarizeModel
@@ -666,10 +687,20 @@ export function apply(ctx, config = {}) {
   }
 
   const memsearchCmd = detectMemsearchCmd()
+  // Legacy plugin-config fields were removed in favor of memsearch config /
+  // environment (aligned with the other platform plugins). A leftover field in
+  // the profile patch is now ignored; warn once so an upgrade is not silent.
+  const LEGACY_CONFIG_FIELDS = ['summarizeProvider', 'summarizeModel', 'memsearchDir', 'collection', 'milvusUri', 'agentName']
+  const legacyField = LEGACY_CONFIG_FIELDS.find((field) => config[field] !== undefined)
+  if (legacyField) {
+    ctx.logger.warn(
+      `[memsearch] config field '${legacyField}' is no longer used; provider/model/milvus/memory-dir now come from memsearch config (see README "Configuration")`,
+    )
+  }
   // Resolve the effective summarize backend now: explicit summarizeMode wins;
   // otherwise (auto) mirror the other plugins — a configured
   // [plugins.dsh.summarize] provider selects custom-llm, else dsh-headless.
-  const resolvedSummarize = resolveSummarizeMode(memsearchCmd, opts, config)
+  const resolvedSummarize = resolveSummarizeMode(memsearchCmd, opts, config, ctx.logger)
   opts.summarizeMode = resolvedSummarize.mode
   if (resolvedSummarize.provider) opts.summarizeProvider = resolvedSummarize.provider
   if (resolvedSummarize.model) opts.summarizeModel = resolvedSummarize.model
@@ -681,7 +712,7 @@ export function apply(ctx, config = {}) {
   //                   surface it for the skill's MILVUS_FLAG)
   //   - agent name:   fixed display name
   opts.agentName = DEFAULT_AGENT_NAME
-  opts.milvusUri = readMemsearchConfigValue(memsearchCmd, 'milvus.uri') || ''
+  opts.milvusUri = readMemsearchConfigValue(memsearchCmd, 'milvus.uri').value || ''
   const memoryDirFor = (projectDir) => join(memsearchDirFor(projectDir), 'memory')
 
   const collectionCache = new Map()
@@ -735,9 +766,8 @@ export function apply(ctx, config = {}) {
   // Each turn is processed against its *own* project directory (from
   // `session.header.cwd`), which on a long-lived web surface is not
   // necessarily `process.cwd()` — the boot directory. Turns are serialized
-  // through a promise chain so LLM summarize calls never overlap. The
-  // `captureExists` dedup makes a turn idempotent even if its event replays
-  // after a restart — nothing is lost in a queue, and nothing needs draining.
+  // through a promise chain so LLM summarize calls never overlap, and the
+  // `captureExists` dedup keeps a turn idempotent if its event replays.
   let captureChain = Promise.resolve()
   const enqueueCapture = (work) => {
     captureChain = captureChain
@@ -766,8 +796,11 @@ export function apply(ctx, config = {}) {
           body = '- Memory summary unavailable: summarizer returned empty output. Use the transcript anchor for progressive disclosure.'
         }
       } catch (error) {
-        ctx.logger.warn(`[memsearch] summarization failed (${error.message}); wrote unavailable note`)
-        body = `- Memory summary unavailable: ${error.message}; transcript content was omitted. Use the transcript anchor for progressive disclosure.`
+        // Collapse newlines so the reason stays a single `- ` bullet in the
+        // daily file (summarize.py stderr can span lines).
+        const reason = String(error.message).replace(/\s+/g, ' ').trim()
+        ctx.logger.warn(`[memsearch] summarization failed (${reason}); wrote unavailable note`)
+        body = `- Memory summary unavailable: ${reason}; transcript content was omitted. Use the transcript anchor for progressive disclosure.`
       }
     }
     writeCapture(memoryDir, body, sessionId, turn, dbPath)

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -27,6 +27,9 @@
     "cordis",
     "plugin"
   ],
+  "scripts": {
+    "test": "node --test tests/index.test.js"
+  },
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """DSH plugin summarizer: reuse memsearch's ``[llm.providers.*]`` config.
 
-The memsearch CLI exposes ``memsearch summarize --plugin <name>`` for the four
-built-in platforms, but ``plugins.dsh.*`` is not part of the core config
-schema, so this plugin ships its own thin summarizer that imports the same
-memsearch config + LLM plumbing directly:
+This is the ``custom-llm`` summarizer backend (``summarizeMode: custom-llm``):
+it imports the same memsearch config + LLM plumbing the four built-in
+platform plugins use via ``memsearch summarize --plugin <name>``:
 
     prompt + transcript  ->  resolve_config() -> compact.summarize_text()
 
@@ -12,9 +11,11 @@ Provider selection (most specific first):
 
 1. ``--provider <name>``  — the DSH plugin config's ``summarizeProvider``;
    looked up in ``[llm.providers.<name>]``. Missing entry is a visible error.
-2. ``cfg.llm.provider``   — when it names a configured provider or is a raw
+2. ``[plugins.dsh.summarize]`` — the memsearch-managed section aligned with the
+   other platform plugins (``[plugins.<platform>.summarize]``).
+3. ``cfg.llm.provider``   — when it names a configured provider or is a raw
    provider type (openai/anthropic/gemini).
-3. ``cfg.compact.llm_provider`` (deprecated fallback) or ``openai``.
+4. ``cfg.compact.llm_provider`` (deprecated fallback) or ``openai``.
 
 Failures exit non-zero with a message on stderr so the plugin can surface a
 visible error instead of silently writing nothing.
@@ -39,8 +40,14 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 
-def ensure_memsearch_importable() -> None:
-    """Make the memsearch Python API importable from any environment."""
+def ensure_memsearch_importable(transcript: str = "") -> None:
+    """Make the memsearch Python API importable from any environment.
+
+    May re-exec the process under a memsearch-enabled interpreter (uv run);
+    when it does, the transcript payload is carried over via
+    ``MEMSEARCH_DSH_TRANSCRIPT`` so the re-exec'd process still sees it even
+    though the original stdin pipe has been consumed.
+    """
     user_paths = [
         str(Path.home() / ".local" / "bin"),
         str(Path.home() / ".cargo" / "bin"),
@@ -71,6 +78,11 @@ def ensure_memsearch_importable() -> None:
     if os.environ.get("MEMSEARCH_DSH_UV_BOOTSTRAP") == "1":
         return
 
+    # Carry the already-consumed stdin payload across the re-exec below.
+    reexec_env = {**os.environ, "MEMSEARCH_DSH_UV_BOOTSTRAP": "1"}
+    if transcript:
+        reexec_env["MEMSEARCH_DSH_TRANSCRIPT"] = transcript
+
     memsearch_bin = _which("memsearch")
     if memsearch_bin:
         try:
@@ -81,7 +93,7 @@ def ensure_memsearch_importable() -> None:
                     os.execvpe(
                         python_bin,
                         [python_bin, str(Path(__file__).resolve()), *sys.argv[1:]],
-                        {**os.environ, "MEMSEARCH_DSH_UV_BOOTSTRAP": "1"},
+                        reexec_env,
                     )
         except (OSError, UnicodeDecodeError):
             pass
@@ -90,7 +102,6 @@ def ensure_memsearch_importable() -> None:
     if not uv:
         return
 
-    env = {**os.environ, "MEMSEARCH_DSH_UV_BOOTSTRAP": "1"}
     os.execvpe(
         uv,
         [
@@ -102,7 +113,7 @@ def ensure_memsearch_importable() -> None:
             str(Path(__file__).resolve()),
             *sys.argv[1:],
         ],
-        env,
+        reexec_env,
     )
 
 
@@ -155,27 +166,45 @@ def _resolve_llm_settings(config, provider_arg: str, model_arg: str) -> tuple[st
 
     Mirrors the plugin summarize resolution in ``cli.py`` while adding the
     compact-style fallback for when no ``[llm.providers.*]`` entry is named.
+
+    Resolution order (most specific first):
+    1. ``--provider`` / ``--model`` CLI args (the DSH plugin's own
+       ``summarizeProvider`` / ``summarizeModel`` config).
+    2. ``[plugins.dsh.summarize]`` — the memsearch-managed config that the
+       other four platform plugins (Claude Code, Codex, OpenCode, OpenClaw)
+       share; added so DSH aligns with the same single config surface.
+    3. ``[llm.providers.*]`` / ``llm.provider`` / ``compact.llm_provider``.
     """
     llm = getattr(config, "llm", None)
     compact = getattr(config, "compact", None)
 
-    def _named_provider(name: str) -> tuple[str, str | None, str | None, str | None]:
+    # 2. memsearch [plugins.dsh.summarize] — aligned with the other plugins.
+    plugins = getattr(config, "plugins", None)
+    dsh_cfg = getattr(plugins, "dsh", None) if plugins else None
+    dsh_summarize = getattr(dsh_cfg, "summarize", None) if dsh_cfg else None
+    dsh_provider = getattr(dsh_summarize, "provider", "") or ""
+    dsh_model = getattr(dsh_summarize, "model", "") or ""
+
+    def _named_provider(name: str, model_override: str = "") -> tuple[str, str | None, str | None, str | None]:
         providers = getattr(llm, "providers", {}) if llm else {}
         provider_cfg = providers.get(name)
         if provider_cfg is None:
             raise ValueError(f"Unknown LLM provider {name!r}. Configure [llm.providers.{name}] in memsearch config.")
         provider_type = provider_cfg.type or name
-        model = model_arg or provider_cfg.model or (getattr(llm, "model", "") or "")
+        model = model_override or provider_cfg.model or (getattr(llm, "model", "") or "")
         base_url = provider_cfg.base_url or getattr(llm, "base_url", "") or None
         api_key = provider_cfg.api_key or getattr(llm, "api_key", "") or None
         return provider_type, model or None, base_url, api_key
 
     if provider_arg:
-        return _named_provider(provider_arg)
+        return _named_provider(provider_arg, model_arg)
+
+    if dsh_provider:
+        return _named_provider(dsh_provider, dsh_model or model_arg)
 
     top_provider = getattr(llm, "provider", "") if llm else ""
     if top_provider and top_provider in (getattr(llm, "providers", {}) or {}):
-        return _named_provider(top_provider)
+        return _named_provider(top_provider, model_arg)
 
     if not top_provider:
         top_provider = getattr(compact, "llm_provider", "") if compact else ""
@@ -209,7 +238,13 @@ def main() -> int:
     parser.add_argument("--plugin-dir", default="", help="Plugin directory (prompt template location).")
     args = parser.parse_args()
 
-    transcript = sys.stdin.read()
+    # Read the transcript from stdin BEFORE any exec-based bootstrap: the uv
+    # re-exec below replaces the process image and the pipe would otherwise be
+    # consumed already. The re-exec'd process recovers the payload from
+    # MEMSEARCH_DSH_TRANSCRIPT (set by _preserve_transcript_for_reexec).
+    transcript = os.environ.get("MEMSEARCH_DSH_TRANSCRIPT", "")
+    if not transcript:
+        transcript = sys.stdin.read()
     if not transcript.strip():
         return 0
 
@@ -218,7 +253,7 @@ def main() -> int:
     if args.project_dir:
         os.chdir(args.project_dir)
 
-    ensure_memsearch_importable()
+    ensure_memsearch_importable(transcript)
 
     try:
         from memsearch.config import resolve_config

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -241,7 +241,7 @@ def main() -> int:
     # Read the transcript from stdin BEFORE any exec-based bootstrap: the uv
     # re-exec below replaces the process image and the pipe would otherwise be
     # consumed already. The re-exec'd process recovers the payload from
-    # MEMSEARCH_DSH_TRANSCRIPT (set by _preserve_transcript_for_reexec).
+    # MEMSEARCH_DSH_TRANSCRIPT (set by ensure_memsearch_importable).
     transcript = os.environ.get("MEMSEARCH_DSH_TRANSCRIPT", "")
     if not transcript:
         transcript = sys.stdin.read()

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -1,0 +1,558 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+
+import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor } from '../index.js'
+test('detectDshCmd: prefers dsh on PATH as a plain argv', () => {
+  // DSH_CLI is checked after PATH; simulate PATH hit by masking DSH_CLI.
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.DSH_CLI
+    process.env.PATH = '/usr/bin:/bin'
+    const cmd = detectDshCmd()
+    assert.ok(cmd === null || (Array.isArray(cmd) && cmd.length >= 1), `expected null or argv, got ${JSON.stringify(cmd)}`)
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('detectDshCmd: DSH_CLI interpreter invocation returns argv array', () => {
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.PATH
+    process.env.DSH_CLI = 'node /opt/dsh/bin.js'
+    const cmd = detectDshCmd()
+    assert.deepEqual(cmd, ['node', '/opt/dsh/bin.js'])
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('detectDshCmd: DSH_CLI with trailing spaces is trimmed', () => {
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.PATH
+    process.env.DSH_CLI = 'dsh   '
+    const cmd = detectDshCmd()
+    assert.deepEqual(cmd, ['dsh'])
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: explicit custom-llm mode dispatches to the LLM path', async () => {
+  // custom-llm mode spawns python3 summarize.py; without a real transcript we
+  // only assert it picks that branch (no crash before spawn).
+  const opts = { summarizeMode: 'custom-llm', agentName: 'X', summarizeProvider: '', summarizeModel: '' }
+  const ctx = { logger: { warn: () => {} } }
+  const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+  // If dispatch is wrong (e.g. treats anything not dsh-headless as dsh), this
+  // would reject with a dsh-CLI error instead of the custom-llm path error.
+  try {
+    await summarizeTurn(ctx, opts, render, process.cwd())
+    assert.fail('expected custom-llm summarizer to fail (no provider configured)')
+  } catch (error) {
+    // custom-llm path failure: summarize.py exits non-zero or times out, or
+    // python3 is missing — never a "dsh CLI not found" error.
+    assert.ok(
+      !/dsh CLI not found/.test(error.message),
+      `unexpected dsh CLI error: ${error.message}`,
+    )
+    assert.ok(
+      !/spawn .* ENOENT/.test(error.message),
+      `unexpected spawn ENOENT: ${error.message}`,
+    )
+  }
+})
+
+test('resolveSummarizeMode: explicit custom-llm pins the backend', () => {
+  const r = resolveSummarizeMode('unused-cmd', { summarizeMode: 'custom-llm', summarizeProvider: 'p', summarizeModel: 'm' }, {})
+  assert.deepEqual(r, { mode: 'custom-llm', provider: 'p', model: 'm' })
+})
+
+test('resolveSummarizeMode: explicit dsh-headless pins the backend', () => {
+  const r = resolveSummarizeMode('unused-cmd', { summarizeMode: 'dsh-headless', summarizeProvider: '', summarizeModel: '' }, {})
+  assert.equal(r.mode, 'dsh-headless')
+})
+
+test('resolveSummarizeMode: auto with unreachable memsearch falls back to dsh-headless', () => {
+  // A missing/broken memsearch must not throw: treat as "no [plugins.dsh.summarize]"
+  // and fall back to the zero-config dsh-headless backend.
+  const r = resolveSummarizeMode('definitely-not-a-real-cmd-xyz', { summarizeMode: undefined, summarizeProvider: '', summarizeModel: '' }, {})
+  assert.equal(r.mode, 'dsh-headless')
+})
+
+test('resolveSummarizeMode: auto with configured provider selects custom-llm', () => {
+  // Simulate `[plugins.dsh.summarize] provider = "x"` by pointing memsearchCmd
+  // at a shim that echoes the requested key.
+  const prevPath = process.env.PATH
+  const tmp = os.tmpdir()
+  const shimBin = `${tmp}/memsearch-config-shim-${process.pid}`
+  fs.mkdirSync(shimBin, { recursive: true })
+  const shim = `${shimBin}/memsearch`
+  fs.writeFileSync(
+    shim,
+    `#!/bin/sh\ncase "$3" in\n  plugins.dsh.summarize.provider) echo "deepseek-zilliz" ;;\n  plugins.dsh.summarize.model) echo "deepseek-v4-flash" ;;\n  plugins.dsh.summarize.enabled) echo "true" ;;\nesac\n`,
+    'utf-8',
+  )
+  fs.chmodSync(shim, 0o755)
+  try {
+    process.env.PATH = `${shimBin}:${prevPath}`
+    const r = resolveSummarizeMode('memsearch', { summarizeMode: undefined, summarizeProvider: '', summarizeModel: '' }, {})
+    assert.equal(r.mode, 'custom-llm')
+    assert.equal(r.provider, 'deepseek-zilliz')
+    assert.equal(r.model, 'deepseek-v4-flash')
+  } finally {
+    fs.rmSync(shimBin, { recursive: true, force: true })
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: default (no mode configured) dispatches to dsh-headless', async () => {
+  // The default is dsh-headless: an omitted summarizeMode must boot the dsh
+  // agent, so without a CLI it errors with "dsh CLI not found".
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.DSH_CLI
+    process.env.PATH = '/nonexistent'
+    const opts = { agentName: 'X', summarizeProvider: '', summarizeModel: '' } // no summarizeMode
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    await assert.rejects(
+      summarizeTurn(ctx, opts, render, process.cwd()),
+      /dsh CLI not found/,
+    )
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: dsh-headless mode without CLI errors visibly', async () => {
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.DSH_CLI
+    process.env.PATH = '/nonexistent'
+    const opts = { summarizeMode: 'dsh-headless', agentName: 'X', summarizeProvider: '', summarizeModel: '' }
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    await assert.rejects(
+      summarizeTurn(ctx, opts, render, process.cwd()),
+      /dsh CLI not found/,
+    )
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: custom-llm forwards --provider/--model to summarize.py', async () => {
+  // Point a fake `python3` (argv recorder) at the front of PATH so the spawn
+  // inside summarizeCustomLlm hits it; assert the provider/model options from
+  // plugin config reach summarize.py as CLI args.
+  const prevPath = process.env.PATH
+  const tmp = await import('node:os').then((os) => os.tmpdir())
+  const fs = await import('node:fs')
+  const fakeBin = `${tmp}/memsearch-py3bin-${process.pid}`
+  const argvFile = `${tmp}/memsearch-py3argv-${process.pid}.txt`
+  fs.mkdirSync(fakeBin, { recursive: true })
+  fs.writeFileSync(
+    `${fakeBin}/python3`,
+    `#!/bin/sh\nprintf "%s\\n" "$@" > "${argvFile}"\ncat > /dev/null\nexit 0\n`,
+    'utf-8',
+  )
+  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  try {
+    process.env.PATH = `${fakeBin}:${prevPath}`
+    const opts = {
+      summarizeMode: 'custom-llm',
+      agentName: 'AgentX',
+      summarizeProvider: 'deepseek-zilliz',
+      summarizeModel: 'deepseek-v4-pro',
+    }
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    const summary = await summarizeTurn(ctx, opts, render, process.cwd())
+    assert.equal(summary, null, 'recorder exits 0 with no stdout -> null summary')
+    const recorded = fs.readFileSync(argvFile, 'utf-8').trim().split('\n')
+    assert.ok(recorded[0].endsWith('scripts/summarize.py'), `first arg = summarize.py, got: ${recorded[0]}`)
+    const joined = recorded.join(' ')
+    assert.ok(joined.includes('--provider deepseek-zilliz'), `--provider forwarded: ${joined}`)
+    assert.ok(joined.includes('--model deepseek-v4-pro'), `--model forwarded: ${joined}`)
+    assert.ok(joined.includes('--agent-name AgentX'), `--agent-name forwarded: ${joined}`)
+  } finally {
+    try { fs.rmSync(fakeBin, { recursive: true, force: true }) } catch { /* cleanup */ }
+    try { fs.unlinkSync(argvFile) } catch { /* cleanup */ }
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: custom-llm surfaces summarize.py stderr as a visible error', async () => {
+  // A failing summarize.py must reject with its stderr message (visible), not
+  // silently resolve null/empty — so the caller writes the unavailable note
+  // with the real reason.
+  const prevPath = process.env.PATH
+  const tmp = await import('node:os').then((os) => os.tmpdir())
+  const fs = await import('node:fs')
+  const fakeBin = `${tmp}/memsearch-py3fail-${process.pid}`
+  fs.mkdirSync(fakeBin, { recursive: true })
+  fs.writeFileSync(
+    `${fakeBin}/python3`,
+    '#!/bin/sh\necho "provider deepseek-zilliz not found in config" >&2\ncat > /dev/null\nexit 3\n',
+    'utf-8',
+  )
+  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  try {
+    process.env.PATH = `${fakeBin}:${prevPath}`
+    const opts = {
+      summarizeMode: 'custom-llm',
+      agentName: 'X',
+      summarizeProvider: 'deepseek-zilliz',
+      summarizeModel: '',
+    }
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    await assert.rejects(
+      summarizeTurn(ctx, opts, render, process.cwd()),
+      /provider deepseek-zilliz not found in config/,
+    )
+  } finally {
+    try { fs.rmSync(fakeBin, { recursive: true, force: true }) } catch { /* cleanup */ }
+    process.env.PATH = prevPath
+  }
+})
+
+test('detectDshCmd: falls back to pnpm global bin directory', async () => {
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
+  const tmp = await import('node:os').then((os) => os.tmpdir())
+  const fs = await import('node:fs')
+  const fakeHome = `${tmp}/memsearch-home-${process.pid}`
+  fs.mkdirSync(`${fakeHome}/.local/share/pnpm`, { recursive: true })
+  fs.writeFileSync(`${fakeHome}/.local/share/pnpm/dsh`, '#!/bin/sh\nexit 0\n', 'utf-8')
+  fs.chmodSync(`${fakeHome}/.local/share/pnpm/dsh`, 0o755)
+  try {
+    delete process.env.DSH_CLI
+    delete process.env.PATH
+    process.env.HOME = fakeHome
+    const cmd = detectDshCmd()
+    assert.deepEqual(cmd, [`${fakeHome}/.local/share/pnpm/dsh`])
+  } finally {
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }) } catch { /* cleanup */ }
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    if (prevPath === undefined) delete process.env.PATH
+    else process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+  }
+})
+
+test('apply: captureEnabled:false skips session/event capture listener', () => {
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  apply(ctx, { captureEnabled: false })
+  assert.ok(!listeners['session/event'], 'must not register capture when disabled')
+})
+
+test('apply: summarizeEnabled:false writes the raw transcript (no summarizer)', async () => {
+  const tmp = os.tmpdir()
+  const projDir = `${tmp}/memsearch-raw-${process.pid}`
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  apply(ctx, { summarizeEnabled: false })
+  const session = {
+    id: 'session-raw-test',
+    header: { cwd: projDir },
+    events: [
+      { type: 'turn/start', data: { turn: 1 } },
+      { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'remember raw-marker-001' }] } },
+      { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'ok' }] } } },
+      { type: 'turn/end', data: { turn: 1 } },
+    ],
+  }
+  try {
+    // session/event fires with (session, event); capture drains asynchronously.
+    await listeners['session/event'](session, { type: 'turn/end', data: { turn: 1 } })
+    // captureChain runs async; wait a beat for the write to land.
+    await new Promise((r) => setTimeout(r, 300))
+    const memoryDir = `${projDir}/.memsearch/memory`
+    const files = fs.readdirSync(memoryDir)
+    assert.equal(files.length, 1, 'one daily file written')
+    const content = fs.readFileSync(`${memoryDir}/${files[0]}`, 'utf-8')
+    assert.ok(content.includes('raw-marker-001'), 'raw transcript written when summarize disabled')
+    assert.ok(content.includes('<!-- session:session-raw-test turn:1 '), 'anchor present')
+  } finally {
+    fs.rmSync(projDir, { recursive: true, force: true })
+  }
+})
+
+test('apply: summarize failure writes unavailable note (not raw)', async () => {
+  const tmp = os.tmpdir()
+  const projDir = `${tmp}/memsearch-fail-${process.pid}`
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  // Default summarizeEnabled:true + auto resolves headless with no CLI → error
+  // path in processTurn → unavailable note.
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.DSH_CLI
+    process.env.PATH = '/nonexistent'
+    apply(ctx, {})
+    const session = {
+      id: 'session-fail-test',
+      header: { cwd: projDir },
+      events: [
+        { type: 'turn/start', data: { turn: 1 } },
+        { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'secret raw content that must not leak' }] } },
+        { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'ok' }] } } },
+        { type: 'turn/end', data: { turn: 1 } },
+      ],
+    }
+    await listeners['session/event'](session, { type: 'turn/end', data: { turn: 1 } })
+    await new Promise((r) => setTimeout(r, 500))
+    const memoryDir = `${projDir}/.memsearch/memory`
+    const files = fs.readdirSync(memoryDir)
+    const content = fs.readFileSync(`${memoryDir}/${files[0]}`, 'utf-8')
+    assert.ok(content.includes('Memory summary unavailable'), 'unavailable note written on failure')
+    assert.ok(!content.includes('secret raw content'), 'raw content must NOT be written')
+    assert.ok(content.includes('<!-- session:session-fail-test turn:1 '), 'anchor preserved')
+  } finally {
+    fs.rmSync(projDir, { recursive: true, force: true })
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('apply: multi-project capture writes to each project memory dir', async () => {
+  const tmp = os.tmpdir()
+  const projA = `${tmp}/memsearch-projA-${process.pid}`
+  const projB = `${tmp}/memsearch-projB-${process.pid}`
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    delete process.env.DSH_CLI
+    process.env.PATH = '/nonexistent'
+    apply(ctx, { summarizeEnabled: false }) // raw writes, no CLI needed
+    const mkSession = (id, cwd, marker) => ({
+      id,
+      header: { cwd },
+      events: [
+        { type: 'turn/start', data: { turn: 1 } },
+        { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: marker }] } },
+        { type: 'turn/end', data: { turn: 1 } },
+      ],
+    })
+    await listeners['session/event'](mkSession('session-a', projA, 'marker-proj-a'), { type: 'turn/end', data: { turn: 1 } })
+    await listeners['session/event'](mkSession('session-b', projB, 'marker-proj-b'), { type: 'turn/end', data: { turn: 1 } })
+    await new Promise((r) => setTimeout(r, 400))
+    const filesA = fs.readdirSync(`${projA}/.memsearch/memory`)
+    const filesB = fs.readdirSync(`${projB}/.memsearch/memory`)
+    assert.equal(filesA.length, 1, 'project A memory written')
+    assert.equal(filesB.length, 1, 'project B memory written')
+    const contentA = fs.readFileSync(`${projA}/.memsearch/memory/${filesA[0]}`, 'utf-8')
+    const contentB = fs.readFileSync(`${projB}/.memsearch/memory/${filesB[0]}`, 'utf-8')
+    assert.ok(contentA.includes('marker-proj-a'), 'A contains its own marker')
+    assert.ok(contentB.includes('marker-proj-b'), 'B contains its own marker')
+    assert.ok(!contentA.includes('marker-proj-b'), 'A does not leak B')
+  } finally {
+    fs.rmSync(projA, { recursive: true, force: true })
+    fs.rmSync(projB, { recursive: true, force: true })
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('apply: MEMSEARCH_DSH_SUMMARIZE=1 makes the plugin inert', () => {
+  const prev = process.env.MEMSEARCH_DSH_SUMMARIZE
+  const listeners = {}
+  try {
+    process.env.MEMSEARCH_DSH_SUMMARIZE = '1'
+    const ctx = {
+      logger: { warn: () => {}, debug: () => {} },
+      skills: { register: () => {} },
+      on: (name, fn) => { listeners[name] = fn },
+    }
+    apply(ctx, {})
+    assert.deepEqual(listeners, {}, 'summarize sub-agent must register nothing')
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
+    else process.env.MEMSEARCH_DSH_SUMMARIZE = prev
+  }
+})
+
+test('apply: custom-llm config is honored in summarizeMode', async () => {
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  apply(ctx, { summarizeMode: 'custom-llm', summarizeProvider: 'p', summarizeModel: 'm' })
+  assert.ok(listeners['session/event'], 'capture listener registered by default')
+  assert.ok(listeners['agent/pre-step'], 'injection listener registered by default')
+})
+
+test('summarizeHeadless: does not build a --patch overlay for the model', async () => {
+  // The DSH settings user layer (`agent-default-model` in ~/.dsh/settings.yaml)
+  // outranks any `--patch` overlay, so headless summarize must NOT emit one:
+  // a real dsh boot here should not carry a memsearch-generated overlay file.
+  // We point DSH_CLI at a recorder script that writes its argv to a file, then
+  // assert the recorded args contain no `--patch` (and no temp overlay path).
+  const prevCli = process.env.DSH_CLI
+  const prevDshSummarize = process.env.MEMSEARCH_DSH_SUMMARIZE
+  const tmp = await import('node:os').then((os) => os.tmpdir())
+  const fs = await import('node:fs')
+  const recorder = `${tmp}/memsearch-dsh-argv-recorder-${process.pid}.sh`
+  fs.writeFileSync(
+    recorder,
+    '#!/bin/sh\nprintf "%s\\n" "$@" > "${MEMSEARCH_ARGV_FILE}"\nexit 0\n',
+    'utf-8',
+  )
+  fs.chmodSync(recorder, 0o755)
+  const argvFile = `${tmp}/memsearch-dsh-argv-${process.pid}.txt`
+  try {
+    process.env.DSH_CLI = `sh ${recorder}`
+    process.env.MEMSEARCH_ARGV_FILE = argvFile
+    const opts = {
+      summarizeMode: 'dsh-headless',
+      agentName: 'X',
+      summarizeProvider: 'deepseek-zilliz',
+      summarizeModel: 'deepseek-v4-pro',
+    }
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    const summary = await summarizeTurn(ctx, opts, render, process.cwd())
+    assert.equal(summary, null, 'recorder exits 0 with no stdout -> null summary')
+    const recorded = fs.readFileSync(argvFile, 'utf-8').trim().split('\n')
+    assert.ok(
+      !recorded.includes('--patch'),
+      `headless summarize must not pass --patch; got argv: ${JSON.stringify(recorded)}`,
+    )
+    assert.ok(
+      !recorded.some((arg) => arg.includes('memsearch-dsh-summarize-')),
+      `headless summarize must not reference an overlay file; got argv: ${JSON.stringify(recorded)}`,
+    )
+  } finally {
+    try { fs.unlinkSync(recorder) } catch { /* cleanup */ }
+    try { fs.unlinkSync(argvFile) } catch { /* cleanup */ }
+    delete process.env.MEMSEARCH_ARGV_FILE
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    if (prevDshSummarize === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
+    else process.env.MEMSEARCH_DSH_SUMMARIZE = prevDshSummarize
+  }
+})
+
+test('renderTurn: renders user/assistant/tool events into the shared format', () => {
+  const session = {
+    events: [
+      { type: 'turn/start', data: { turn: 7 } },
+      { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'hello there' }] } },
+      { type: 'tool/call', data: { name: 'bash' } },
+      { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'hi back' }] } } },
+      { type: 'turn/end', data: { turn: 7 } },
+    ],
+  }
+  const render = renderTurn(session, { data: { turn: 7 } })
+  assert.ok(render.includes('=== Turn 7 ==='), 'turn header')
+  assert.ok(render.includes('[User]: hello there'), 'user line')
+  assert.ok(render.includes('[Assistant]: hi back'), 'assistant line')
+  assert.ok(render.includes('[Tool call]: bash'), 'tool line')
+})
+
+test('renderTurn: returns null when no user message', () => {
+  const session = {
+    events: [
+      { type: 'turn/start', data: { turn: 1 } },
+      { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'only assistant' }] } } },
+      { type: 'turn/end', data: { turn: 1 } },
+    ],
+  }
+  assert.equal(renderTurn(session, { data: { turn: 1 } }), null)
+})
+
+test('writeCapture + captureExists: writes shared format and dedups', () => {
+  const tmp = os.tmpdir()
+  const dir = `${tmp}/memsearch-capture-${process.pid}`
+  const memoryDir = `${dir}/memory`
+  try {
+    writeCapture(memoryDir, '- a note', 'session-abc', 3, '/path/db.jsonl')
+    const files = fs.readdirSync(memoryDir)
+    assert.equal(files.length, 1, 'one daily file')
+    const content = fs.readFileSync(`${memoryDir}/${files[0]}`, 'utf-8')
+    assert.ok(content.includes('<!-- session:session-abc turn:3 db:/path/db.jsonl -->'), 'anchor format')
+    assert.ok(content.includes('- a note'), 'body present')
+    // dedup: same turn already captured
+    assert.equal(captureExists(memoryDir, 'session-abc', 3), true)
+    assert.equal(captureExists(memoryDir, 'session-abc', 4), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('memsearchDirFor: MEMSEARCH_DIR env wins (global scope)', () => {
+  const prev = process.env.MEMSEARCH_DIR
+  try {
+    process.env.MEMSEARCH_DIR = '/global/memsearch'
+    assert.equal(memsearchDirFor('/proj/x'), '/global/memsearch')
+    delete process.env.MEMSEARCH_DIR
+    assert.equal(memsearchDirFor('/proj/x'), '/proj/x/.memsearch')
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})
+
+test('apply: injectEnabled:false makes pre-step injection a no-op', async () => {
+  // The listener is always registered; the flag short-circuits inside it so a
+  // disabled plugin still forwards the decision unchanged (never injects).
+  const listeners = {}
+  const ctx = {
+    logger: { warn: () => {}, debug: () => {} },
+    skills: { register: () => {} },
+    on: (name, fn) => { listeners[name] = fn },
+  }
+  apply(ctx, { injectEnabled: false })
+  assert.ok(listeners['agent/pre-step'], 'listener registered')
+  const decision = { kind: 'enter', messages: [{ role: 'user', content: 'remember marker' }] }
+  const result = await listeners['agent/pre-step']({ agent: {}, turn: 1, step: 1, signal: {} }, async () => decision)
+  assert.equal(result, decision, 'decision forwarded unchanged when injection disabled')
+  assert.equal(result.messages.length, 1, 'no memory message injected')
+})

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -92,6 +92,26 @@ test('resolveSummarizeMode: auto with unreachable memsearch falls back to dsh-he
   assert.equal(r.mode, 'dsh-headless')
 })
 
+test('resolveSummarizeMode: read failure logs a warning (not silent)', () => {
+  // M3: a config-read failure must be surfaced, not silently treated as
+  // "not configured" — otherwise a slow/absent memsearch flips auto to the
+  // wrong backend with no signal.
+  const warnings = []
+  const logger = { warn: (m) => warnings.push(m) }
+  const r = resolveSummarizeMode('definitely-not-a-real-cmd-xyz', { summarizeMode: undefined, summarizeProvider: '', summarizeModel: '' }, {}, logger)
+  assert.equal(r.mode, 'dsh-headless')
+  assert.ok(warnings.length >= 1, 'a warning was logged')
+  assert.ok(warnings[0].includes('could not read'), `warning mentions the read failure: ${warnings[0]}`)
+})
+
+test('resolveSummarizeMode: unknown explicit mode logs a warning and treats as auto', () => {
+  const warnings = []
+  const logger = { warn: (m) => warnings.push(m) }
+  const r = resolveSummarizeMode('unused-cmd', { summarizeMode: 'custom-lm', summarizeProvider: '', summarizeModel: '' }, {}, logger)
+  assert.equal(r.mode, 'dsh-headless') // treated as auto with no provider configured
+  assert.ok(warnings.some((w) => w.includes('unknown summarizeMode')), `unknown-mode warning logged: ${warnings}`)
+})
+
 test('resolveSummarizeMode: auto with configured provider selects custom-llm', () => {
   // Simulate `[plugins.dsh.summarize] provider = "x"` by pointing memsearchCmd
   // at a shim that echoes the requested key.
@@ -123,9 +143,11 @@ test('summarizeTurn: default (no mode configured) dispatches to dsh-headless', a
   // agent, so without a CLI it errors with "dsh CLI not found".
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
   try {
     delete process.env.DSH_CLI
     process.env.PATH = '/nonexistent'
+    process.env.HOME = '/nonexistent-home' // mask pnpm-global dsh fallback
     const opts = { agentName: 'X', summarizeProvider: '', summarizeModel: '' } // no summarizeMode
     const ctx = { logger: { warn: () => {} } }
     const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
@@ -137,15 +159,19 @@ test('summarizeTurn: default (no mode configured) dispatches to dsh-headless', a
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
     process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
   }
 })
 
 test('summarizeTurn: dsh-headless mode without CLI errors visibly', async () => {
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
   try {
     delete process.env.DSH_CLI
     process.env.PATH = '/nonexistent'
+    process.env.HOME = '/nonexistent-home' // mask pnpm-global dsh fallback
     const opts = { summarizeMode: 'dsh-headless', agentName: 'X', summarizeProvider: '', summarizeModel: '' }
     const ctx = { logger: { warn: () => {} } }
     const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
@@ -157,6 +183,8 @@ test('summarizeTurn: dsh-headless mode without CLI errors visibly', async () => 
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
     process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
   }
 })
 
@@ -323,9 +351,11 @@ test('apply: summarize failure writes unavailable note (not raw)', async () => {
   // path in processTurn → unavailable note.
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
   try {
     delete process.env.DSH_CLI
     process.env.PATH = '/nonexistent'
+    process.env.HOME = '/nonexistent-home' // mask pnpm-global dsh fallback (would boot a real agent)
     apply(ctx, {})
     const session = {
       id: 'session-fail-test',
@@ -350,6 +380,8 @@ test('apply: summarize failure writes unavailable note (not raw)', async () => {
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
     process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
   }
 })
 

--- a/plugins/dsh/tests/test_summarize.py
+++ b/plugins/dsh/tests/test_summarize.py
@@ -30,7 +30,10 @@ def make_config(**overrides) -> SimpleNamespace:
     llm = SimpleNamespace(provider="", model="", base_url="", api_key="", providers=providers)
     compact = SimpleNamespace(llm_provider="", llm_model="", base_url="", api_key="")
     prompts = SimpleNamespace(summarize="")
-    config = SimpleNamespace(llm=llm, compact=compact, prompts=prompts)
+    plugins = SimpleNamespace(
+        dsh=SimpleNamespace(summarize=SimpleNamespace(enabled=True, provider="", model=""))
+    )
+    config = SimpleNamespace(llm=llm, compact=compact, prompts=prompts, plugins=plugins)
     return config
 
 
@@ -85,6 +88,69 @@ class TestResolveLlmSettings:
         provider_type, model, _, _ = summarize._resolve_llm_settings(config, "", "")
         assert provider_type == "anthropic"
         assert model == "claude-sonnet-4-6"
+
+    def test_plugins_dsh_summarize_provider(self) -> None:
+        """[plugins.dsh.summarize] provider is used when no CLI arg is passed."""
+        config = make_config()
+        config.plugins.dsh.summarize.provider = "deepseek"
+        provider_type, model, base_url, api_key = summarize._resolve_llm_settings(config, "", "")
+        assert provider_type == "openai"
+        assert model == "deepseek-chat"
+        assert base_url == "https://api.deepseek.com"
+        assert api_key == "env:DSK"
+
+    def test_plugins_dsh_summarize_model_override(self) -> None:
+        """[plugins.dsh.summarize] model wins over the provider's default."""
+        config = make_config()
+        config.plugins.dsh.summarize.provider = "deepseek"
+        config.plugins.dsh.summarize.model = "deepseek-v4-flash"
+        _, model, _, _ = summarize._resolve_llm_settings(config, "", "")
+        assert model == "deepseek-v4-flash"
+
+    def test_cli_arg_beats_plugins_dsh_config(self) -> None:
+        """The DSH plugin's own --provider/--model (from plugin config) wins."""
+        config = make_config()
+        config.plugins.dsh.summarize.provider = "deepseek"
+        provider_type, model, _, _ = summarize._resolve_llm_settings(config, "local-anthropic", "my-model")
+        assert provider_type == "anthropic"
+        assert model == "my-model"
+
+
+class TestMainTranscriptRecovery:
+    """The uv re-exec must not lose the stdin payload.
+
+    ``ensure_memsearch_importable`` re-execs under ``uv run`` when uv is on
+    PATH; the re-exec'd process can no longer read the consumed stdin pipe, so
+    ``main()`` prefers ``MEMSEARCH_DSH_TRANSCRIPT`` (carried across the exec)
+    over a fresh stdin read. With the env payload present, main() must proceed
+    to summarization (not bail out on the empty stdin).
+    """
+
+    def test_main_uses_env_transcript_when_stdin_is_empty(self, monkeypatch, capsys) -> None:
+        marker = "env-transcript-marker-001"
+        monkeypatch.setenv("MEMSEARCH_DSH_TRANSCRIPT", f"=== Turn 1 ===\n[User]: remember {marker}\n[Assistant]: ok")
+        monkeypatch.setattr("sys.stdin.read", lambda: "")
+        # main() parses sys.argv; in pytest that is the pytest invocation, so
+        # replace it with the summarize.py CLI shape.
+        monkeypatch.setattr("sys.argv", ["summarize.py", "--agent-name", "Test"])
+
+        seen = {}
+
+        async def fake_summarize(prompt, provider_type, model, base_url, api_key):
+            seen["prompt"] = prompt
+            return "- remembered"
+
+        monkeypatch.setattr(summarize, "_summarize", fake_summarize)
+        monkeypatch.setattr(summarize, "_load_summarize_prompt", lambda *a, **k: "SYSTEM")
+        monkeypatch.setattr(summarize, "ensure_memsearch_importable", lambda transcript="": None)
+        # Point the local `from memsearch.config import resolve_config` at a stub.
+        monkeypatch.setattr("memsearch.config.resolve_config", lambda: make_config(), raising=False)
+
+        rc = summarize.main()
+        assert rc == 0
+        assert "env-transcript-marker-001" in seen.get("prompt", "")
+        out = capsys.readouterr().out
+        assert "- remembered" in out
 
 
 class TestLoadSummarizePrompt:

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -203,6 +203,7 @@ class PluginsConfig:
     codex: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
     opencode: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
     openclaw: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
+    dsh: PluginPlatformConfig = field(default_factory=PluginPlatformConfig)
 
 
 @dataclass
@@ -239,12 +240,14 @@ _PLUGIN_KEY_TO_FIELD = {
     "codex": "codex",
     "opencode": "opencode",
     "openclaw": "openclaw",
+    "dsh": "dsh",
 }
 _PLUGIN_FIELD_TO_KEY = {
     "claude_code": "claude-code",
     "codex": "codex",
     "opencode": "opencode",
     "openclaw": "openclaw",
+    "dsh": "dsh",
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,8 @@ def test_default_config():
     assert cfg.plugins.codex.project_review.input_dir == ".memsearch/memory"
     assert cfg.plugins.codex.project_review.output_file == ".memsearch/PROJECT.md"
     assert cfg.plugins.codex.user_profile.output_file == ".memsearch/USER.md"
+    assert cfg.plugins.dsh.summarize.provider == ""
+    assert cfg.plugins.dsh.summarize.model == ""
 
 
 def test_load_toml_file(tmp_path: Path):
@@ -254,12 +256,14 @@ def test_plugin_summarize_model_config_roundtrip(tmp_path: Path, monkeypatch: py
     set_config_value("plugins.codex.summarize.model", "gpt-5.1-codex-mini")
     set_config_value("plugins.opencode.summarize.model", "anthropic/claude-haiku")
     set_config_value("plugins.openclaw.summarize.model", "qwen3-coder")
+    set_config_value("plugins.dsh.summarize.model", "deepseek-v4-flash")
 
     cfg = resolve_config()
     assert cfg.plugins.claude_code.summarize.model == "claude-haiku-4-5"
     assert cfg.plugins.codex.summarize.model == "gpt-5.1-codex-mini"
     assert cfg.plugins.opencode.summarize.model == "anthropic/claude-haiku"
     assert cfg.plugins.openclaw.summarize.model == "qwen3-coder"
+    assert cfg.plugins.dsh.summarize.model == "deepseek-v4-flash"
     assert get_config_value("plugins.claude-code.summarize.model", cfg) == "claude-haiku-4-5"
 
     saved = load_config_file(cfg_path)


### PR DESCRIPTION
## Summary

Refines the DSH plugin's summarization so it behaves exactly like the Claude Code / Codex / OpenClaw / OpenCode plugins: configure a provider in memsearch config → direct LLM call; configure nothing → zero-config headless agent.

## Changes

### Summarize mode: `auto` (new default)
- `summarizeMode` default is now `auto`: reads `[plugins.dsh.summarize] provider` from memsearch config. A configured provider selects `custom-llm`, otherwise `dsh-headless` (zero-config, uses the user's DSH default model). Explicit `custom-llm` / `dsh-headless` pin the backend.
- No silent fallback between modes: the resolved backend either produces a summary or fails visibly (unavailable note with reason).

### Config convergence (aligns with other plugins)
- Removed per-plugin config fields: `summarizeProvider`, `summarizeModel`, `memsearchDir`, `collection`, `milvusUri`, `agentName`.
- Provider/model come from memsearch config (`[plugins.dsh.summarize]`), memory dir from `MEMSEARCH_DIR` env, collection derived from project path, Milvus from `[milvus] uri` — exactly like the other four plugins.

### Bug fix: custom-llm stdin lost across uv bootstrap
- `summarize.py` re-execs via `os.execvpe` when memsearch isn't importable; the stdin pipe is consumed by the re-exec, so the transcript arrived empty. The transcript is now read before re-exec and passed via `MEMSEARCH_DSH_TRANSCRIPT` env.

### Schema & docs
- `PluginsConfig` gains the `dsh` field; config get/set round-trips it.
- README and `cordis.patch.yml` document the `auto` mode and the memsearch-side config surface.

## Tests
- JS: 25 tests (new `resolveSummarizeMode` cases, `renderTurn`, `writeCapture`/dedup, failure-fallback writes unavailable note not raw, per-project isolation, `MEMSEARCH_DIR` override, summarizeEnabled/injectEnabled switches).
- Python: 71 tests (summarize.py transcript recovery, config dsh field).
- Ruff clean. Manual E2E: headless + custom-llm real summaries, recall path, auto resolution both ways.