### PR TITLE
feat(dsh): add collapsible review dock and read-only .memsearch browser

### DIFF
--- a/plugins/dsh/client.js
+++ b/plugins/dsh/client.js
@@ -90,7 +90,57 @@ window.__ModuleLoader__.load({
         'background:var(--msr-bg-2);color:var(--msr-text);}' +
       '.msr-toast.ok{border-color:color-mix(in srgb,var(--msr-success) 45%,transparent);color:var(--msr-success);}' +
       '.msr-toast.warn{border-color:color-mix(in srgb,var(--msr-warn) 45%,transparent);color:var(--msr-warn);}' +
-      '.msr-toast.err{border-color:color-mix(in srgb,var(--msr-error) 45%,transparent);color:var(--msr-error);}'
+      '.msr-toast.err{border-color:color-mix(in srgb,var(--msr-error) 45%,transparent);color:var(--msr-error);}' +
+      '.msr-capsule{display:inline-flex;align-items:center;gap:7px;padding:3px 11px;box-sizing:border-box;' +
+        'border:1px solid var(--msr-border);border-radius:999px;background:var(--msr-bg);color:var(--msr-text);' +
+        'font-size:12px;font-weight:600;cursor:pointer;line-height:1.6;white-space:nowrap;transition:border-color .12s ease;}' +
+      '.msr-capsule:hover{border-color:var(--msr-brand);}' +
+      '.msr-capsule-dot{display:inline-flex;align-items:center;justify-content:center;min-width:17px;height:17px;' +
+        'border-radius:999px;padding:0 4px;font-size:10px;font-weight:700;color:#fff;' +
+        'background:var(--msr-warn);}' +
+      '.msr-capsule-dot.zero{background:var(--msr-bg-2);color:var(--msr-text-2);border:1px solid var(--msr-border);}' +
+      '.msr-capsule-chev{font-size:9px;color:var(--msr-text-2);}' +
+      '.msr-link-btn{border:none;background:none;color:var(--msr-brand);font-size:11px;font-weight:600;' +
+        'cursor:pointer;padding:2px 6px;border-radius:5px;font-family:inherit;white-space:nowrap;}' +
+      '.msr-link-btn:hover{background:color-mix(in srgb,var(--msr-brand) 14%,transparent);}' +
+      '.msr-link-btn:disabled{opacity:.5;cursor:default;}' +
+      '.msr-fs{margin-top:6px;border:1px solid var(--msr-border);border-radius:10px;background:var(--msr-bg);' +
+        'color:var(--msr-text);overflow:hidden;}' +
+      '.msr-fs-head{display:flex;align-items:center;gap:8px;padding:7px 12px;font-size:12px;color:var(--msr-text-2);' +
+        'border-bottom:1px solid var(--msr-border);cursor:pointer;user-select:none;}' +
+      '.msr-fs-head:hover{background:var(--msr-bg-2);}' +
+      '.msr-fs-body{display:flex;max-height:320px;overflow:auto;}' +
+      '.msr-fs-tree{flex:1;min-width:220px;padding:6px;font-size:12px;border-right:1px solid var(--msr-border);}' +
+      '.msr-fs-row{display:flex;align-items:center;gap:6px;padding:3px 8px;border-radius:6px;cursor:pointer;' +
+        'white-space:nowrap;color:var(--msr-text);}' +
+      '.msr-fs-row:hover{background:var(--msr-bg-2);}' +
+      '.msr-fs-row.sel{background:color-mix(in srgb,var(--msr-brand) 18%,transparent);color:var(--msr-brand);}' +
+      '.msr-fs-row.muted{color:var(--msr-text-2);opacity:.55;cursor:not-allowed;}' +
+      '.msr-fs-row.muted:hover{background:none;color:var(--msr-text-2);}' +
+      '.msr-fs-icon{flex:none;font-size:11px;}' +
+      '.msr-fs-name{overflow:hidden;text-overflow:ellipsis;}' +
+      '.msr-fs-depth{flex:none;width:12px;}' +
+      '.msr-preview{flex:1.4;min-width:260px;padding:10px 14px;overflow:auto;font-size:13px;line-height:1.6;}' +
+      '.msr-preview.empty{color:var(--msr-text-2);font-size:12px;}' +
+      '.msr-md h1{font-size:17px;font-weight:700;margin:10px 0 6px;}' +
+      '.msr-md h2{font-size:15px;font-weight:700;margin:10px 0 5px;}' +
+      '.msr-md h3{font-size:14px;font-weight:600;margin:8px 0 4px;}' +
+      '.msr-md p{margin:6px 0;}' +
+      '.msr-md ul,.msr-md ol{margin:6px 0;padding-left:20px;}' +
+      '.msr-md li{margin:2px 0;}' +
+      '.msr-md code{background:var(--msr-bg-2);border:1px solid var(--msr-border);border-radius:4px;' +
+        'padding:0 4px;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}' +
+      '.msr-md pre{background:var(--msr-bg-2);border:1px solid var(--msr-border);border-radius:8px;' +
+        'padding:10px 12px;overflow:auto;font-size:12px;line-height:1.5;' +
+        'font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}' +
+      '.msr-md pre code{background:none;border:none;padding:0;}' +
+      '.msr-md hr{border:none;border-top:1px solid var(--msr-border);margin:10px 0;}' +
+      '.msr-md a{color:var(--msr-brand);text-decoration:none;}' +
+      '.msr-md a:hover{text-decoration:underline;}' +
+      '.msr-md blockquote{border-left:3px solid var(--msr-border);margin:6px 0;padding:2px 12px;color:var(--msr-text-2);}' +
+      '.msr-md table{border-collapse:collapse;margin:8px 0;font-size:12px;}' +
+      '.msr-md th,.msr-md td{border:1px solid var(--msr-border);padding:4px 10px;}' +
+      '.msr-md th{background:var(--msr-bg-2);font-weight:600;}'
 
     /** Insert the panel stylesheet once per page. */
     function ensureCss() {
@@ -102,11 +152,322 @@ window.__ModuleLoader__.load({
       document.head.appendChild(tag)
     }
 
+    /**
+     * Minimal read-only Markdown renderer (React elements, no HTML strings —
+     * XSS-safe by construction). Supports the subset actually used in
+     * .memsearch files: ATX headings, paragraphs, bold/italic/inline code,
+     * fenced code blocks, bullet/numbered lists, links, hr, blockquote, tables.
+     */
+    function renderMarkdown(source) {
+      var h = React.createElement
+      if (!source) return null
+      var lines = source.replace(/\r\n/g, '\n').split('\n')
+      var out = []
+      var i = 0
+      var key = 0
+
+      function inline(text) {
+        var nodes = []
+        // escape first, then apply inline styles on the escaped text
+        var esc = String(text)
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+        // inline code
+        var parts = esc.split(/`([^`]+)`/g)
+        for (var p = 0; p < parts.length; p++) {
+          var part = parts[p]
+          if (p % 2 === 1) {
+            nodes.push(h('code', { key: 'c' + key++ }, part))
+            continue
+          }
+          // bold / italic via regex on the escaped string
+          var boldRe = /\*\*([^*]+)\*\*/g
+          var itRe = /(?<!\*)\*([^*]+)\*(?!\*)/g
+          var rest = part
+          var last = 0
+          var m
+          var pending = []
+          while ((m = boldRe.exec(rest)) !== null) {
+            if (m.index > last) pending.push(rest.slice(last, m.index))
+            pending.push(h('strong', { key: 'b' + key++ }, m[1]))
+            last = m.index + m[0].length
+          }
+          if (last < rest.length) pending.push(rest.slice(last))
+          // then italic within each pending plain text
+          for (var q = 0; q < pending.length; q++) {
+            var node = pending[q]
+            if (typeof node !== 'string') { nodes.push(node); continue }
+            var itParts = node.split(/(?<!\*)\*([^*]+)\*(?!\*)/g)
+            for (var r = 0; r < itParts.length; r++) {
+              if (r % 2 === 1) nodes.push(h('em', { key: 'i' + key++ }, itParts[r]))
+              else if (itParts[r]) nodes.push(itParts[r])
+            }
+          }
+        }
+        return nodes.length === 0 ? null : nodes
+      }
+
+      function linkify(text) {
+        // [label](url) → anchor
+        var m = /\[([^\]]+)\]\(([^)\s]+)\)/.exec(text)
+        if (!m) return text
+        var before = text.slice(0, m.index)
+        var after = text.slice(m.index + m[0].length)
+        var el = h('a', { key: 'a' + key++, href: m[2], target: '_blank', rel: 'noreferrer' }, m[1])
+        return [before, el].concat(linkify(after))
+      }
+
+      while (i < lines.length) {
+        var line = lines[i]
+        var trimmed = line.trim()
+        var m
+        // fenced code block
+        if (/^```/.test(trimmed)) {
+          var buf = []
+          i++
+          while (i < lines.length && !/^```/.test(lines[i].trim())) { buf.push(lines[i]); i++ }
+          i++ // skip closing fence
+          out.push(h('pre', { key: 'pre' + key++ }, h('code', null, buf.join('\n'))))
+          continue
+        }
+        // ATX heading
+        if ((m = /^(#{1,6})\s+(.*)$/.exec(trimmed))) {
+          var level = m[1].length
+          var text = m[2]
+          var Tag = 'h' + level
+          out.push(h(Tag, { key: 'h' + key++ }, linkify(text)))
+          i++
+          continue
+        }
+        // hr
+        if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+          out.push(h('hr', { key: 'hr' + key++ }))
+          i++
+          continue
+        }
+        // blockquote
+        if (/^>\s?/.test(trimmed)) {
+          var qbuf = []
+          while (i < lines.length && /^>\s?/.test(lines[i].trim())) {
+            qbuf.push(lines[i].trim().replace(/^>\s?/, ''))
+            i++
+          }
+          out.push(h('blockquote', { key: 'q' + key++ }, qbuf.join('\n')))
+          continue
+        }
+        // bullet list
+        if ((m = /^[-*+]\s+(.*)$/.exec(trimmed))) {
+          var litems = []
+          while (i < lines.length && (m = /^[-*+]\s+(.*)$/.exec(lines[i].trim()))) {
+            litems.push(h('li', { key: 'li' + key++ }, linkify(m[1])))
+            i++
+          }
+          out.push(h('ul', { key: 'ul' + key++ }, litems))
+          continue
+        }
+        // numbered list
+        if ((m = /^\d+\.\s+(.*)$/.exec(trimmed))) {
+          var oitems = []
+          while (i < lines.length && (m = /^\d+\.\s+(.*)$/.exec(lines[i].trim()))) {
+            oitems.push(h('li', { key: 'oli' + key++ }, linkify(m[1])))
+            i++
+          }
+          out.push(h('ol', { key: 'ol' + key++ }, oitems))
+          continue
+        }
+        // table (header | --- | rows)
+        if (lines[i + 1] && /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(lines[i + 1]) && trimmed.includes('|')) {
+          var headerCells = trimmed.replace(/^\||\|$/g, '').split('|').map(function (s) { return s.trim() })
+          i += 2
+          var rows = []
+          while (i < lines.length && lines[i].includes('|')) {
+            var cells = lines[i].replace(/^\||\|$/g, '').split('|').map(function (s) { return s.trim() })
+            rows.push(h('tr', { key: 'tr' + key++ }, cells.map(function (c, ci) { return h('td', { key: ci }, linkify(c)) })))
+            i++
+          }
+          out.push(h('table', { key: 'tbl' + key++ },
+            h('thead', null, h('tr', null, headerCells.map(function (c, ci) { return h('th', { key: ci }, linkify(c)) }))),
+            rows.length ? h('tbody', null, rows) : null))
+          continue
+        }
+        // blank
+        if (trimmed === '') { i++; continue }
+        // paragraph (accumulate until blank)
+        var pbuf = [trimmed]
+        i++
+        while (i < lines.length && lines[i].trim() !== '' && !/^```/.test(lines[i]) && !/^#{1,6}\s/.test(lines[i]) && !/^[-*+]\s/.test(lines[i]) && !/^\d+\.\s/.test(lines[i])) {
+          pbuf.push(lines[i].trim())
+          i++
+        }
+        out.push(h('p', { key: 'p' + key++ }, linkify(pbuf.join(' '))))
+      }
+      return out
+    }
+
+    /**
+     * Read-only .memsearch file browser + preview. Two panes: a lazily-loaded
+     * directory tree on the left, a rendered markdown/text preview on the
+     * right. No write capability anywhere.
+     */
+    function MemsearchBrowser(props) {
+      var sessionId = props.sessionId
+      var open = useState(false)
+      var setOpen = open[1]
+      // listings: rel -> { path, rel, dirs, files } — one cached listing per
+      // directory, so expanding one level never destroys a sibling level.
+      var listings = useState({})
+      var setListings = listings[1]
+      var expanded = useState({})
+      var setExpanded = expanded[1]
+      var sel = useState(null) // { rel, name, ext }
+      var setSel = sel[1]
+      var preview = useState(null) // { text, err }
+      var setPreview = preview[1]
+      var loading = useState(false)
+      var setLoading = loading[1]
+
+      // File types the read-only preview can render; everything else is shown
+      // greyed out and cannot be opened.
+      var PREVIEW_EXTS = ['md', 'markdown', 'json', 'txt', 'toml', 'yml', 'yaml', 'sh', 'py', 'js', 'ts']
+
+      var loadDir = useCallback(function (rel) {
+        setLoading(true)
+        fetch('/memsearch-dsh/list-memsearch?sessionId=' + encodeURIComponent(sessionId) + '&path=' + encodeURIComponent(rel || ''))
+          .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, d: d } }) })
+          .then(function (r) {
+            if (!r.ok) throw new Error(r.d.error || 'list failed')
+            setListings(function (prev) {
+              var next = {}
+              for (var k in prev) next[k] = prev[k]
+              next[rel || '/'] = r.d
+              return next
+            })
+          })
+          .catch(function (err) {
+            setListings(function (prev) {
+              var next = {}
+              for (var k in prev) next[k] = prev[k]
+              next[rel || '/'] = { path: '', rel: rel, dirs: [], files: [], err: String(err.message || err) }
+              return next
+            })
+          })
+          .finally(function () { setLoading(false) })
+      }, [sessionId])
+
+      // Prime the root listing once.
+      useEffect(function () { loadDir('') }, [loadDir])
+
+      var toggleDir = function (rel) {
+        var key = rel || '/'
+        setExpanded(function (prev) {
+          var next = {}
+          for (var k in prev) next[k] = prev[k]
+          next[key] = !next[key]
+          return next
+        })
+        if (!listings[0][key]) loadDir(rel)
+      }
+
+      // Monotonic request id: a slow response for an older click must never
+      // overwrite the preview of a newer click (race guard).
+      var reqSeq = 0
+      var openFile = function (rel, name, ext) {
+        var seq = ++reqSeq
+        setSel({ rel: rel, name: name, ext: ext })
+        if (PREVIEW_EXTS.indexOf(ext) < 0) {
+          if (seq === reqSeq) setPreview({ err: 'File type .' + ext + ' is not supported for preview (read-only .md/.json/.txt/.toml and similar text).' })
+          return
+        }
+        setPreview({ text: null })
+        fetch('/memsearch-dsh/read-file?sessionId=' + encodeURIComponent(sessionId) + '&path=' + encodeURIComponent(rel))
+          .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, d: d } }) })
+          .then(function (r) {
+            if (seq !== reqSeq) return // stale response — a newer click won
+            if (!r.ok) throw new Error(r.d.error || 'read failed')
+            setPreview({ text: r.d.content, ext: r.d.ext })
+          })
+          .catch(function (err) {
+            if (seq !== reqSeq) return
+            setPreview({ text: null, err: String(err.message || err) })
+          })
+      }
+
+      var h = React.createElement
+
+      // Recursive tree renderer — a plain function, NOT a component. Defining a
+      // component inside render would give it a new identity on every render,
+      // making React unmount/remount the whole tree (lost expansion, lost
+      // clicks). A plain recursive call returns elements directly.
+      var renderDir = function (rel, name, depth) {
+        var key = rel || '/'
+        var isOpen = !!expanded[0][key]
+        var listing = listings[0][key]
+        var children = null
+        if (isOpen && listing) {
+          var dirChildren = (listing.dirs || []).map(function (d) {
+            var childRel = rel ? rel + '/' + d : d
+            return renderDir(childRel, d, depth + 1)
+          })
+          var fileChildren = (listing.files || []).map(function (f) {
+            var fRel = rel ? rel + '/' + f : f
+            var dot = f.lastIndexOf('.')
+            var ext = dot >= 0 ? f.slice(dot + 1).toLowerCase() : ''
+            var previewable = PREVIEW_EXTS.indexOf(ext) >= 0
+            var isSel = sel[0] && sel[0].rel === fRel
+            return h('div', {
+              key: fRel,
+              className: 'msr-fs-row' + (isSel ? ' sel' : '') + (previewable ? '' : ' muted'),
+              style: { paddingLeft: 8 + (depth + 1) * 14 },
+              onClick: function () { openFile(fRel, f, ext) },
+            },
+              h('span', { className: 'msr-fs-icon' }, previewable ? '📄' : '🚫'),
+              h('span', { className: 'msr-fs-name' }, f))
+          })
+          children = h('div', { key: 'kids' }, dirChildren.concat(fileChildren))
+        }
+        return h('div', { key: key },
+          h('div', { className: 'msr-fs-row', style: { paddingLeft: 8 + depth * 14 }, onClick: function () { toggleDir(rel) } },
+            h('span', { className: 'msr-fs-icon' }, isOpen && listing ? '▾' : '▸'),
+            h('span', { className: 'msr-fs-icon' }, '📁'),
+            h('span', { className: 'msr-fs-name' }, name)),
+          children)
+      }
+
+      var previewPane
+      if (preview[0] && preview[0].err) {
+        previewPane = h('div', { className: 'msr-preview empty' }, '⚠ ' + preview[0].err)
+      } else if (preview[0] && preview[0].text !== null) {
+        var ext = preview[0].ext
+        var isMd = ext === 'md' || ext === 'markdown'
+        previewPane = h('div', { className: 'msr-md msr-preview' },
+          isMd ? renderMarkdown(preview[0].text) : h('pre', { className: 'msr-md' }, preview[0].text))
+      } else {
+        previewPane = h('div', { className: 'msr-preview empty' }, 'Select a file to preview its contents (read-only).')
+      }
+
+      var rootListing = listings[0]['/']
+      return h('div', { className: 'msr-fs' },
+        h('div', { className: 'msr-fs-head', onClick: function () { setOpen(!open[0]) } },
+          h('span', null, open[0] ? '▾' : '▸'),
+          h('span', null, '📁'),
+          h('span', { className: 'msr-panel-title' }, '.memsearch/'),
+          h('span', { className: 'msr-spacer' }),
+          h('span', null, loading[0] ? 'Loading…' : (rootListing ? rootListing.path : ''))),
+        open[0]
+          ? h('div', { className: 'msr-fs-body' },
+              h('div', { className: 'msr-fs-tree' },
+                h('div', { key: 'root' }, renderDir('', '.memsearch/', 0))),
+              previewPane)
+          : null)
+    }
+
     /** The dock strip: candidate count + expandable review list. */
     function SkillReviewPanel(props) {
       var sessionId = props.sessionId
       var candidates = useState(null) // null = loading
       var setCandidates = candidates[1]
+      var collapsed = useState(true)
+      var setCollapsed = collapsed[1]
       var open = useState(false)
       var setOpen = open[1]
       var dismissed = useState({})
@@ -156,11 +517,41 @@ window.__ModuleLoader__.load({
           .finally(function () { setBusy(null) })
       }
 
+      var openDir = function (scope) {
+        setBusy('__dir__')
+        fetch('/memsearch-dsh/open-memsearch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: sessionId, scope: scope }),
+        })
+          .then(function (res) { return res.json().then(function (data) { return { ok: res.ok, data: data } }) })
+          .then(function (r) {
+            if (!r.ok) throw new Error(r.data.error || 'could not open directory')
+            setToast({ kind: 'ok', text: 'Opening ' + r.data.path + ' in your file manager…' })
+          })
+          .catch(function (err) {
+            setToast({ kind: 'err', text: String(err && err.message ? err.message : err) + ' — open the folder manually to browse it.' })
+          })
+          .finally(function () { setBusy(null) })
+      }
+
       var h = React.createElement
       var visible = (candidates[0] || []).filter(function (c) { return !dismissed[0][c.name] })
       var pending = visible.filter(function (c) { return c.status === 'candidate' })
       var installed = visible.length - pending.length
       var loading = candidates[0] === null
+
+      var expand = function () {
+        setCollapsed(false)
+        setOpen(true)
+      }
+
+      var capsule = h(
+        'button', { className: 'msr-capsule', onClick: expand, title: 'MemSearch skill candidates — click to review' },
+        h('span', { className: 'msr-badge', style: { background: 'transparent', padding: 0 } }, '🧠 MemSearch'),
+        h('span', { className: 'msr-capsule-dot ' + (pending.length > 0 ? '' : 'zero') }, String(pending.length)),
+        h('span', { className: 'msr-capsule-chev' }, '▾')
+      )
 
       var bar = h(
         'div', { className: 'msr-bar' },
@@ -175,7 +566,8 @@ window.__ModuleLoader__.load({
         h('span', { className: 'msr-spacer' }),
         h('button', { className: 'msr-btn', onClick: function () { setOpen(!open[0]) } },
           open[0] ? 'Collapse' : 'Review'),
-        h('button', { className: 'msr-btn ghost', onClick: function () { setDismissed({}); load() } }, 'Refresh')
+        h('button', { className: 'msr-btn ghost', onClick: function () { setDismissed({}); load() } }, 'Refresh'),
+        h('button', { className: 'msr-btn ghost', onClick: function () { setCollapsed(true) } }, 'Hide')
       )
 
       var items = visible.map(function (c) {
@@ -231,13 +623,14 @@ window.__ModuleLoader__.load({
         ? h(
             'div', { className: 'msr-panel' },
             h('div', { className: 'msr-panel-head' },
-              h('span', { className: 'msr-panel-title' }, 'Skill candidates (.memsearch/skill-candidates/)'),
+              h('span', { className: 'msr-panel-title' }, 'Skill candidates'),
               h('span', { className: 'msr-spacer' }),
-              h('span', null, 'Review opens in the conversation · Install runs in the background')),
+              h('span', { style: { color: 'var(--msr-text-2)' } }, 'Review opens in the conversation · Install runs in the background')),
             visible.length === 0
               ? h('div', { className: 'msr-item', style: { color: 'var(--msr-text-2)' } },
                   loading ? 'Loading…' : 'No skill candidates.')
               : h('div', { className: 'msr-list' }, items),
+            h(MemsearchBrowser, { sessionId: sessionId }),
             h('div', { className: 'msr-note' },
               'Installation is a manual step (memsearch skills install) and is never automatic. Target directory follows plugins.dsh.memory_to_skill.paths, defaulting to ~/.agents/skills.')
           )
@@ -245,8 +638,8 @@ window.__ModuleLoader__.load({
 
       return h(
         'div', { className: 'msr-root' },
-        bar,
-        panel,
+        collapsed[0] ? capsule : bar,
+        !collapsed[0] ? panel : null,
         toast[0] ? h('div', { className: 'msr-toast ' + toast[0].kind }, toast[0].text) : null
       )
     }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -35,10 +35,11 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  statSync,
   writeFileSync,
 } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url))
@@ -468,6 +469,23 @@ function resolveSkillInstallTarget(memsearchCmd, projectDir) {
   return join(process.env.HOME || '', '.agents', 'skills')
 }
 
+/** Hard cap for read-file payloads (protects the browser from huge files). */
+const READ_FILE_MAX_BYTES = 256 * 1024
+
+/** File extensions the read-only preview may serve (text only). */
+const TEXT_FILE_EXTS = new Set(['md', 'markdown', 'json', 'txt', 'toml', 'yml', 'yaml', 'sh', 'py', 'js', 'ts'])
+
+/**
+ * Resolve `rel` inside `root` and reject anything that escapes the root
+ * (path traversal). Returns the absolute path or null.
+ */
+function safeJoinWithin(root, rel) {
+  const abs = resolve(root, rel || '.')
+  const rootResolved = resolve(root)
+  if (abs !== rootResolved && !abs.startsWith(rootResolved + '/')) return null
+  return abs
+}
+
 /**
  * Register the browser-facing skill-review JSON routes on the web server.
  *
@@ -556,6 +574,105 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       })
       child.unref()
       return sendJson(res, 200, { ok: true, action, name, started: true, target })
+    },
+  })
+
+  webServer.register({
+    kind: 'exact',
+    path: '/memsearch-dsh/open-memsearch',
+    handler: async (req, res) => {
+      if (req.method !== 'POST') return sendJson(res, 405, { error: 'method not allowed' })
+      const body = await readJsonBody(req)
+      const { sessionId, scope } = body // scope: 'memsearch' (default) | 'candidates'
+      const projectDir = projectDirForSession(sessionId)
+      const memsearchDir = memsearchDirFor(projectDir)
+      const dir = scope === 'candidates' ? join(memsearchDir, 'skill-candidates') : memsearchDir
+      if (!existsSync(dir)) {
+        return sendJson(res, 404, { ok: false, error: `no such directory: ${dir}`, path: dir })
+      }
+      // Open the directory in the local file manager (xdg-open on Linux). The
+      // response is success regardless of whether a desktop is present; the
+      // path is returned so the client can show it if nothing opens.
+      const child = execFile('xdg-open', [dir], {
+        detached: true,
+        stdio: 'ignore',
+        timeout: 10000,
+      }, (error) => {
+        if (error) ctx.logger.warn(`[memsearch] open dir failed: ${error.message}`)
+      })
+      child.unref()
+      return sendJson(res, 200, { ok: true, path: dir })
+    },
+  })
+
+  webServer.register({
+    kind: 'exact',
+    path: '/memsearch-dsh/list-memsearch',
+    handler: async (req, res) => {
+      if (req.method !== 'GET') return sendJson(res, 405, { error: 'method not allowed' })
+      const sessionId = new URL(req.url, 'http://localhost').searchParams.get('sessionId')
+      const relPath = new URL(req.url, 'http://localhost').searchParams.get('path') || ''
+      const projectDir = projectDirForSession(sessionId)
+      const memsearchDir = memsearchDirFor(projectDir)
+      // Only ever list inside the project's .memsearch tree.
+      const abs = safeJoinWithin(memsearchDir, relPath)
+      if (abs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      let entries = []
+      try {
+        entries = readdirSync(abs, { withFileTypes: true })
+      } catch {
+        return sendJson(res, 404, { error: `no such directory: ${abs}`, path: abs })
+      }
+      const dirs = []
+      const files = []
+      for (const e of entries) {
+        if (e.name.startsWith('.')) continue // skip hidden (e.g. .git inside candidates)
+        if (e.isDirectory()) dirs.push(e.name)
+        else if (e.isFile()) files.push(e.name)
+      }
+      dirs.sort()
+      files.sort()
+      sendJson(res, 200, {
+        path: abs,
+        rel: relPath,
+        dirs,
+        files,
+      })
+    },
+  })
+
+  webServer.register({
+    kind: 'exact',
+    path: '/memsearch-dsh/read-file',
+    handler: async (req, res) => {
+      if (req.method !== 'GET') return sendJson(res, 405, { error: 'method not allowed' })
+      const sessionId = new URL(req.url, 'http://localhost').searchParams.get('sessionId')
+      const relPath = new URL(req.url, 'http://localhost').searchParams.get('path') || ''
+      const projectDir = projectDirForSession(sessionId)
+      const memsearchDir = memsearchDirFor(projectDir)
+      const abs = safeJoinWithin(memsearchDir, relPath)
+      if (abs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      let stat
+      try {
+        stat = statSync(abs)
+      } catch {
+        return sendJson(res, 404, { error: `no such file: ${abs}`, path: abs })
+      }
+      if (!stat.isFile()) return sendJson(res, 400, { error: 'not a file' })
+      if (stat.size > READ_FILE_MAX_BYTES) {
+        return sendJson(res, 413, { error: `file too large (${stat.size} bytes, max ${READ_FILE_MAX_BYTES})` })
+      }
+      const ext = abs.split('.').pop().toLowerCase()
+      if (!TEXT_FILE_EXTS.has(ext)) {
+        return sendJson(res, 415, { error: `unsupported file type: .${ext}` })
+      }
+      let content
+      try {
+        content = readFileSync(abs, 'utf-8')
+      } catch {
+        return sendJson(res, 500, { error: 'read failed' })
+      }
+      sendJson(res, 200, { path: abs, rel: relPath, name: abs.split('/').pop(), ext, content })
     },
   })
 }

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -776,3 +776,124 @@ test('registerSkillReviewRoutes: POST review with unknown session returns 404', 
     else process.env.MEMSEARCH_DIR = prev
   }
 })
+
+test('registerSkillReviewRoutes: POST open-memsearch opens existing dir, 404 for missing', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-open-')
+  fs.mkdirSync(`${tmp}/.memsearch`, { recursive: true })
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  let opened = null
+  const ctx = {
+    agents: { get: () => undefined },
+    logger: { warn: (m) => { opened = m } },
+  }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  const { execFile } = await import('node:child_process')
+  // stub execFile so xdg-open doesn't actually fire
+  const { registerSkillReviewRoutes: real } = await import('../index.js')
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const route = routes['/memsearch-dsh/open-memsearch']
+    assert.ok(route, 'open-memsearch route registered')
+    const { EventEmitter } = await import('node:events')
+
+    // existing dir
+    const req1 = Object.assign(new EventEmitter(), { method: 'POST' })
+    const res1 = { writeHead: (s) => { res1.status = s }, end: (b) => { res1.body = JSON.parse(b) } }
+    const done1 = route.handler(req1, res1)
+    req1.emit('data', JSON.stringify({ sessionId: 'sess-1', scope: 'memsearch' }))
+    req1.emit('end')
+    await done1
+    assert.equal(res1.status, 200)
+    assert.equal(res1.body.ok, true)
+    assert.equal(res1.body.path, tmp, 'path is the memsearch dir (MEMSEARCH_DIR override)')
+
+    // missing dir
+    const req2 = Object.assign(new EventEmitter(), { method: 'POST' })
+    const res2 = { writeHead: (s) => { res2.status = s }, end: (b) => { res2.body = JSON.parse(b) } }
+    const done2 = route.handler(req2, res2)
+    req2.emit('data', JSON.stringify({ sessionId: 'sess-1', scope: 'candidates' }))
+    req2.emit('end')
+    await done2
+    assert.equal(res2.status, 404)
+    assert.equal(res2.body.ok, false)
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})
+
+test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks traversal', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-list-')
+  fs.mkdirSync(`${tmp}/memory`, { recursive: true })
+  fs.mkdirSync(`${tmp}/skill-candidates/foo`, { recursive: true })
+  fs.writeFileSync(`${tmp}/memory/2026-08-22.md`, '# hello')
+  fs.writeFileSync(`${tmp}/config.toml`, 'x = 1')
+  fs.writeFileSync(`${tmp}/.hidden`, 'no')
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const route = routes['/memsearch-dsh/list-memsearch']
+    assert.ok(route, 'list route registered')
+
+    const res = { writeHead: (s) => { res.status = s }, end: (b) => { res.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch' }, res)
+    assert.equal(res.status, 200)
+    assert.deepEqual(res.body.dirs.sort(), ['memory', 'skill-candidates'])
+    assert.deepEqual(res.body.files, ['config.toml'])
+    assert.ok(!res.body.files.includes('.hidden'), 'hidden skipped')
+
+    // traversal blocked
+    const res2 = { writeHead: (s) => { res2.status = s }, end: (b) => { res2.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch?path=..%2F..%2Fetc' }, res2)
+    assert.equal(res2.status, 400)
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})
+
+test('registerSkillReviewRoutes: read-file serves text, rejects binary/traversal/oversize', async () => {
+  const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-read-')
+  fs.mkdirSync(`${tmp}/skill-candidates/foo`, { recursive: true })
+  fs.writeFileSync(`${tmp}/skill-candidates/foo/SKILL.md`, '# Foo\n\nDo the thing.\n')
+  fs.writeFileSync(`${tmp}/skill-candidates/foo/meta.json`, '{"name":"foo"}')
+  fs.writeFileSync(`${tmp}/blob.bin`, Buffer.from([0, 1, 2, 3]))
+  const routes = {}
+  const webServer = { register: (r) => { routes[r.path] = r } }
+  const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
+  const { registerSkillReviewRoutes } = await import('../index.js')
+  const prev = process.env.MEMSEARCH_DIR
+  process.env.MEMSEARCH_DIR = tmp
+  try {
+    registerSkillReviewRoutes(ctx, webServer, 'memsearch')
+    const route = routes['/memsearch-dsh/read-file']
+    assert.ok(route, 'read route registered')
+
+    // md file
+    const res = { writeHead: (s) => { res.status = s }, end: (b) => { res.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=skill-candidates%2Ffoo%2FSKILL.md' }, res)
+    assert.equal(res.status, 200)
+    assert.ok(res.body.content.includes('# Foo'))
+
+    // binary rejected
+    const res2 = { writeHead: (s) => { res2.status = s }, end: (b) => { res2.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=blob.bin' }, res2)
+    assert.equal(res2.status, 415)
+
+    // traversal rejected
+    const res3 = { writeHead: (s) => { res3.status = s }, end: (b) => { res3.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=..%2F..%2Fetc%2Fpasswd' }, res3)
+    assert.equal(res3.status, 400)
+  } finally {
+    if (prev === undefined) delete process.env.MEMSEARCH_DIR
+    else process.env.MEMSEARCH_DIR = prev
+  }
+})


### PR DESCRIPTION
## Summary

Two interaction improvements to the @zilliz/memsearch-dsh web skill-candidate panel, plus the host routes that back them.

## Collapsible dock

The dock strip no longer occupies the composer permanently. It defaults to a small capsule (`[MemSearch N]`, N = pending candidates, greyed out at 0). Clicking expands the full bar + review list; **Hide** collapses back to the capsule.

## Read-only .memsearch browser

A new browser docked under the candidate list:

- Lazily-loaded directory tree — each directory's listing is cached independently, so nested expansion works without destroying sibling levels.
- Content preview pane: **Markdown files render** (headings, bold/italic, inline code, fenced code blocks, lists, links, hr, blockquote, tables) via a dependency-free renderer that builds React elements directly — no HTML strings, XSS-safe by construction. Other text types (json/toml/yml/yaml/sh/py/js/ts) show as plain text.
- Files outside the preview allowlist are **greyed out and cannot be opened**.

## Host routes

- `GET /memsearch-dsh/list-memsearch` — list one directory level (dirs/files, hidden skipped).
- `GET /memsearch-dsh/read-file` — read one text file.
- Both are restricted to the session project's `.memsearch` tree (path traversal → 400), text extensions only (binary → 415), 256KB payload cap (→ 413).
- `POST /memsearch-dsh/open-memsearch` (xdg-open on the host) is kept for local-desktop setups but no longer wired to a button — the in-browser preview replaces it.

## Bug fixes found in real usage

- **Tree remount bug**: the directory tree was defined as a component inside the render body, so React unmounted/remounted the whole tree on every state change — after a few clicks the next click hit a detached DOM node and did nothing. The tree is now a plain recursive renderer.
- **Preview race**: a request-seq guard ensures a slow preview response never overwrites a newer click.

## Tests

`plugins/dsh/tests/index.test.js` grows list/read coverage (dirs/files parsing, hidden-skip, traversal rejection, binary rejection, oversize rejection). Full suite 39/39 passing.

Version stays at 0.1.2 (0.1.3 publish can follow after merge).