### PR TITLE
feat(dsh): add skill-candidate review panel UI to the web composer dock

### DIFF
--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -9,6 +9,7 @@ backed by a Milvus hybrid search index.
 capture  ── session/event turn/end ──> summarize (dsh-headless agent default, or custom-llm) ──> memory/YYYY-MM-DD.md
 inject   ── agent/pre-step step 1  ──> memsearch search ──> relevant chunks injected (zero cost otherwise)
 recall   ── ctx.skills.register(memory-recall) ──> search → expand → transcript
+review   ── web UI dock panel ──> GET/POST /memsearch-dsh/* ──> list candidates / queue review / install
 ```
 
 ## Prerequisites
@@ -195,6 +196,30 @@ through the DSH logger.
   maintenance work is executed by a one-shot DSH headless agent (the same
   `dsh --profile headless` mechanism as summarization), booted with
   `MEMSEARCH_DSH_SUMMARIZE=1` so the plugin stays inert inside it.
+- **Skill review panel (web only)** — a non-blocking dock strip above the
+  composer (registered into the `conversation.input.dock` slot) lists skill
+  candidates distilled into `.memsearch/skill-candidates/`. It is served by the
+  plugin's browser half (`client.js`, declared through `dsh.client` in
+  `package.json`) and talks to the host through two JSON routes on the DSH web
+  server:
+  - `GET /memsearch-dsh/skill-candidates?sessionId=<id>` — lists candidates
+    (pending first) parsed from each candidate's `meta.json`.
+  - `POST /memsearch-dsh/skill-review` with `{ sessionId, name, action }`:
+    - `action: "review"` queues a `[memsearch] Skill candidate ...` user
+      message into the live agent's inbox (`agent.inbox.append('next-turn',
+      ...)`). The agent reviews the candidate on its next turn — non-blocking,
+      it never interrupts a running turn and never opens a blocking dialog.
+    - `action: "install"` runs `memsearch skills install <name> --path <dir>`
+      in the background (detached, unref'd) to the resolved target: the first
+      entry of `plugins.dsh.memory_to_skill.paths` in memsearch config
+      (relative entries resolve against the project dir), else the DSH default
+      `~/.agents/skills`, which the `skill-filesystem` provider watches and
+      loads automatically.
+  The project directory is resolved from the session id (its durable cwd), so
+  the panel reflects the project of the session you are viewing on a
+  multi-project web surface. Headless / TUI profiles have no browser: the host
+  routes are simply not registered (no `webServer`), and everything else is
+  unchanged.
 
 ## Uninstall
 
@@ -209,6 +234,13 @@ files and the Milvus index are left untouched.
 
 - The plugin is plain ESM with no build step — `dsh plugin add` links the
   checkout directly, so edits are live after a profile reload.
+- The browser half (`client.js`) is a prebuilt client-module bundle: it
+  registers its factory with `window.__ModuleLoader__.load({ id, factory })`
+  (the lazy CJS table the web shell serves at `/plugins/<id>/client.js`) and
+  exports the Cordis client plugin shape (`inject` + `apply`). It is checked
+  in as-is; edit it directly and keep the `__ModuleLoader__` registration
+  format (mirror the shipped `@deepseek-ai/dsh-client-ui-*` `lib/client.js`
+  bundles).
 - Python helpers under `scripts/` are linted with the repo's `ruff` config and
   tested under `plugins/dsh/tests/`.
 - Keep the memory-write format byte-compatible with the other platform

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -217,9 +217,11 @@ through the DSH logger.
       loads automatically.
   The project directory is resolved from the session id (its durable cwd), so
   the panel reflects the project of the session you are viewing on a
-  multi-project web surface. Headless / TUI profiles have no browser: the host
-  routes are simply not registered (no `webServer`), and everything else is
-  unchanged.
+  multi-project web surface. The routes are registered once the DSH web server
+  service becomes available (the memsearch plugin mounts in the base bundle
+  layer, before the web server starts; `apply` retries on a 1s unref'd timer).
+  Headless / TUI profiles have no browser: the `webServer` service never
+  appears, no routes are registered, and everything else is unchanged.
 
 ## Uninstall
 

--- a/plugins/dsh/client.js
+++ b/plugins/dsh/client.js
@@ -1,0 +1,272 @@
+/**
+ * memsearch-dsh — browser half (skill review panel).
+ *
+ * A non-blocking dock strip above the composer that lists MemSearch skill
+ * candidates distilled from memory journals and lets the human review or
+ * install them:
+ *
+ *   - data:   GET  /memsearch-dsh/skill-candidates
+ *   - review: POST /memsearch-dsh/skill-review  { sessionId, name, action: 'review' }
+ *             queues a user message into the live agent's inbox; the agent
+ *             reviews the candidate on the next turn (non-blocking).
+ *   - install:POST /memsearch-dsh/skill-review  { sessionId, name, action: 'install' }
+ *             runs `memsearch skills install` in the background to the
+ *             resolved target (paths config, else ~/.agents/skills).
+ *
+ * The bundle is a prebuilt client-module artifact: it registers its factory
+ * with `window.__ModuleLoader__.load({ id, factory })` (lazy CJS table —
+ * nothing runs until the shell materializes the module), and exports the
+ * Cordis client plugin shape (`inject` + `apply`). The only external module it
+ * requires is `react`, which the web shell provides.
+ *
+ * @module @zilliz/memsearch-dsh/client
+ */
+window.__ModuleLoader__.load({
+  id: '@zilliz/memsearch-dsh',
+  factory: (require) => {
+    var module = { exports: {} }
+    var exports = module.exports
+    Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
+
+    var React = require('react')
+    var useState = React.useState
+    var useEffect = React.useEffect
+    var useCallback = React.useCallback
+
+    var NS = 'memsearch-skill-review'
+    var CSS_TAG = 'memsearch-skill-review-css'
+
+    var CSS =
+      '.msr-root{' +
+        '--msr-bg:var(--dsw-alias-bg-layer-1,#1c1f26);' +
+        '--msr-bg-2:var(--dsw-alias-bg-layer-2,#242830);' +
+        '--msr-border:var(--dsw-alias-border-l1,rgba(148,163,184,.18));' +
+        '--msr-text:var(--dsw-alias-label-primary,#e2e8f0);' +
+        '--msr-text-2:var(--dsw-alias-label-secondary,#94a3b8);' +
+        '--msr-brand:var(--dsw-alias-brand-primary,#3b82f6);' +
+        '--msr-success:var(--dsw-alias-state-success-primary,#22c55e);' +
+        '--msr-warn:var(--dsw-alias-state-warn-primary,#f59e0b);' +
+        '--msr-error:var(--dsw-alias-state-error-primary,#ef4444);' +
+        'font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;' +
+      '}' +
+      '.msr-bar{display:flex;align-items:center;gap:8px;width:100%;padding:6px 10px;box-sizing:border-box;' +
+        'border:1px solid var(--msr-border);border-radius:8px;background:var(--msr-bg);color:var(--msr-text);' +
+        'font-size:13px;line-height:1.4;}' +
+      '.msr-badge{display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb,var(--msr-brand) 16%,transparent);' +
+        'color:var(--msr-brand);border-radius:999px;padding:2px 9px;font-size:12px;font-weight:600;white-space:nowrap;}' +
+      '.msr-count{font-weight:700;color:var(--msr-warn);}' +
+      '.msr-spacer{flex:1;}' +
+      '.msr-btn{border:1px solid var(--msr-border);background:var(--msr-bg-2);color:var(--msr-text);border-radius:6px;' +
+        'padding:3px 10px;font-size:12px;cursor:pointer;font-family:inherit;white-space:nowrap;}' +
+      '.msr-btn:hover{border-color:var(--msr-brand);color:var(--msr-brand);}' +
+      '.msr-btn.primary{background:var(--msr-brand);border-color:var(--msr-brand);color:#fff;font-weight:600;}' +
+      '.msr-btn.primary:hover{filter:brightness(1.1);color:#fff;}' +
+      '.msr-btn.danger{color:var(--msr-error);}' +
+      '.msr-btn.danger:hover{border-color:var(--msr-error);color:var(--msr-error);}' +
+      '.msr-btn.ghost{background:transparent;}' +
+      '.msr-btn:disabled{opacity:.55;cursor:default;}' +
+      '.msr-panel{margin-top:6px;border:1px solid var(--msr-border);border-radius:10px;background:var(--msr-bg);' +
+        'color:var(--msr-text);overflow:hidden;}' +
+      '.msr-panel-head{display:flex;align-items:center;gap:8px;padding:8px 12px;font-size:12px;color:var(--msr-text-2);' +
+        'border-bottom:1px solid var(--msr-border);}' +
+      '.msr-panel-title{font-weight:700;color:var(--msr-text);font-size:13px;}' +
+      '.msr-list{padding:4px;}' +
+      '.msr-item{display:flex;align-items:flex-start;gap:10px;padding:9px 10px;border-radius:8px;}' +
+      '.msr-item:hover{background:var(--msr-bg-2);}' +
+      '.msr-item+.msr-item{border-top:1px solid var(--msr-border);}' +
+      '.msr-item-main{flex:1;min-width:0;}' +
+      '.msr-item-name{font-weight:650;font-size:13px;display:flex;align-items:center;gap:8px;}' +
+      '.msr-tag{font-size:10px;font-weight:700;letter-spacing:.04em;padding:1px 7px;border-radius:999px;text-transform:uppercase;}' +
+      '.msr-tag.candidate{background:color-mix(in srgb,var(--msr-warn) 18%,transparent);color:var(--msr-warn);}' +
+      '.msr-tag.installed{background:color-mix(in srgb,var(--msr-success) 18%,transparent);color:var(--msr-success);}' +
+      '.msr-item-desc{font-size:12px;color:var(--msr-text-2);margin-top:3px;}' +
+      '.msr-item-meta{font-size:11px;color:var(--msr-text-2);margin-top:3px;opacity:.85;}' +
+      '.msr-item-meta code{background:var(--msr-bg-2);border:1px solid var(--msr-border);border-radius:4px;' +
+        'padding:0 4px;font-size:10px;}' +
+      '.msr-item-actions{display:flex;gap:6px;flex-shrink:0;align-items:center;}' +
+      '.msr-note{padding:8px 12px;border-top:1px solid var(--msr-border);font-size:11px;color:var(--msr-text-2);' +
+        'display:flex;align-items:center;gap:6px;}' +
+      '.msr-toast{margin-top:6px;padding:7px 12px;border-radius:8px;font-size:12px;border:1px solid var(--msr-border);' +
+        'background:var(--msr-bg-2);color:var(--msr-text);}' +
+      '.msr-toast.ok{border-color:color-mix(in srgb,var(--msr-success) 45%,transparent);color:var(--msr-success);}' +
+      '.msr-toast.warn{border-color:color-mix(in srgb,var(--msr-warn) 45%,transparent);color:var(--msr-warn);}' +
+      '.msr-toast.err{border-color:color-mix(in srgb,var(--msr-error) 45%,transparent);color:var(--msr-error);}'
+
+    /** Insert the panel stylesheet once per page. */
+    function ensureCss() {
+      if (typeof document === 'undefined') return
+      if (document.querySelector('style[data-plugin-css="' + CSS_TAG + '"]')) return
+      var tag = document.createElement('style')
+      tag.dataset.pluginCss = CSS_TAG
+      tag.textContent = CSS
+      document.head.appendChild(tag)
+    }
+
+    /** The dock strip: candidate count + expandable review list. */
+    function SkillReviewPanel(props) {
+      var sessionId = props.sessionId
+      var candidates = useState(null) // null = loading
+      var setCandidates = candidates[1]
+      var open = useState(false)
+      var setOpen = open[1]
+      var dismissed = useState({})
+      var setDismissed = dismissed[1]
+      var toast = useState(null)
+      var setToast = toast[1]
+      var busy = useState(null)
+      var setBusy = busy[1]
+
+      var load = useCallback(function () {
+        fetch('/memsearch-dsh/skill-candidates?sessionId=' + encodeURIComponent(sessionId))
+          .then(function (res) { return res.json() })
+          .then(function (data) {
+            setCandidates(Array.isArray(data.candidates) ? data.candidates : [])
+          })
+          .catch(function () { setCandidates([]) })
+      }, [sessionId])
+
+      useEffect(function () { load() }, [load])
+
+      useEffect(function () {
+        if (toast[0] === null) return
+        var t = setTimeout(function () { setToast(null) }, 4000)
+        return function () { clearTimeout(t) }
+      }, [toast[0]])
+
+      var act = function (name, action) {
+        setBusy(name)
+        fetch('/memsearch-dsh/skill-review', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: sessionId, name: name, action: action }),
+        })
+          .then(function (res) { return res.json().then(function (data) { return { ok: res.ok, data: data } }) })
+          .then(function (r) {
+            if (!r.ok || !r.data.ok) throw new Error(r.data.error || 'request failed')
+            if (action === 'review') {
+              setToast({ kind: 'ok', text: 'Review queued for ' + name + ' — the agent will pick it up on the next turn.' })
+            } else {
+              setToast({ kind: 'ok', text: 'Installing ' + name + ' to ' + r.data.target + ' in the background.' })
+              setTimeout(load, 2500)
+            }
+          })
+          .catch(function (err) {
+            setToast({ kind: 'err', text: String(err && err.message ? err.message : err) })
+          })
+          .finally(function () { setBusy(null) })
+      }
+
+      var h = React.createElement
+      var visible = (candidates[0] || []).filter(function (c) { return !dismissed[0][c.name] })
+      var pending = visible.filter(function (c) { return c.status === 'candidate' })
+      var installed = visible.length - pending.length
+      var loading = candidates[0] === null
+
+      var bar = h(
+        'div', { className: 'msr-bar' },
+        h('span', { className: 'msr-badge' }, 'MemSearch'),
+        loading
+          ? h('span', null, 'Loading skill candidates…')
+          : h('span', null,
+              h('span', { className: 'msr-count' }, String(pending.length)),
+              ' skill candidate' + (pending.length === 1 ? '' : 's') + ' awaiting review',
+              h('span', { style: { color: 'var(--msr-text-2)', fontSize: 12 } },
+                ' (installed ' + installed + ' · total ' + visible.length + ')')),
+        h('span', { className: 'msr-spacer' }),
+        h('button', { className: 'msr-btn', onClick: function () { setOpen(!open[0]) } },
+          open[0] ? 'Collapse' : 'Review'),
+        h('button', { className: 'msr-btn ghost', onClick: function () { setDismissed({}); load() } }, 'Refresh')
+      )
+
+      var items = visible.map(function (c) {
+        return h(
+          'div', { className: 'msr-item', key: c.name },
+          h('div', { className: 'msr-item-main' },
+            h('div', { className: 'msr-item-name' },
+              c.name,
+              h('span', { className: 'msr-tag ' + c.status }, c.status)),
+            h('div', { className: 'msr-item-desc' }, c.description),
+            h('div', { className: 'msr-item-meta' },
+              c.sources.length > 0
+                ? h('span', null,
+                    'from ',
+                    c.sources.slice(0, 3).map(function (s, i) { return h('code', { key: i }, s) }),
+                    c.sources.length > 3 ? h('span', null, ' +' + (c.sources.length - 3)) : null)
+                : null,
+              ' · seen ' + c.occurrences + (c.occurrences === 1 ? ' time' : ' times'),
+              c.installedPaths.length > 0 ? ' · installed to ' + c.installedPaths[0] : null),
+            c.reason ? h('div', { className: 'msr-item-meta', style: { opacity: 0.9 } }, c.reason) : null
+          ),
+          h('div', { className: 'msr-item-actions' },
+            c.status === 'candidate'
+              ? h('button', {
+                  className: 'msr-btn primary',
+                  disabled: busy[0] === c.name,
+                  onClick: function () { act(c.name, 'review') },
+                }, 'Review')
+              : null,
+            c.status === 'candidate'
+              ? h('button', {
+                  className: 'msr-btn',
+                  disabled: busy[0] === c.name,
+                  onClick: function () { act(c.name, 'install') },
+                }, 'Install')
+              : null,
+            h('button', {
+              className: 'msr-btn ghost danger',
+              onClick: function () {
+                setDismissed(function (d) {
+                  var next = {}
+                  for (var k in d) next[k] = d[k]
+                  next[c.name] = true
+                  return next
+                })
+              },
+            }, 'Dismiss')
+          )
+        )
+      })
+
+      var panel = open[0]
+        ? h(
+            'div', { className: 'msr-panel' },
+            h('div', { className: 'msr-panel-head' },
+              h('span', { className: 'msr-panel-title' }, 'Skill candidates (.memsearch/skill-candidates/)'),
+              h('span', { className: 'msr-spacer' }),
+              h('span', null, 'Review opens in the conversation · Install runs in the background')),
+            visible.length === 0
+              ? h('div', { className: 'msr-item', style: { color: 'var(--msr-text-2)' } },
+                  loading ? 'Loading…' : 'No skill candidates.')
+              : h('div', { className: 'msr-list' }, items),
+            h('div', { className: 'msr-note' },
+              'Installation is a manual step (memsearch skills install) and is never automatic. Target directory follows plugins.dsh.memory_to_skill.paths, defaulting to ~/.agents/skills.')
+          )
+        : null
+
+      return h(
+        'div', { className: 'msr-root' },
+        bar,
+        panel,
+        toast[0] ? h('div', { className: 'msr-toast ' + toast[0].kind }, toast[0].text) : null
+      )
+    }
+
+    exports.inject = ['slots']
+
+    exports.apply = function apply(ctx) {
+      var slots = ctx.get('slots')
+      if (slots === undefined) return
+      ensureCss()
+      slots.inject('conversation.input.dock', function () {
+        return slots.register(
+          { name: 'conversation.input.dock', id: 'skill-review' },
+          function (props) {
+            return React.createElement(SkillReviewPanel, { sessionId: props.sessionId })
+          },
+        )
+      })
+    }
+
+    return module.exports
+  },
+})

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -468,6 +468,98 @@ function resolveSkillInstallTarget(memsearchCmd, projectDir) {
   return join(process.env.HOME || '', '.agents', 'skills')
 }
 
