### PR TITLE
fix: preserve latest session memory within context budget

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -129,6 +129,8 @@ PROJECT_BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-.}")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
 RECENT_MEMORY_MAX_LINES=40
+# Claude Code head-truncates inline hook context at roughly 2 KB.
+# Keep a safety margin below the observed threshold from #684.
 RECENT_MEMORY_MAX_BYTES=1800
 
 _byte_len() {
@@ -164,12 +166,13 @@ _tail_lines_within_bytes() {
 
 _recent_memory_preview() {
   local file="$1" max_lines="${2:-40}" max_bytes="${3:-0}"
+  local candidate trimmed
 
   if [ "$max_bytes" -le 0 ]; then
     return 0
   fi
 
-  awk '
+  candidate=$(awk '
     function flush_section() {
       if (section_len > 0 && has_body) {
         for (i = 1; i <= section_len; i++) {
@@ -201,7 +204,23 @@ _recent_memory_preview() {
     END {
       flush_section()
     }
-  ' "$file" 2>/dev/null | tail -n "$max_lines" | _tail_lines_within_bytes "$max_bytes" || true
+  ' "$file" 2>/dev/null | tail -n "$max_lines" || true)
+
+  # No useful recent-memory content in this journal. The caller may try
+  # an older journal.
+  if [ -z "$candidate" ]; then
+    return 0
+  fi
+
+  trimmed=$(printf '%s\n' "$candidate" | _tail_lines_within_bytes "$max_bytes")
+
+  # Candidate content exists, but even its newest complete line does not fit.
+  # Signal the caller not to fall back to an older journal.
+  if [ -z "$trimmed" ]; then
+    return 2
+  fi
+
+  printf '%s' "$trimmed"
 }
 
 # The session heading is written lazily by stop.sh on the first
@@ -260,6 +279,7 @@ recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name "$DAILY_JOURNAL_PATT
 
 if [ -n "$recent_files" ]; then
   context="# Recent Memory\n\n"
+  has_recent_memory=false
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     basename_f=$(basename "$f")
@@ -271,14 +291,26 @@ if [ -n "$recent_files" ]; then
     fi
     # Extract recent non-empty session sections. Legacy journals may contain
     # empty headings, but they do not carry useful context.
-    content=$(_recent_memory_preview "$f" "$RECENT_MEMORY_MAX_LINES" "$content_budget")
-    if [ -n "$content" ]; then
-      context+="$file_header$content\n\n"
+    content=""
+    if content=$(_recent_memory_preview "$f" "$RECENT_MEMORY_MAX_LINES" "$content_budget"); then
+      if [ -n "$content" ]; then
+        context+="$file_header$content\n\n"
+        has_recent_memory=true
+      fi
+    else
+      preview_status=$?
+      if [ "$preview_status" -eq 2 ]; then
+        break
+      fi
     fi
     if [ "$(_byte_len "$context")" -ge "$RECENT_MEMORY_MAX_BYTES" ]; then
       break
     fi
   done <<< "$recent_files"
+
+  if [ "$has_recent_memory" != true ]; then
+    context=""
+  fi
 fi
 
 # Note: Detailed memory search is handled by the memory-recall skill (pull-based).

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -128,8 +128,47 @@ fi
 PROJECT_BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-.}")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
+RECENT_MEMORY_MAX_LINES=40
+RECENT_MEMORY_MAX_BYTES=1800
+
+_byte_len() {
+  LC_ALL=C printf '%s' "$1" | wc -c | tr -d '[:space:]'
+}
+
+_tail_lines_within_bytes() {
+  local max_bytes="$1"
+  LC_ALL=C awk -v budget="$max_bytes" '
+    {
+      lines[NR] = $0
+      sizes[NR] = length($0) + 1
+    }
+
+    END {
+      total = 0
+      start = NR + 1
+
+      for (i = NR; i >= 1; i--) {
+        if (total + sizes[i] > budget) {
+          break
+        }
+        total += sizes[i]
+        start = i
+      }
+
+      for (i = start; i <= NR; i++) {
+        print lines[i]
+      }
+    }
+  '
+}
+
 _recent_memory_preview() {
-  local file="$1" max_lines="${2:-40}"
+  local file="$1" max_lines="${2:-40}" max_bytes="${3:-0}"
+
+  if [ "$max_bytes" -le 0 ]; then
+    return 0
+  fi
+
   awk '
     function flush_section() {
       if (section_len > 0 && has_body) {
@@ -162,7 +201,7 @@ _recent_memory_preview() {
     END {
       flush_section()
     }
-  ' "$file" 2>/dev/null | tail -n "$max_lines" || true
+  ' "$file" 2>/dev/null | tail -n "$max_lines" | _tail_lines_within_bytes "$max_bytes" || true
 }
 
 # The session heading is written lazily by stop.sh on the first
@@ -224,11 +263,20 @@ if [ -n "$recent_files" ]; then
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     basename_f=$(basename "$f")
+    file_header="## $basename_f\n"
+    used_bytes=$(_byte_len "$context$file_header\n\n")
+    content_budget=$((RECENT_MEMORY_MAX_BYTES - used_bytes))
+    if [ "$content_budget" -le 0 ]; then
+      break
+    fi
     # Extract recent non-empty session sections. Legacy journals may contain
     # empty headings, but they do not carry useful context.
-    content=$(_recent_memory_preview "$f" 40)
+    content=$(_recent_memory_preview "$f" "$RECENT_MEMORY_MAX_LINES" "$content_budget")
     if [ -n "$content" ]; then
-      context+="## $basename_f\n$content\n\n"
+      context+="$file_header$content\n\n"
+    fi
+    if [ "$(_byte_len "$context")" -ge "$RECENT_MEMORY_MAX_BYTES" ]; then
+      break
     fi
   done <<< "$recent_files"
 fi

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -74,7 +74,8 @@ exit 0
         check=True,
     )
 
-    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+    payload = json.loads(result.stdout)
+    return payload.get("hookSpecificOutput", {}).get("additionalContext", "")
 
 
 def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Path) -> None:
@@ -300,6 +301,33 @@ def test_claude_session_start_recent_memory_prioritizes_newest_journal(tmp_path:
     assert "TODAY_LATEST_MARKER" in context
     assert "OLD_DAY_MARKER" not in context
     assert len(context.encode("utf-8")) <= 1800
+
+
+def test_claude_session_start_does_not_fall_back_when_newest_entry_exceeds_budget(tmp_path: Path) -> None:
+    newest = "\n".join(
+        [
+            "# 2026-08-19",
+            "",
+            "## Session 17:00",
+            "### 17:00",
+            f"- NEWEST_OVERSIZED_ENTRY {'x' * 2000}",
+            "",
+        ]
+    )
+    older = """# 2026-08-18
+
+## Session 16:00
+### 16:00
+- OLD_DAY_MARKER
+"""
+
+    context = _run_claude_session_start_with_memory(
+        tmp_path,
+        {"2026-08-18.md": older, "2026-08-19.md": newest},
+    )
+
+    assert "OLD_DAY_MARKER" not in context
+    assert context == ""
 
 
 def test_claude_session_start_recent_memory_trims_utf8_on_line_boundaries(tmp_path: Path) -> None:

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -33,6 +33,50 @@ def _write_claude_transcript(path: Path, *, turn_uuid: str) -> None:
     )
 
 
+def _run_claude_session_start_with_memory(tmp_path: Path, journals: dict[str, str]) -> str:
+    script = Path("plugins/claude-code/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memory = tmp_path / ".memsearch" / "memory"
+    home.mkdir()
+    fake_bin.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+    memory.mkdir(parents=True)
+
+    for name, content in journals.items():
+        (memory / name).write_text(content, encoding="utf-8")
+
+    _write_executable(
+        fake_bin / "memsearch",
+        """#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "list" ]; then
+  echo '{"embedding":{"provider":"onnx","model":"","api_key":""},"milvus":{"uri":"http://localhost:19530"}}'
+  exit 0
+fi
+exit 0
+""",
+    )
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(tmp_path / ".memsearch"),
+        "MEMSEARCH_NO_WATCH": "1",
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
 def test_claude_hook_memsearch_disable_exits_before_writing_memory(tmp_path: Path) -> None:
     script = Path("plugins/claude-code/hooks/session-start.sh")
     env = {
@@ -200,6 +244,81 @@ exit 0
     assert "Scratch content should not displace daily journals." not in context
     assert "Session 09:00" not in context
     assert "Session 09:02" not in context
+
+
+def test_claude_session_start_recent_memory_keeps_latest_entries_within_budget(tmp_path: Path) -> None:
+    filler = "x" * 180
+    journal = "\n".join(
+        [
+            "# 2026-08-19",
+            "",
+            "## Session 09:00",
+            "### 09:00",
+            "- OLDEST_ENTRY",
+            *[f"- {filler}-{index}" for index in range(30)],
+            "",
+            "## Session 17:00",
+            "### 17:00",
+            "- LATEST_ENTRY",
+            "",
+        ]
+    )
+
+    context = _run_claude_session_start_with_memory(tmp_path, {"2026-08-19.md": journal})
+
+    assert "LATEST_ENTRY" in context
+    assert "OLDEST_ENTRY" not in context
+    assert len(context.encode("utf-8")) <= 1800
+
+
+def test_claude_session_start_recent_memory_prioritizes_newest_journal(tmp_path: Path) -> None:
+    filler = "x" * 180
+    newest = "\n".join(
+        [
+            "# 2026-08-19",
+            "",
+            "## Session 17:00",
+            "### 17:00",
+            *[f"- {filler}-{index}" for index in range(20)],
+            "- TODAY_LATEST_MARKER",
+            "",
+        ]
+    )
+    older_filler = "x" * 180
+    older = f"""# 2026-08-18
+
+## Session 17:00
+### 17:00
+- OLD_DAY_MARKER {older_filler}
+"""
+
+    context = _run_claude_session_start_with_memory(
+        tmp_path,
+        {"2026-08-18.md": older, "2026-08-19.md": newest},
+    )
+
+    assert "TODAY_LATEST_MARKER" in context
+    assert "OLD_DAY_MARKER" not in context
+    assert len(context.encode("utf-8")) <= 1800
+
+
+def test_claude_session_start_recent_memory_trims_utf8_on_line_boundaries(tmp_path: Path) -> None:
+    journal = "\n".join(
+        [
+            "# 2026-08-19",
+            "",
+            "## Session 17:00",
+            "### 17:00",
+            *[f"- 用户讨论了新的检索策略 需要保留完整中文内容 {index}" for index in range(50)],
+            "- 最新记录: 需要优先保存",
+            "",
+        ]
+    )
+
+    context = _run_claude_session_start_with_memory(tmp_path, {"2026-08-19.md": journal})
+
+    assert "最新记录" in context
+    assert len(context.encode("utf-8")) <= 1800
 
 
 def test_claude_session_start_uv_tool_upgrade_hint_preserves_extras(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #684.

Claude Code SessionStart currently builds the Recent Memory context from the two most recent daily journals and selects the latest entries from each journal. However, the assembled `additionalContext` can still exceed the Claude Code inline hook context limit.

When that happens, the downstream harness keeps a head preview of the payload. This means memsearch first selects recent entries, but the newest part of that selection can still be discarded before it reaches the session.

This is the same class of recency-preservation issue addressed for maintenance prompts in #653 and #656, but on the Claude Code SessionStart path.

This change makes the SessionStart recent-memory preview byte-budget aware before it is passed to the harness. When the available context is limited, newer journal content is prioritized and older content is dropped first.

## Changes

* Add an explicit byte budget for Claude Code SessionStart recent-memory context
* Keep the existing recent-session filtering and line-based candidate window
* Apply the byte budget before emitting `additionalContext`
* Preserve complete recent lines instead of relying on downstream head truncation
* Prioritize the newest daily journal when the combined recent-memory context exceeds the available budget
* Keep the final Recent Memory block within the configured internal size limit
* Preserve valid UTF-8 content when trimming multibyte text
* Leave the existing two-journal selection behavior unchanged

The fix is intentionally scoped to the Claude Code SessionStart path. It does not change maintenance prompt budgeting, memory indexing, or other plugin implementations.

## Why byte budgeting

The existing preview uses a fixed line count, but journal entries can vary significantly in length. A smaller line count reduces the likelihood of downstream truncation but cannot guarantee that the resulting payload stays within a byte-based context limit.

Budgeting the generated Recent Memory block by bytes allows memsearch to control truncation before handing the context to Claude Code and ensures that truncation follows memsearch's recency policy rather than the harness's head-preview behavior.

## Recency behavior

When the available budget is insufficient for all selected recent memory, the priority is:

1. Newest content from the newest daily journal
2. Earlier content from the newest daily journal
3. Content from the previous daily journal when space remains

This keeps the information most relevant to a newly started session while preserving the existing chronological order of the content that survives.

If the newest candidate entry itself exceeds the available budget, SessionStart does not fall back to an older journal, preserving recency priority rather than injecting stale context.

## Tests

Added regression coverage for:

* An oversized single daily journal where the latest entry must remain in `additionalContext`
* Multiple recent journals where the newest journal must take priority when the shared budget is exhausted
* Keeping the final Recent Memory context within the byte budget
* UTF-8 journal content remaining valid after byte-aware trimming
* Existing behavior that skips empty sessions and ignores non-daily journal files

Commands run:

```text
uv run python -m pytest tests/test_claude_hooks.py -v
uv run ruff check tests/test_claude_hooks.py
uv run ruff format --check tests/test_claude_hooks.py
uv run python -m pytest
```

## Test plan

* [x] Oversized recent memory keeps the latest journal entry
* [x] Older entries are removed before newer entries when the budget is exceeded
* [x] The newest daily journal is prioritized over the previous daily journal
* [x] The emitted Recent Memory block stays within the internal byte budget
* [x] UTF-8 content remains valid after trimming
* [x] Existing Claude Code SessionStart hook tests pass
* [x] Ruff lint passes
* [x] Ruff format check passes
* [x] Full test suite passes
