### PR TITLE
fix(dsh): patch name must match npm package name

### DIFF
--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -53,7 +53,7 @@ Append this row to the profile's `cordis.patch.yml` and make sure
 ```yaml
 - insert:
     - id: memsearch
-      name: 'memsearch-dsh'
+      name: '@zilliz/memsearch-dsh'
 ```
 
 ### Verify it loaded

--- a/plugins/dsh/cordis.patch.yml
+++ b/plugins/dsh/cordis.patch.yml
@@ -6,10 +6,15 @@
 # path (see README.md). A later user override in the profile's own
 # cordis.patch.yml can address the same `id` to tune `config`, and removing
 # the dependency removes the row.
+#
+# Note: `name` is the package name the cordis loader imports. It MUST equal
+# the npm package name (@zilliz/memsearch-dsh) — a path install links the
+# checkout under whatever name package.json declares, and `dsh plugin add`
+# installs the scoped name, so both resolve to the same string.
 
 - insert:
     - id: memsearch
-      name: 'memsearch-dsh'
+      name: '@zilliz/memsearch-dsh'
       config:
         # Optional overrides — see README.md for the full set. Everything else
         # (summarize provider/model, Milvus, collection, memory dir) comes from


### PR DESCRIPTION
## Summary

The cordis loader imports a plugin by the `name` in its `cordis.patch.yml`. Since the package is published as `@zilliz/memsearch-dsh`, the old `name: 'memsearch-dsh'` fails to resolve after a real npm install:

```
Cannot find package 'memsearch-dsh' imported from ~/.dsh/profiles/web/
Error [ERR_MODULE_NOT_FOUND]
```

## Fix

- `cordis.patch.yml`: `name: '@zilliz/memsearch-dsh'` (plus a comment explaining the constraint).
- `README.md`: manual patch example updated to match.

## Verified

- Web and headless profiles reinstalled under the scoped name (old `memsearch-dsh` dependency removed).
- Headless session: plugin loads, capture + dsh-headless summarize write the expected memory entry.