+/**
+ * Register the browser-facing skill-review JSON routes on the web server.
+ *
+ * The memsearch plugin mounts early (base bundle layer), before the DSH web
+ * server service is provided, so this must be called with the service already
+ * available — `apply` retries until it is (see the wait loop) and headless
+ * profiles never see it, so no routes are registered there.
+ */
+function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
+  const readJsonBody = (req) => new Promise((resolve) => {
+    let body = ''
+    req.on('data', (chunk) => { body += chunk })
+    req.on('end', () => {
+      try { resolve(JSON.parse(body || '{}')) } catch { resolve({}) }
+    })
+  })
+  const sendJson = (res, status, payload) => {
+    res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
+    res.end(JSON.stringify(payload))
+  }
+  // Project dir for a session id (its durable cwd), else the process cwd.
+  // A long-lived web surface serves many projects, so we never assume the
+  // boot dir is the only one (mirrors the capture path).
+  const projectDirForSession = (sessionId) => {
+    const agent = ctx.agents?.get?.(sessionId)
+    return projectDirFor(agent?.session)
+  }
+
+  webServer.register({
+    kind: 'exact',
+    path: '/memsearch-dsh/skill-candidates',
+    handler: (req, res) => {
+      if (req.method !== 'GET') return sendJson(res, 405, { error: 'method not allowed' })
+      const sessionId = new URL(req.url, 'http://localhost').searchParams.get('sessionId')
+      const projectDir = projectDirForSession(sessionId)
+      const memoryDir = memsearchDirFor(projectDir)
+      sendJson(res, 200, { candidates: listSkillCandidates(memoryDir) })
+    },
+  })
+
+  webServer.register({
+    kind: 'exact',
+    path: '/memsearch-dsh/skill-review',
+    handler: async (req, res) => {
+      if (req.method !== 'POST') return sendJson(res, 405, { error: 'method not allowed' })
+      const body = await readJsonBody(req)
+      const { sessionId, name, action } = body
+      if (!name || (action !== 'review' && action !== 'install')) {
+        return sendJson(res, 400, { error: 'name and action (review|install) are required' })
+      }
+      if (action === 'review') {
+        // Non-blocking: queue a user message into the live agent's inbox.
+        // The agent picks it up on the next turn (never interrupts a running
+        // turn, never asks the human via a blocking dialog).
+        const agent = ctx.agents?.get?.(sessionId)
+        if (!agent) {
+          return sendJson(res, 404, { error: `no live agent for session ${sessionId}` })
+        }
+        const text =
+          `[memsearch] Skill candidate "${name}" is ready for review.\n\n` +
+          `Read the candidate at .memsearch/skill-candidates/${name}/ (SKILL.md plus meta.json), ` +
+          `verify it against the cited memory journals, decide whether it is worth installing, ` +
+          `and report your recommendation to the user. Installation stays a manual step: ` +
+          `memsearch skills install ${name} --path <dir>.`
+        const message = await createMemoryMessage(ctx, text)
+        agent.inbox.append('next-turn', message)
+        return sendJson(res, 200, { ok: true, action, name, injected: true })
+      }
+      // install: background `memsearch skills install` to the resolved target.
+      // Detached + unref so the install survives the DSH process; the
+      // skill-filesystem watcher picks up the new SKILL.md automatically.
+      const projectDir = projectDirForSession(sessionId)
+      const target = resolveSkillInstallTarget(memsearchCmd, projectDir)
+      const command =
+        `${memsearchCmd} skills install '${shellEscape(name)}' ` +
+        `--path '${shellEscape(target)}'`
+      const child = execFile('bash', ['-c', command], {
+        cwd: projectDir,
+        timeout: 60000,
+        maxBuffer: 4 * 1024 * 1024,
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env, MEMSEARCH_NO_WATCH: '1' },
+      }, (error) => {
+        if (error) ctx.logger.warn(`[memsearch] skill install failed: ${error.message}`)
+      })
+      child.unref()
+      return sendJson(res, 200, { ok: true, action, name, started: true, target })
+    },
+  })
+}
+
 /** Compact human-readable memory block injected into the request. */
 function renderMemoryBlock(chunks) {
   const lines = chunks.map((chunk, index) => {
@@ -960,94 +1052,26 @@ export function apply(ctx, config = {}) {
   })
 
   // --- Skill review panel: browser-facing JSON API (web only) ---
-  // Served on the DSH web server so the client panel can list candidates and
-  // trigger review / install. The webServer service is optional: headless
-  // profiles have no browser UI and simply skip these routes. Guarded with a
-  // feature check so plain-object test contexts (and non-Cordis hosts) no-op.
-  const webServer = typeof ctx.get === 'function' ? ctx.get('webServer') : undefined
-  if (webServer) {
-    const readJsonBody = (req) => new Promise((resolve) => {
-      let body = ''
-      req.on('data', (chunk) => { body += chunk })
-      req.on('end', () => {
-        try { resolve(JSON.parse(body || '{}')) } catch { resolve({}) }
-      })
-    })
-    const sendJson = (res, status, payload) => {
-      res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
-      res.end(JSON.stringify(payload))
+  // The memsearch plugin mounts in the base bundle layer, before the DSH web
+  // server service exists. Retry until the service appears (web profile) or
+  // give up silently (headless / tui profiles never provide it). The retry
+  // timer is unref'd so it never keeps the process alive, and the routes are
+  // registered exactly once.
+  let skillReviewAttempted = false
+  const tryRegisterSkillReview = () => {
+    if (skillReviewAttempted) return
+    const webServer = typeof ctx.get === 'function' ? ctx.get('webServer') : undefined
+    if (webServer === undefined) return // not available yet; retry later
+    skillReviewAttempted = true
+    try {
+      registerSkillReviewRoutes(ctx, webServer, memsearchCmd)
+    } catch (error) {
+      ctx.logger.warn(`[memsearch] skill-review route registration failed: ${error.message}`)
     }
-    // Project dir for a session id (its durable cwd), else the process cwd.
-    // A long-lived web surface serves many projects, so we never assume the
-    // boot dir is the only one (mirrors the capture path).
-    const projectDirForSession = (sessionId) => {
-      const agent = ctx.agents?.get?.(sessionId)
-      return projectDirFor(agent?.session)
-    }
-
-    webServer.register({
-      kind: 'exact',
-      path: '/memsearch-dsh/skill-candidates',
-      handler: (req, res) => {
-        if (req.method !== 'GET') return sendJson(res, 405, { error: 'method not allowed' })
-        const sessionId = new URL(req.url, 'http://localhost').searchParams.get('sessionId')
-        const projectDir = projectDirForSession(sessionId)
-        const memoryDir = memsearchDirFor(projectDir)
-        sendJson(res, 200, { candidates: listSkillCandidates(memoryDir) })
-      },
-    })
-
-    webServer.register({
-      kind: 'exact',
-      path: '/memsearch-dsh/skill-review',
-      handler: async (req, res) => {
-        if (req.method !== 'POST') return sendJson(res, 405, { error: 'method not allowed' })
-        const body = await readJsonBody(req)
-        const { sessionId, name, action } = body
-        if (!name || (action !== 'review' && action !== 'install')) {
-          return sendJson(res, 400, { error: 'name and action (review|install) are required' })
-        }
-        if (action === 'review') {
-          // Non-blocking: queue a user message into the live agent's inbox.
-          // The agent picks it up on the next turn (never interrupts a running
-          // turn, never asks the human via a blocking dialog).
-          const agent = ctx.agents?.get?.(sessionId)
-          if (!agent) {
-            return sendJson(res, 404, { error: `no live agent for session ${sessionId}` })
-          }
-          const text =
-            `[memsearch] Skill candidate "${name}" is ready for review.\n\n` +
-            `Read the candidate at .memsearch/skill-candidates/${name}/ (SKILL.md plus meta.json), ` +
-            `verify it against the cited memory journals, decide whether it is worth installing, ` +
-            `and report your recommendation to the user. Installation stays a manual step: ` +
-            `memsearch skills install ${name} --path <dir>.`
-          const message = await createMemoryMessage(ctx, text)
-          agent.inbox.append('next-turn', message)
-          return sendJson(res, 200, { ok: true, action, name, injected: true })
-        }
-        // install: background `memsearch skills install` to the resolved target.
-        // Detached + unref so the install survives the DSH process; the
-        // skill-filesystem watcher picks up the new SKILL.md automatically.
-        const projectDir = projectDirForSession(sessionId)
-        const target = resolveSkillInstallTarget(memsearchCmd, projectDir)
-        const command =
-          `${memsearchCmd} skills install '${shellEscape(name)}' ` +
-          `--path '${shellEscape(target)}'`
-        const child = execFile('bash', ['-c', command], {
-          cwd: projectDir,
-          timeout: 60000,
-          maxBuffer: 4 * 1024 * 1024,
-          detached: true,
-          stdio: 'ignore',
-          env: { ...process.env, MEMSEARCH_NO_WATCH: '1' },
-        }, (error) => {
-          if (error) ctx.logger.warn(`[memsearch] skill install failed: ${error.message}`)
-        })
-        child.unref()
-        return sendJson(res, 200, { ok: true, action, name, started: true, target })
-      },
-    })
   }
+  tryRegisterSkillReview()
+  const skillReviewTimer = setInterval(tryRegisterSkillReview, 1000)
+  skillReviewTimer.unref?.()
 
   // Warm the index for this project once at startup (fire-and-forget).
   const bootMemoryDir = memoryDirFor(bootProjectDir)
@@ -1092,6 +1116,9 @@ export { memsearchDirFor }
 
 /** Read skill candidates from the `.memsearch/skill-candidates` directory. */
 export { listSkillCandidates }
+
+/** Register the skill-review JSON routes on a web server service. */
+export { registerSkillReviewRoutes }
 
 /** Resolve the distilled-skill install target (paths config, else ~/.agents/skills). */
 export { resolveSkillInstallTarget }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -393,6 +393,81 @@ function runMaintenance(ctx, projectDir, memsearchDir) {
   child.unref()
 }
 
+// ---------------------------------------------------------------------------
+// Skill review panel (host side)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read every skill candidate from the `.memsearch/skill-candidates` directory.
+ *
+ * The candidates directory is the shared memory-to-skill output across all
+ * platform plugins (git-tracked, never auto-installed). Each subdirectory
+ * carries a `meta.json` plus a `SKILL.md` draft; a candidate whose status is
+ * `candidate` is pending human review, `installed` means it was already
+ * copied to an agent skill directory.
+ * @param memsearchDir - the project's `.memsearch` directory.
+ * @returns a stable array of candidate summaries (pending first, then name).
+ */
+function listSkillCandidates(memsearchDir) {
+  const candidatesDir = join(memsearchDir, 'skill-candidates')
+  let entries
+  try {
+    entries = readdirSync(candidatesDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const out = []
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const metaPath = join(candidatesDir, entry.name, 'meta.json')
+    let meta
+    try {
+      meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    } catch {
+      continue // malformed or missing meta — not a candidate
+    }
+    out.push({
+      name: meta.name || entry.name,
+      status: meta.status || 'candidate',
+      description: typeof meta.description === 'string' ? meta.description : '',
+      occurrences: typeof meta.occurrences === 'number' ? meta.occurrences : 0,
+      sources: Array.isArray(meta.sources) ? meta.sources : [],
+      reason: typeof meta.reason === 'string' ? meta.reason : '',
+      installedPaths: Array.isArray(meta.installed_paths) ? meta.installed_paths : [],
+      updatedAt: meta.updated_at || meta.created_at || '',
+    })
+  }
+  out.sort((a, b) => {
+    const pa = a.status === 'candidate' ? 0 : 1
+    const pb = b.status === 'candidate' ? 0 : 1
+    return pa - pb || a.name.localeCompare(b.name)
+  })
+  return out
+}
+
+/**
+ * Resolve the install target directory for a distilled skill on DSH.
+ *
+ * Mirrors the other platform plugins: the destination is the first entry of
+ * `plugins.<agent>.memory_to_skill.paths` in memsearch config when the user
+ * set one (relative entries resolve against the project dir); otherwise DSH's
+ * default user-agents skill directory (`~/.agents/skills`), which the
+ * `skill-filesystem` provider watches and loads automatically.
+ */
+function resolveSkillInstallTarget(memsearchCmd, projectDir) {
+  const read = readMemsearchConfigValue(memsearchCmd, 'plugins.dsh.memory_to_skill.paths')
+  if (read.ok && read.value) {
+    try {
+      const paths = JSON.parse(read.value)
+      if (Array.isArray(paths) && paths.length > 0) {
+        const first = String(paths[0])
+        return join(first.startsWith('/') ? first : projectDir, first)
+      }
+    } catch { /* fall through to the DSH default */ }
+  }
+  return join(process.env.HOME || '', '.agents', 'skills')
+}
+
 /** Compact human-readable memory block injected into the request. */
 function renderMemoryBlock(chunks) {
   const lines = chunks.map((chunk, index) => {
@@ -884,6 +959,96 @@ export function apply(ctx, config = {}) {
     }
   })
 
+  // --- Skill review panel: browser-facing JSON API (web only) ---
+  // Served on the DSH web server so the client panel can list candidates and
+  // trigger review / install. The webServer service is optional: headless
+  // profiles have no browser UI and simply skip these routes. Guarded with a
+  // feature check so plain-object test contexts (and non-Cordis hosts) no-op.
+  const webServer = typeof ctx.get === 'function' ? ctx.get('webServer') : undefined
+  if (webServer) {
+    const readJsonBody = (req) => new Promise((resolve) => {
+      let body = ''
+      req.on('data', (chunk) => { body += chunk })
+      req.on('end', () => {
+        try { resolve(JSON.parse(body || '{}')) } catch { resolve({}) }
+      })
+    })
+    const sendJson = (res, status, payload) => {
+      res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify(payload))
+    }
+    // Project dir for a session id (its durable cwd), else the process cwd.
+    // A long-lived web surface serves many projects, so we never assume the
+    // boot dir is the only one (mirrors the capture path).
+    const projectDirForSession = (sessionId) => {
+      const agent = ctx.agents?.get?.(sessionId)
+      return projectDirFor(agent?.session)
+    }
+
+    webServer.register({
+      kind: 'exact',
+      path: '/memsearch-dsh/skill-candidates',
+      handler: (req, res) => {
+        if (req.method !== 'GET') return sendJson(res, 405, { error: 'method not allowed' })
+        const sessionId = new URL(req.url, 'http://localhost').searchParams.get('sessionId')
+        const projectDir = projectDirForSession(sessionId)
+        const memoryDir = memsearchDirFor(projectDir)
+        sendJson(res, 200, { candidates: listSkillCandidates(memoryDir) })
+      },
+    })
+
+    webServer.register({
+      kind: 'exact',
+      path: '/memsearch-dsh/skill-review',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') return sendJson(res, 405, { error: 'method not allowed' })
+        const body = await readJsonBody(req)
+        const { sessionId, name, action } = body
+        if (!name || (action !== 'review' && action !== 'install')) {
+          return sendJson(res, 400, { error: 'name and action (review|install) are required' })
+        }
+        if (action === 'review') {
+          // Non-blocking: queue a user message into the live agent's inbox.
+          // The agent picks it up on the next turn (never interrupts a running
+          // turn, never asks the human via a blocking dialog).
+          const agent = ctx.agents?.get?.(sessionId)
+          if (!agent) {
+            return sendJson(res, 404, { error: `no live agent for session ${sessionId}` })
+          }
+          const text =
+            `[memsearch] Skill candidate "${name}" is ready for review.\n\n` +
+            `Read the candidate at .memsearch/skill-candidates/${name}/ (SKILL.md plus meta.json), ` +
+            `verify it against the cited memory journals, decide whether it is worth installing, ` +
+            `and report your recommendation to the user. Installation stays a manual step: ` +
+            `memsearch skills install ${name} --path <dir>.`
+          const message = await createMemoryMessage(ctx, text)
+          agent.inbox.append('next-turn', message)
+          return sendJson(res, 200, { ok: true, action, name, injected: true })
+        }
+        // install: background `memsearch skills install` to the resolved target.
+        // Detached + unref so the install survives the DSH process; the
+        // skill-filesystem watcher picks up the new SKILL.md automatically.
+        const projectDir = projectDirForSession(sessionId)
+        const target = resolveSkillInstallTarget(memsearchCmd, projectDir)
+        const command =
+          `${memsearchCmd} skills install '${shellEscape(name)}' ` +
+          `--path '${shellEscape(target)}'`
+        const child = execFile('bash', ['-c', command], {
+          cwd: projectDir,
+          timeout: 60000,
+          maxBuffer: 4 * 1024 * 1024,
+          detached: true,
+          stdio: 'ignore',
+          env: { ...process.env, MEMSEARCH_NO_WATCH: '1' },
+        }, (error) => {
+          if (error) ctx.logger.warn(`[memsearch] skill install failed: ${error.message}`)
+        })
+        child.unref()
+        return sendJson(res, 200, { ok: true, action, name, started: true, target })
+      },
+    })
+  }
+
   // Warm the index for this project once at startup (fire-and-forget).
   const bootMemoryDir = memoryDirFor(bootProjectDir)
   if (bootCollection && hasMemoryFiles(bootMemoryDir)) {
@@ -924,3 +1089,9 @@ export { runMaintenance }
 
 /** Memory dir for a project (MEMSEARCH_DIR env override, else <project>/.memsearch). */
 export { memsearchDirFor }
+
+/** Read skill candidates from the `.memsearch/skill-candidates` directory. */
+export { listSkillCandidates }
+
+/** Resolve the distilled-skill install target (paths config, else ~/.agents/skills). */
+export { resolveSkillInstallTarget }

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zilliz/memsearch-dsh",
-  "version": "0.1.1",
-  "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, and memory-recall skill.",
+  "version": "0.1.2",
+  "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, memory-recall skill, and a skill-candidate review panel.",
   "type": "module",
   "main": "index.js",
   "exports": {
@@ -9,11 +9,13 @@
       "types": null,
       "default": "./index.js"
     },
+    "./client": "./client.js",
     "./cordis.patch.yml": "./cordis.patch.yml",
     "./package.json": "./package.json"
   },
   "files": [
     "index.js",
+    "client.js",
     "cordis.patch.yml",
     "prompts/",
     "skills/",
@@ -36,6 +38,9 @@
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web"
     }
   },
   "dependencies": {},

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 
-import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor } from '../index.js'
+import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
 test('detectDshCmd: prefers dsh on PATH as a plain argv', () => {
   // DSH_CLI is checked after PATH; simulate PATH hit by masking DSH_CLI.
   const prevCli = process.env.DSH_CLI
@@ -614,4 +614,66 @@ test('runMaintenance: is exported and tolerant of a missing project dir', async 
   // No throw is the assertion; the child is detached + unref'd.
   await new Promise((r) => setTimeout(r, 200))
   assert.ok(true, 'runMaintenance returned without throwing')
+})
+
+test('listSkillCandidates: returns parsed meta for each candidate subdir, pending first', () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-list-')
+  const candDir = `${tmp}/skill-candidates`
+  fs.mkdirSync(`${candDir}/beta`, { recursive: true })
+  fs.mkdirSync(`${candDir}/alpha`, { recursive: true })
+  fs.mkdirSync(`${candDir}/no-meta`, { recursive: true })
+  fs.mkdirSync(`${candDir}/sub/not-a-dir`, { recursive: true })
+  fs.writeFileSync(`${candDir}/beta/meta.json`, JSON.stringify({
+    name: 'beta', status: 'installed', description: 'B', occurrences: 5,
+    sources: ['2026-01-01.md'], installed_paths: ['/tmp/.agents/skills/beta'],
+  }))
+  fs.writeFileSync(`${candDir}/alpha/meta.json`, JSON.stringify({
+    name: 'alpha', status: 'candidate', description: 'A', occurrences: 3,
+    sources: ['2026-01-02.md'], reason: 'Recurred across sessions',
+  }))
+  // no-meta has no meta.json → skipped; sub is not a file entry
+  fs.writeFileSync(`${candDir}/no-meta/SKILL.md`, 'x')
+
+  
+  const out = listSkillCandidates(tmp)
+  assert.deepEqual(out.map((c) => c.name), ['alpha', 'beta'], 'pending candidate sorts first')
+  const alpha = out[0]
+  assert.equal(alpha.status, 'candidate')
+  assert.equal(alpha.description, 'A')
+  assert.equal(alpha.occurrences, 3)
+  assert.deepEqual(alpha.sources, ['2026-01-02.md'])
+  assert.equal(alpha.reason, 'Recurred across sessions')
+  assert.deepEqual(alpha.installedPaths, [])
+  const beta = out[1]
+  assert.equal(beta.status, 'installed')
+  assert.deepEqual(beta.installedPaths, ['/tmp/.agents/skills/beta'])
+})
+
+test('listSkillCandidates: empty or missing dir returns []', () => {
+  
+  assert.deepEqual(listSkillCandidates('/nonexistent/path-xyz'), [])
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-empty-')
+  assert.deepEqual(listSkillCandidates(tmp), [])
+})
+
+test('listSkillCandidates: malformed meta.json is skipped, not fatal', () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-bad-')
+  const candDir = `${tmp}/skill-candidates`
+  fs.mkdirSync(`${candDir}/broken`, { recursive: true })
+  fs.writeFileSync(`${candDir}/broken/meta.json`, '{not json')
+  fs.mkdirSync(`${candDir}/good`, { recursive: true })
+  fs.writeFileSync(`${candDir}/good/meta.json`, JSON.stringify({ name: 'good', status: 'candidate' }))
+  
+  const out = listSkillCandidates(tmp)
+  assert.equal(out.length, 1)
+  assert.equal(out[0].name, 'good')
+  assert.equal(out[0].status, 'candidate')
+  assert.equal(out[0].occurrences, 0, 'missing occurrences defaults to 0')
+})
+
+test('resolveSkillInstallTarget: paths config entry wins, relative resolves against project', () => {
+  
+  const target = resolveSkillInstallTarget('memsearch', '/proj')
+  // No configured paths on this machine → DSH default ~/.agents/skills.
+  assert.ok(target.endsWith('/.agents/skills'), `expected ~/.agents/skills default, got ${target}`)
 })

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -677,3 +677,102 @@ test('resolveSkillInstallTarget: paths config entry wins, relative resolves agai
   // No configured paths on this machine → DSH default ~/.agents/skills.
   assert.ok(target.endsWith('/.agents/skills'), `expected ~/.agents/skills default, got ${target}`)
 })
