### PR TITLE
fix(hooks): keep the watch registry outside the watched tree

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -289,7 +289,16 @@ kill_orphaned_index() {
 
 # --- Watch singleton management ---
 
+# Legacy pidfile. It lives inside the tree it manages, so it is destroyed along
+# with that tree (e.g. `git worktree remove`) and the watcher is left running
+# with no handle to reap it. Still read below so upgrading does not strand a
+# watcher that an older version started.
 WATCH_PIDFILE="$MEMSEARCH_DIR/.watch.pid"
+
+# Registry of running watchers, kept OUTSIDE any watched tree so that deleting a
+# project directory cannot take the only handle to its watcher with it. One file
+# per watcher, named for its PID, containing "<pid>\n<target dir>".
+WATCH_REGISTRY_DIR="${MEMSEARCH_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/memsearch}/watchers"
 
 # Kill a process and its entire process group to avoid orphans
 _kill_tree() {
@@ -298,23 +307,103 @@ _kill_tree() {
   kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
 }
 
+# Best-effort guard against PID reuse: a recorded PID may have been recycled by
+# an unrelated process before we get to signal it. Succeeds when the process
+# cannot be inspected at all, which is the unconditional behaviour this
+# replaces rather than a regression.
+_watch_pid_is_ours() {
+  local pid="$1" cmd=""
+  cmd="$(ps -o args= -p "$pid" 2>/dev/null || true)"
+  case "$cmd" in
+    "") return 0 ;;
+    *memsearch*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_watch_registry_record() {
+  local pid="$1" target="$2"
+  mkdir -p "$WATCH_REGISTRY_DIR" 2>/dev/null || return 0
+  printf '%s\n%s\n' "$pid" "$target" > "$WATCH_REGISTRY_DIR/$pid.pid" 2>/dev/null || true
+}
+
+_watch_registry_forget() {
+  rm -f "$WATCH_REGISTRY_DIR/$1.pid" 2>/dev/null || true
+}
+
+# Reap watchers whose target directory no longer exists. This is the
+# removed-worktree case, which neither the in-tree pidfile (deleted with the
+# tree) nor a "$MEMORY_DIR"-scoped pgrep (no live session ever has that
+# MEMORY_DIR again) can reach. Uses no pgrep, so it also covers platforms where
+# pgrep is unavailable.
+reap_stale_watchers() {
+  [ -d "$WATCH_REGISTRY_DIR" ] || return 0
+  local entry pid target
+  for entry in "$WATCH_REGISTRY_DIR"/*.pid; do
+    [ -f "$entry" ] || continue
+    pid="$(sed -n '1p' "$entry" 2>/dev/null || true)"
+    target="$(sed -n '2p' "$entry" 2>/dev/null || true)"
+    if [ -z "$pid" ]; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if [ -n "$target" ] && [ ! -d "$target" ]; then
+      if _watch_pid_is_ours "$pid"; then
+        _kill_tree "$pid"
+      fi
+      rm -f "$entry" 2>/dev/null || true
+    fi
+  done
+}
+
+# Kill any registered watcher whose target is this MEMORY_DIR.
+_stop_registered_watchers_for_memory_dir() {
+  [ -d "$WATCH_REGISTRY_DIR" ] || return 0
+  local entry pid target
+  for entry in "$WATCH_REGISTRY_DIR"/*.pid; do
+    [ -f "$entry" ] || continue
+    pid="$(sed -n '1p' "$entry" 2>/dev/null || true)"
+    target="$(sed -n '2p' "$entry" 2>/dev/null || true)"
+    if [ -z "$pid" ]; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if [ "$target" = "$MEMORY_DIR" ]; then
+      if kill -0 "$pid" 2>/dev/null && _watch_pid_is_ours "$pid"; then
+        _kill_tree "$pid"
+      fi
+      rm -f "$entry" 2>/dev/null || true
+    fi
+  done
+}
+
 # Stop the watch process: pidfile first, then sweep for orphans
 stop_watch() {
   # Skip watch management in child claude -p processes (e.g. stop.sh summarization)
   if [ "${MEMSEARCH_NO_WATCH:-}" = "1" ]; then
     return 0
   fi
-  # 1. Kill the process recorded in pidfile
+  # 1. Kill the process recorded in the legacy in-tree pidfile
   if [ -f "$WATCH_PIDFILE" ]; then
     local pid
-    pid=$(cat "$WATCH_PIDFILE" 2>/dev/null)
+    pid="$(cat "$WATCH_PIDFILE" 2>/dev/null || true)"
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       _kill_tree "$pid"
+    fi
+    if [ -n "$pid" ]; then
+      _watch_registry_forget "$pid"
     fi
     rm -f "$WATCH_PIDFILE"
   fi
 
-  # 2. Sweep for orphaned watch processes targeting this MEMORY_DIR
+  # 2. Kill any registered watcher for this MEMORY_DIR
+  _stop_registered_watchers_for_memory_dir
+
+  # 3. Sweep for orphaned watch processes targeting this MEMORY_DIR
   local orphans
   orphans=$(pgrep -f "memsearch watch $MEMORY_DIR" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
@@ -330,6 +419,10 @@ start_watch() {
   if [ "${MEMSEARCH_NO_WATCH:-}" = "1" ]; then
     return 0
   fi
+
+  # Reap watchers stranded by a deleted project tree before starting a new one.
+  reap_stale_watchers
+
   if [ -z "$MEMSEARCH_CMD" ]; then
     return 0
   fi
@@ -356,5 +449,7 @@ start_watch() {
   else
     $launch_prefix $MEMSEARCH_CMD watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
   fi
-  echo $! > "$WATCH_PIDFILE"
+  local _watch_pid=$!
+  echo "$_watch_pid" > "$WATCH_PIDFILE"
+  _watch_registry_record "$_watch_pid" "$MEMORY_DIR"
 }

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -296,12 +296,95 @@ kill_orphaned_index() {
 
 # --- Watch singleton management ---
 
+# Legacy pidfile. It lives inside the tree it manages, so it is destroyed along
+# with that tree (e.g. `git worktree remove`) and the watcher is left running
+# with no handle to reap it. Still read below so upgrading does not strand a
+# watcher that an older version started.
 WATCH_PIDFILE="$MEMSEARCH_DIR/.watch.pid"
+
+# Registry of running watchers, kept OUTSIDE any watched tree so that deleting a
+# project directory cannot take the only handle to its watcher with it. One file
+# per watcher, named for its PID, containing "<pid>\n<target dir>".
+WATCH_REGISTRY_DIR="${MEMSEARCH_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/memsearch}/watchers"
 
 # Kill a process and its entire process group to avoid orphans
 _kill_tree() {
   local pid="$1"
   kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+}
+
+# Best-effort guard against PID reuse: a recorded PID may have been recycled by
+# an unrelated process before we get to signal it. Succeeds when the process
+# cannot be inspected at all, which is the unconditional behaviour this
+# replaces rather than a regression.
+_watch_pid_is_ours() {
+  local pid="$1" cmd=""
+  cmd="$(ps -o args= -p "$pid" 2>/dev/null || true)"
+  case "$cmd" in
+    "") return 0 ;;
+    *memsearch*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_watch_registry_record() {
+  local pid="$1" target="$2"
+  mkdir -p "$WATCH_REGISTRY_DIR" 2>/dev/null || return 0
+  printf '%s\n%s\n' "$pid" "$target" > "$WATCH_REGISTRY_DIR/$pid.pid" 2>/dev/null || true
+}
+
+_watch_registry_forget() {
+  rm -f "$WATCH_REGISTRY_DIR/$1.pid" 2>/dev/null || true
+}
+
+# Reap watchers whose target directory no longer exists. This is the
+# removed-worktree case, which neither the in-tree pidfile (deleted with the
+# tree) nor a "$MEMORY_DIR"-scoped pgrep (no live session ever has that
+# MEMORY_DIR again) can reach. Uses no pgrep, so it also covers platforms where
+# pgrep is unavailable.
+reap_stale_watchers() {
+  [ -d "$WATCH_REGISTRY_DIR" ] || return 0
+  local entry pid target
+  for entry in "$WATCH_REGISTRY_DIR"/*.pid; do
+    [ -f "$entry" ] || continue
+    pid="$(sed -n '1p' "$entry" 2>/dev/null || true)"
+    target="$(sed -n '2p' "$entry" 2>/dev/null || true)"
+    if [ -z "$pid" ]; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if [ -n "$target" ] && [ ! -d "$target" ]; then
+      if _watch_pid_is_ours "$pid"; then
+        _kill_tree "$pid"
+      fi
+      rm -f "$entry" 2>/dev/null || true
+    fi
+  done
+}
+
+# Kill any registered watcher whose target is this MEMORY_DIR.
+_stop_registered_watchers_for_memory_dir() {
+  [ -d "$WATCH_REGISTRY_DIR" ] || return 0
+  local entry pid target
+  for entry in "$WATCH_REGISTRY_DIR"/*.pid; do
+    [ -f "$entry" ] || continue
+    pid="$(sed -n '1p' "$entry" 2>/dev/null || true)"
+    target="$(sed -n '2p' "$entry" 2>/dev/null || true)"
+    if [ -z "$pid" ]; then
+      rm -f "$entry" 2>/dev/null || true
+      continue
+    fi
+    if [ "$target" = "$MEMORY_DIR" ]; then
+      if kill -0 "$pid" 2>/dev/null && _watch_pid_is_ours "$pid"; then
+        _kill_tree "$pid"
+      fi
+      rm -f "$entry" 2>/dev/null || true
+    fi
+  done
 }
 
 # Stop the watch process: pidfile first, then sweep for orphans
@@ -311,12 +394,17 @@ stop_watch() {
   fi
   if [ -f "$WATCH_PIDFILE" ]; then
     local pid
-    pid=$(cat "$WATCH_PIDFILE" 2>/dev/null)
+    pid="$(cat "$WATCH_PIDFILE" 2>/dev/null || true)"
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       _kill_tree "$pid"
     fi
+    if [ -n "$pid" ]; then
+      _watch_registry_forget "$pid"
+    fi
     rm -f "$WATCH_PIDFILE"
   fi
+
+  _stop_registered_watchers_for_memory_dir
 
   local orphans
   orphans=$(pgrep -f "memsearch watch $MEMORY_DIR" 2>/dev/null || true)
@@ -332,6 +420,10 @@ start_watch() {
   if [ "${MEMSEARCH_NO_WATCH:-}" = "1" ]; then
     return 0
   fi
+
+  # Reap watchers stranded by a deleted project tree before starting a new one.
+  reap_stale_watchers
+
   if ! memsearch_available; then
     return 0
   fi
@@ -362,7 +454,9 @@ start_watch() {
       nohup "${MEMSEARCH_CMD[@]}" watch "$MEMORY_DIR" ${COLLECTION_DESC:+--description "$COLLECTION_DESC"} </dev/null &>/dev/null &
     fi
   fi
-  echo $! > "$WATCH_PIDFILE"
+  local _watch_pid=$!
+  echo "$_watch_pid" > "$WATCH_PIDFILE"
+  _watch_registry_record "$_watch_pid" "$MEMORY_DIR"
 }
 
 # --- Orphan cleanup (called at session start since Codex has no SessionEnd hook) ---

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1213,3 +1213,132 @@ exit 0
     # No latest version known, so no hint is claimed either way.
     for run in (first, second):
         assert "UPDATE:" not in json.loads(run.stdout)["systemMessage"]
+
+
+COMMON_SH_PLUGINS = ["plugins/claude-code/hooks/common.sh", "plugins/codex/hooks/common.sh"]
+
+
+def _spawn_fake_watcher(tmp_path: Path, target: Path) -> subprocess.Popen[bytes]:
+    """Start a stub standing in for `memsearch watch <target>`.
+
+    Its argv contains "memsearch" so the reaper's PID-reuse guard recognises it,
+    and start_new_session mirrors the setsid/nohup launch in start_watch, which
+    makes it a process-group leader so _kill_tree's group kill has a group.
+    """
+    stub_dir = tmp_path / "stub"
+    stub_dir.mkdir(exist_ok=True)
+    stub = stub_dir / "memsearch"
+    _write_executable(stub, "#!/usr/bin/env bash\nsleep 300\n")
+    return subprocess.Popen([str(stub), "watch", str(target)], start_new_session=True)
+
+
+def _run_registry_snippet(
+    common_sh: str, snippet: str, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", f'source "$1" < /dev/null\n{snippet}', "bash", common_sh, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+
+def _registry_env(tmp_path: Path, project: Path, state_dir: Path) -> dict[str, str]:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    return {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "MEMSEARCH_STATE_DIR": str(state_dir),
+        "MEMSEARCH_DISABLE": "",
+    }
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SH_PLUGINS, ids=["claude-code", "codex"])
+def test_watch_registry_lives_outside_the_watched_tree(tmp_path: Path, common_sh: str) -> None:
+    """The handle used to reap a watcher must outlive the directory it watches.
+
+    A pidfile stored under the project tree is destroyed with that tree (e.g.
+    `git worktree remove`), which is exactly when reaping is needed.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+
+    result = _run_registry_snippet(
+        common_sh,
+        'printf "%s\\n%s\\n" "$WATCH_REGISTRY_DIR" "$MEMSEARCH_DIR"',
+        _registry_env(tmp_path, project, state_dir),
+    )
+    registry_dir, memsearch_dir = result.stdout.splitlines()
+
+    assert Path(registry_dir) == state_dir / "watchers"
+    assert not Path(registry_dir).is_relative_to(project)
+    assert not Path(registry_dir).is_relative_to(memsearch_dir)
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SH_PLUGINS, ids=["claude-code", "codex"])
+def test_reap_stale_watchers_kills_watcher_whose_target_is_gone(tmp_path: Path, common_sh: str) -> None:
+    """Positive control: the removed-worktree case the in-tree pidfile cannot reach."""
+    project = tmp_path / "project"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    state_dir = tmp_path / "state"
+
+    watcher = _spawn_fake_watcher(tmp_path, memory)
+    try:
+        _run_registry_snippet(
+            common_sh,
+            '_watch_registry_record "$2" "$3"',
+            _registry_env(tmp_path, project, state_dir),
+            str(watcher.pid),
+            str(memory),
+        )
+        entry = state_dir / "watchers" / f"{watcher.pid}.pid"
+        assert entry.exists(), "recording a watcher must create its registry entry"
+
+        shutil.rmtree(project)  # the worktree goes away, taking the in-tree pidfile with it
+
+        _run_registry_snippet(common_sh, "reap_stale_watchers", _registry_env(tmp_path, project, state_dir))
+        assert watcher.wait(timeout=10) is not None
+        assert not entry.exists()
+    finally:
+        if watcher.poll() is None:
+            watcher.kill()
+            watcher.wait(timeout=10)
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SH_PLUGINS, ids=["claude-code", "codex"])
+def test_reap_stale_watchers_leaves_live_watchers_alone(tmp_path: Path, common_sh: str) -> None:
+    """Negative control: a watcher whose target still exists must survive the sweep.
+
+    Without this, a reaper that killed everything unconditionally would pass the
+    positive control above.
+    """
+    project = tmp_path / "project"
+    memory = project / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    state_dir = tmp_path / "state"
+
+    watcher = _spawn_fake_watcher(tmp_path, memory)
+    try:
+        _run_registry_snippet(
+            common_sh,
+            '_watch_registry_record "$2" "$3"',
+            _registry_env(tmp_path, project, state_dir),
+            str(watcher.pid),
+            str(memory),
+        )
+        entry = state_dir / "watchers" / f"{watcher.pid}.pid"
+        assert entry.exists()
+
+        _run_registry_snippet(common_sh, "reap_stale_watchers", _registry_env(tmp_path, project, state_dir))
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            watcher.wait(timeout=1)
+        assert entry.exists(), "a live watcher must keep its registry entry"
+    finally:
+        watcher.kill()
+        watcher.wait(timeout=10)


### PR DESCRIPTION
Fixes #692.

## The problem

`WATCH_PIDFILE` lives at `$MEMSEARCH_DIR/.watch.pid` — inside the very tree it manages. When that tree goes away (`git worktree remove`, deleting a scratch project), the only handle to the running watcher is destroyed along with it.

The fallback sweep in `stop_watch` cannot recover it either:

```sh
orphans=$(pgrep -f "memsearch watch $MEMORY_DIR" 2>/dev/null || true)
```

That query is scoped by the same `MEMORY_DIR` that was just deleted. No future session ever has that `MEMORY_DIR` again, so no future session ever issues a query that could match the orphan. The watcher is launched detached (`setsid`/`nohup`), so it survives indefinitely — the orphan's own `argv` still contains the path, but nothing ever looks for it.

Measured on one macOS laptop before the fix: **34 orphaned watcher trees, 115 processes, ~6.7 GB resident, the oldest 9 days old.** Reaping them returned ~1.7 GB and shrank swap from 36 GB to 6 GB.

## The fix

A handle used to clean something up has to outlive the thing being cleaned. This moves the handle out:

- Each watcher is recorded in `${XDG_STATE_HOME:-$HOME/.local/state}/memsearch/watchers/<pid>.pid`, containing the pid and its target directory. Overridable via `MEMSEARCH_STATE_DIR`.
- `start_watch` calls `reap_stale_watchers`, which kills any registered watcher whose target directory no longer exists — the removed-worktree case, reached from any project, not just the deleted one.
- `stop_watch` also clears registry entries for the current `MEMORY_DIR`.

Compatibility:

- The legacy in-tree pidfile is still written and still honoured, so upgrading does not strand a watcher an older version started.
- The existing `pgrep` sweep is unchanged.
- Entries are named by pid rather than a hash of the path, to avoid depending on `sha256sum`/`shasum`, which differ across platforms.
- PID reuse is guarded best-effort by checking the live process's `argv` before signalling. When the process cannot be inspected at all it is treated as ours — that is the current unconditional behaviour, not a new risk.

### Also fixes the Windows reports

`reap_stale_watchers` uses no `pgrep`. That makes it a path to recovery on Windows/Git Bash, where #658 and #600 report watchers accumulating precisely because `stop_watch`'s sweep needs `pgrep` and cannot find it. Different cause from #692, same symptom, and this reaper covers both.

## Both plugins

`plugins/claude-code/hooks/common.sh` and `plugins/codex/hooks/common.sh` carried the identical bug. Both are fixed, and the shared region is byte-identical between them.

## Tests

`tests/test_claude_hooks.py` gains three tests, parametrized over both plugins:

- The registry path resolves outside the project tree and outside `MEMSEARCH_DIR` — the invariant the bug violated.
- **Positive control:** target directory removed → the watcher is reaped and its entry cleared.
- **Negative control:** target directory present → the watcher survives and keeps its entry. This is the load-bearing one; without it, a reaper that killed unconditionally would pass the positive control.

Each control was verified by mutation: forcing the target-exists branch to `false` fails only the positive control, forcing it to `true` fails only the negative control.

Full suite green (`uv run python -m pytest`), `ruff check` and `ruff format --check` clean, `shellcheck` reports no new findings against the pristine files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
