### PR TITLE
chore(dsh): publish as @zilliz/memsearch-dsh

### DIFF
--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -1,4 +1,4 @@
-# memsearch-dsh
+# @zilliz/memsearch-dsh
 
 MemSearch plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
 It gives DSH persistent, cross-agent memory on the same `.memsearch/memory/`
@@ -47,7 +47,7 @@ dsh plugin --profile web add /path/to/memsearch/plugins/dsh
 ### Manual patch insertion (no `dsh plugin`)
 
 Append this row to the profile's `cordis.patch.yml` and make sure
-`memsearch-dsh` is resolvable from the profile's `node_modules` (for example a
+`@zilliz/memsearch-dsh` is resolvable from the profile's `node_modules` (for example a
 `link:` dependency):
 
 ```yaml
@@ -169,7 +169,7 @@ through the DSH logger.
 ## Uninstall
 
 ```bash
-dsh plugin --profile web rm memsearch-dsh
+dsh plugin --profile web rm @zilliz/memsearch-dsh
 ```
 
 Removing the dependency drops the profile-layer entry; the memory markdown

--- a/plugins/dsh/cordis.patch.yml
+++ b/plugins/dsh/cordis.patch.yml
@@ -2,9 +2,10 @@
 # profile's plugin tree.
 #
 # This patch is applied as one extra layer when the package is installed via
-# `dsh plugin --profile <name> add <path>` (see README.md). A later user
-# override in the profile's own cordis.patch.yml can address the same `id` to
-# tune `config`, and removing the dependency removes the row.
+# `dsh plugin --profile <name> add @zilliz/memsearch-dsh` (npm) or a local
+# path (see README.md). A later user override in the profile's own
+# cordis.patch.yml can address the same `id` to tune `config`, and removing
+# the dependency removes the row.
 
 - insert:
     - id: memsearch

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "memsearch-dsh",
+  "name": "@zilliz/memsearch-dsh",
   "version": "0.1.0",
   "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, and memory-recall skill.",
   "type": "module",
@@ -17,7 +17,9 @@
     "cordis.patch.yml",
     "prompts/",
     "skills/",
-    "scripts/"
+    "scripts/summarize.py",
+    "scripts/parse-transcript.py",
+    "scripts/derive-collection.sh"
   ],
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary

Prepare the DSH plugin for npm publishing under the zilliz scope.

## Changes

- **package.json**: rename to `@zilliz/memsearch-dsh` (matching `@zilliz/memsearch-opencode`); list `scripts/` files explicitly in `files` so compiled `__pycache__` artifacts never ship in the tarball.
- **README.md**: npm install path (`dsh plugin add @zilliz/memsearch-dsh`), uninstall with the scoped name; the cordis plugin id stays `memsearch-dsh` (decoupled from the npm package name, same as OpenCode).
- **cordis.patch.yml**: comment mentions the npm install form.

## Already published

`@zilliz/memsearch-dsh@0.1.0` is live on npm (verified: latest 0.1.0, 9 files, 71.9 kB, zilliz org maintainers). This PR keeps the source in sync.