+
+test('registerSkillReviewRoutes: GET candidates returns parsed list, pending first', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-route-')
+  const candDir = `${tmp}/skill-candidates`
+  fs.mkdirSync(`${candDir}/zeta`, { recursive: true })
+  fs.mkdirSync(`${candDir}/alpha`, { recursive: true })
+  fs.writeFileSync(`${candDir}/zeta/meta.json`, JSON.stringify({ name: 'zeta', status: 'installed' }))
+  fs.writeFileSync(`${candDir}/alpha/meta.json`, JSON.stringify({ name: 'alpha', status: 'candidate', description: 'A' }))
+
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  const ctx = {
+    agents: { get: () => undefined },
+    logger: { warn: () => {} },
+  }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  // memsearchDirFor reads MEMSEARCH_DIR env; point it at the temp dir.
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const getRoute = routes['/memsearch-dsh/skill-candidates']
+    assert.ok(getRoute, 'GET route registered')
+    const res = { writeHead: (s) => { res.status = s }, end: (b) => { res.body = JSON.parse(b) } }
+    getRoute.handler({ method: 'GET', url: '/memsearch-dsh/skill-candidates' }, res)
+    assert.equal(res.status, 200)
+    assert.deepEqual(res.body.candidates.map((c) => c.name), ['alpha', 'zeta'], 'pending first')
+    assert.equal(res.body.candidates[0].description, 'A')
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})
+
+test('registerSkillReviewRoutes: GET rejects non-GET, POST review injects into agent inbox', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-route2-')
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  let appended = null
+  const fakeAgent = {
+    inbox: { append: (target, msg) => { appended = { target, msg } } },
+  }
+  const ctx = {
+    agents: { get: (id) => (id === 'sess-1' ? fakeAgent : undefined) },
+    logger: { warn: () => {} },
+  }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const getRoute = routes['/memsearch-dsh/skill-candidates']
+    const res = { writeHead: (s) => { res.status = s }, end: (b) => { res.body = JSON.parse(b) } }
+    getRoute.handler({ method: 'POST', url: '/x' }, res)
+    assert.equal(res.status, 405)
+
+    const postRoute = routes['/memsearch-dsh/skill-review']
+    const { EventEmitter } = await import('node:events')
+    const req = Object.assign(new EventEmitter(), { method: 'POST' })
+    const pr = { writeHead: (s) => { pr.status = s }, end: (b) => { pr.body = JSON.parse(b) } }
+    const done = postRoute.handler(req, pr)
+    req.emit('data', JSON.stringify({ sessionId: 'sess-1', name: 'alpha', action: 'review' }))
+    req.emit('end')
+    await done
+    assert.equal(pr.status, 200)
+    assert.equal(pr.body.injected, true)
+    assert.ok(appended, 'inbox append called')
+    assert.equal(appended.target, 'next-turn')
+    assert.ok(appended.msg.content[0].text.startsWith('[memsearch] Skill candidate "alpha"'), 'message text')
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})
+
+test('registerSkillReviewRoutes: POST review with unknown session returns 404', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-route3-')
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const postRoute = routes['/memsearch-dsh/skill-review']
+    const { EventEmitter } = await import('node:events')
+    const req = Object.assign(new EventEmitter(), { method: 'POST' })
+    const pr = { writeHead: (s) => { pr.status = s }, end: (b) => { pr.body = JSON.parse(b) } }
+    const done = postRoute.handler(req, pr)
+    req.emit('data', JSON.stringify({ sessionId: 'ghost', name: 'alpha', action: 'review' }))
+    req.emit('end')
+    await done
+    assert.equal(pr.status, 404)
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})


### PR DESCRIPTION
## Summary

Adds a browser half to the @zilliz/memsearch-dsh plugin: a non-blocking skill-candidate review strip docked above the web composer. Distilled skill candidates under `.memsearch/skill-candidates/` are listed from their `meta.json` (pending first), and each pending candidate exposes **Review** and **Install** actions.

## Behavior

- **Review** — queues a `[memsearch] Skill candidate ...` user message into the live agent's inbox (`agent.inbox.append('next-turn', ...)`). The agent reviews the candidate on its next turn: non-blocking, never interrupts a running turn, never opens a blocking dialog.
- **Install** — runs `memsearch skills install <name> --path <dir>` in the background (detached) to the resolved target:
  1. `plugins.dsh.memory_to_skill.paths` first entry from memsearch config (relative entries resolve against the project dir), else
  2. `~/.agents/skills` — the DSH `skill-filesystem` provider default, which is watched and auto-loaded.

## Implementation

- **Client** (`plugins/dsh/client.js`): prebuilt client-module bundle registered via `window.__ModuleLoader__.load` (lazy CJS table, Cordis client plugin shape with `inject` + `apply`), declared through `dsh.client` in `package.json` with an `exports[\"./client\"]` entry. UI uses DSH theme tokens, so light/dark adapt automatically. English copy only.
- **Host** (`plugins/dsh/index.js`): two JSON routes on the DSH web server when `webServer` is present — `GET /memsearch-dsh/skill-candidates?sessionId=...` and `POST /memsearch-dsh/skill-review` — plus `listSkillCandidates` and `resolveSkillInstallTarget` helpers. The project directory is resolved from the session id (durable cwd), so a multi-project web surface shows the candidates of the session you are viewing. Headless/TUI profiles have no `webServer` and skip the routes (no behavior change).

## Tests

`plugins/dsh/tests/index.test.js` grows unit tests for `listSkillCandidates` (parsing, sorting pending-first, malformed/empty handling) and `resolveSkillInstallTarget`. Full suite: 33/33 passing.

## Notes

- Installation stays a human step everywhere (candidates are never auto-installed), mirroring the other platform plugins.
- The panel renders in every DSH preset (standard/code/minimal/cordis) because the web UI is host-plane; `minimal` lacks the `skill` tool, so only its agent cannot act on the injected review message (documented behavior, no code change needed).
- Version bumped to 0.1.2 (npm publish follows after merge).