### PR TITLE
fix(dsh): harden memsearch browser preview

### DIFF
--- a/plugins/dsh/client.js
+++ b/plugins/dsh/client.js
@@ -32,6 +32,7 @@ window.__ModuleLoader__.load({
     var useState = React.useState
     var useEffect = React.useEffect
     var useCallback = React.useCallback
+    var useRef = React.useRef
 
     var NS = 'memsearch-skill-review'
     var CSS_TAG = 'memsearch-skill-review-css'
@@ -168,10 +169,8 @@ window.__ModuleLoader__.load({
 
       function inline(text) {
         var nodes = []
-        // escape first, then apply inline styles on the escaped text
+        // React escapes text nodes, so keep the source text unchanged here.
         var esc = String(text)
-          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
         // inline code
         var parts = esc.split(/`([^`]+)`/g)
         for (var p = 0; p < parts.length; p++) {
@@ -180,9 +179,8 @@ window.__ModuleLoader__.load({
             nodes.push(h('code', { key: 'c' + key++ }, part))
             continue
           }
-          // bold / italic via regex on the escaped string
+          // bold / italic via regex on the remaining source text
           var boldRe = /\*\*([^*]+)\*\*/g
-          var itRe = /(?<!\*)\*([^*]+)\*(?!\*)/g
           var rest = part
           var last = 0
           var m
@@ -204,17 +202,31 @@ window.__ModuleLoader__.load({
             }
           }
         }
-        return nodes.length === 0 ? null : nodes
+        return nodes
       }
 
       function linkify(text) {
-        // [label](url) → anchor
-        var m = /\[([^\]]+)\]\(([^)\s]+)\)/.exec(text)
-        if (!m) return text
-        var before = text.slice(0, m.index)
-        var after = text.slice(m.index + m[0].length)
-        var el = h('a', { key: 'a' + key++, href: m[2], target: '_blank', rel: 'noreferrer' }, m[1])
-        return [before, el].concat(linkify(after))
+        // Parse links around the other inline styles. Unsafe URL schemes stay
+        // as plain text rather than becoming clickable anchors.
+        var source = String(text)
+        var nodes = []
+        var linkRe = /\[([^\]]+)\]\(([^)\s]+)\)/g
+        var last = 0
+        var m
+        while ((m = linkRe.exec(source)) !== null) {
+          nodes = nodes.concat(inline(source.slice(last, m.index)))
+          var href = m[2]
+          var hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(href)
+          var safe = /^(https?:|mailto:)/i.test(href) || (!hasScheme && !/^\/\//.test(href))
+          if (safe) {
+            nodes.push(h('a', { key: 'a' + key++, href: href, target: '_blank', rel: 'noreferrer' }, inline(m[1])))
+          } else {
+            nodes = nodes.concat(inline(m[0]))
+          }
+          last = m.index + m[0].length
+        }
+        nodes = nodes.concat(inline(source.slice(last)))
+        return nodes.length === 0 ? null : nodes
       }
 
       while (i < lines.length) {
@@ -370,24 +382,24 @@ window.__ModuleLoader__.load({
 
       // Monotonic request id: a slow response for an older click must never
       // overwrite the preview of a newer click (race guard).
-      var reqSeq = 0
+      var reqSeq = useRef(0)
       var openFile = function (rel, name, ext) {
-        var seq = ++reqSeq
+        var seq = ++reqSeq.current
         setSel({ rel: rel, name: name, ext: ext })
         if (PREVIEW_EXTS.indexOf(ext) < 0) {
-          if (seq === reqSeq) setPreview({ err: 'File type .' + ext + ' is not supported for preview (read-only .md/.json/.txt/.toml and similar text).' })
+          if (seq === reqSeq.current) setPreview({ err: 'File type .' + ext + ' is not supported for preview (read-only .md/.json/.txt/.toml and similar text).' })
           return
         }
         setPreview({ text: null })
         fetch('/memsearch-dsh/read-file?sessionId=' + encodeURIComponent(sessionId) + '&path=' + encodeURIComponent(rel))
           .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, d: d } }) })
           .then(function (r) {
-            if (seq !== reqSeq) return // stale response — a newer click won
+            if (seq !== reqSeq.current) return // stale response — a newer click won
             if (!r.ok) throw new Error(r.d.error || 'read failed')
             setPreview({ text: r.d.content, ext: r.d.ext })
           })
           .catch(function (err) {
-            if (seq !== reqSeq) return
+            if (seq !== reqSeq.current) return
             setPreview({ text: null, err: String(err.message || err) })
           })
       }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -34,12 +34,13 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   statSync,
   writeFileSync,
 } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url))
@@ -482,8 +483,27 @@ const TEXT_FILE_EXTS = new Set(['md', 'markdown', 'json', 'txt', 'toml', 'yml', 
 function safeJoinWithin(root, rel) {
   const abs = resolve(root, rel || '.')
   const rootResolved = resolve(root)
-  if (abs !== rootResolved && !abs.startsWith(rootResolved + '/')) return null
-  return abs
+  return pathIsWithin(rootResolved, abs) ? abs : null
+}
+
+/** Return true when `target` is `root` or one of its descendants. */
+function pathIsWithin(root, target) {
+  const rel = relative(root, target)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+/**
+ * Resolve symlinks for an existing candidate and reject targets outside the
+ * real memory root. `undefined` means one of the paths does not exist.
+ */
+function realPathWithin(root, candidate) {
+  try {
+    const rootReal = realpathSync(root)
+    const candidateReal = realpathSync(candidate)
+    return pathIsWithin(rootReal, candidateReal) ? candidateReal : null
+  } catch {
+    return undefined
+  }
 }
 
 /**
@@ -617,9 +637,14 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       // Only ever list inside the project's .memsearch tree.
       const abs = safeJoinWithin(memsearchDir, relPath)
       if (abs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      const realAbs = realPathWithin(memsearchDir, abs)
+      if (realAbs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      if (realAbs === undefined) {
+        return sendJson(res, 404, { error: `no such directory: ${abs}`, path: abs })
+      }
       let entries = []
       try {
-        entries = readdirSync(abs, { withFileTypes: true })
+        entries = readdirSync(realAbs, { withFileTypes: true })
       } catch {
         return sendJson(res, 404, { error: `no such directory: ${abs}`, path: abs })
       }
@@ -652,9 +677,14 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       const memsearchDir = memsearchDirFor(projectDir)
       const abs = safeJoinWithin(memsearchDir, relPath)
       if (abs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      const realAbs = realPathWithin(memsearchDir, abs)
+      if (realAbs === null) return sendJson(res, 400, { error: 'path outside .memsearch' })
+      if (realAbs === undefined) {
+        return sendJson(res, 404, { error: `no such file: ${abs}`, path: abs })
+      }
       let stat
       try {
-        stat = statSync(abs)
+        stat = statSync(realAbs)
       } catch {
         return sendJson(res, 404, { error: `no such file: ${abs}`, path: abs })
       }
@@ -662,17 +692,17 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       if (stat.size > READ_FILE_MAX_BYTES) {
         return sendJson(res, 413, { error: `file too large (${stat.size} bytes, max ${READ_FILE_MAX_BYTES})` })
       }
-      const ext = abs.split('.').pop().toLowerCase()
+      const ext = extname(realAbs).slice(1).toLowerCase()
       if (!TEXT_FILE_EXTS.has(ext)) {
         return sendJson(res, 415, { error: `unsupported file type: .${ext}` })
       }
       let content
       try {
-        content = readFileSync(abs, 'utf-8')
+        content = readFileSync(realAbs, 'utf-8')
       } catch {
         return sendJson(res, 500, { error: 'read failed' })
       }
-      sendJson(res, 200, { path: abs, rel: relPath, name: abs.split('/').pop(), ext, content })
+      sendJson(res, 200, { path: abs, rel: relPath, name: basename(abs), ext, content })
     },
   })
 }

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -33,7 +33,7 @@
     "plugin"
   ],
   "scripts": {
-    "test": "node --test tests/index.test.js"
+    "test": "node --test tests/*.test.js"
   },
   "dsh": {
     "bundle": {

--- a/plugins/dsh/tests/client.test.js
+++ b/plugins/dsh/tests/client.test.js
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+function createHarness() {
+  let cursor = 0
+  let stateValues = []
+  let stateSetters = []
+  const refs = []
+  let moduleDefinition
+  let dockRenderer
+
+  const React = {
+    createElement(type, props, ...children) {
+      return {
+        type,
+        props: {
+          ...(props || {}),
+          children: children.length <= 1 ? children[0] : children,
+        },
+      }
+    },
+    useState(initial) {
+      const index = cursor++
+      const value = index < stateValues.length ? stateValues[index] : initial
+      return [value, stateSetters[index] || (() => {})]
+    },
+    useCallback(fn) {
+      cursor++
+      return fn
+    },
+    useEffect() {
+      cursor++
+    },
+    useRef(initial) {
+      const index = cursor++
+      if (!refs[index]) refs[index] = { current: initial }
+      return refs[index]
+    },
+  }
+
+  const context = vm.createContext({
+    window: {
+      __ModuleLoader__: {
+        load(definition) {
+          moduleDefinition = definition
+        },
+      },
+    },
+  })
+  const source = fs.readFileSync(new URL('../client.js', import.meta.url), 'utf8')
+  vm.runInContext(source, context)
+  const client = moduleDefinition.factory((name) => {
+    assert.equal(name, 'react')
+    return React
+  })
+  const slots = {
+    inject(_name, register) {
+      register()
+    },
+    register(_meta, renderer) {
+      dockRenderer = renderer
+    },
+  }
+  client.apply({ get: () => slots })
+
+  function renderWith(values, setters = []) {
+    cursor = 0
+    stateValues = values
+    stateSetters = setters
+  }
+
+  renderWith([[], false, true, {}, null, null])
+  const panelElement = dockRenderer({ sessionId: 'session-1' })
+  const panelTree = panelElement.type(panelElement.props)
+  const browserElement = findElement(panelTree, (element) => (
+    typeof element.type === 'function' && element.type.name === 'MemsearchBrowser'
+  ))
+  assert.ok(browserElement, 'MemsearchBrowser component is reachable from the expanded panel')
+
+  return {
+    Browser: browserElement.type,
+    context,
+    renderWith,
+  }
+}
+
+function visit(value, callback) {
+  if (Array.isArray(value)) {
+    for (const child of value) visit(child, callback)
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  callback(value)
+  visit(value.props?.children, callback)
+}
+
+function findElement(tree, predicate) {
+  let match = null
+  visit(tree, (element) => {
+    if (match === null && predicate(element)) match = element
+  })
+  return match
+}
+
+function fileRow(tree, name) {
+  return findElement(tree, (element) => {
+    if (element.type !== 'div' || typeof element.props?.onClick !== 'function') return false
+    let found = false
+    visit(element.props.children, (child) => {
+      const children = child.props?.children
+      if (children === name || (Array.isArray(children) && children.includes(name))) found = true
+    })
+    return found
+  })
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+test('markdown preview renders inline styles and leaves unsafe links inert', () => {
+  const { Browser, renderWith } = createHarness()
+  renderWith([
+    true,
+    { '/': { dirs: [], files: [] } },
+    { '/': true },
+    null,
+    { text: '**bold** *italic* `code` [guide](guide.md) [bad](javascript:alert)', ext: 'md' },
+    false,
+  ])
+  const tree = Browser({ sessionId: 'session-1' })
+  const types = []
+  visit(tree, (element) => types.push(element.type))
+  assert.ok(types.includes('strong'))
+  assert.ok(types.includes('em'))
+  assert.ok(types.includes('code'))
+  const anchors = []
+  visit(tree, (element) => {
+    if (element.type === 'a') anchors.push(element)
+  })
+  assert.equal(anchors.length, 1, 'only the safe relative link is clickable')
+  assert.equal(anchors[0].props.href, 'guide.md')
+})
+
+test('an older file response cannot replace a newer preview after rerender', async () => {
+  const { Browser, context, renderWith } = createHarness()
+  const pending = []
+  const previewUpdates = []
+  context.fetch = (url) => new Promise((resolve) => pending.push({ url, resolve }))
+
+  const values = [
+    true,
+    { '/': { dirs: [], files: ['first.md', 'second.md'] } },
+    { '/': true },
+    null,
+    null,
+    false,
+  ]
+  const setters = []
+  setters[4] = (value) => previewUpdates.push(value)
+
+  renderWith(values, setters)
+  const firstTree = Browser({ sessionId: 'session-1' })
+  fileRow(firstTree, 'first.md').props.onClick()
+
+  renderWith(values, setters)
+  const secondTree = Browser({ sessionId: 'session-1' })
+  fileRow(secondTree, 'second.md').props.onClick()
+  assert.equal(pending.length, 2)
+
+  pending[1].resolve({ ok: true, json: async () => ({ content: 'SECOND', ext: 'md' }) })
+  await flushPromises()
+  pending[0].resolve({ ok: true, json: async () => ({ content: 'FIRST', ext: 'md' }) })
+  await flushPromises()
+
+  assert.equal(previewUpdates.at(-1).text, 'SECOND')
+  assert.ok(!previewUpdates.some((update) => update.text === 'FIRST'))
+})

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -827,11 +827,13 @@ test('registerSkillReviewRoutes: POST open-memsearch opens existing dir, 404 for
 
 test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks traversal', async () => {
   const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-list-')
+  const outside = fs.mkdtempSync(os.tmpdir() + '/msr-list-outside-')
   fs.mkdirSync(`${tmp}/memory`, { recursive: true })
   fs.mkdirSync(`${tmp}/skill-candidates/foo`, { recursive: true })
   fs.writeFileSync(`${tmp}/memory/2026-08-22.md`, '# hello')
   fs.writeFileSync(`${tmp}/config.toml`, 'x = 1')
   fs.writeFileSync(`${tmp}/.hidden`, 'no')
+  fs.symlinkSync(outside, `${tmp}/outside-link`)
   const routes = {}
   const webServer = { register: (r) => { routes[r.path] = r } }
   const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
@@ -854,6 +856,11 @@ test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks travers
     const res2 = { writeHead: (s) => { res2.status = s }, end: (b) => { res2.body = JSON.parse(b) } }
     route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch?path=..%2F..%2Fetc' }, res2)
     assert.equal(res2.status, 400)
+
+    // A symlink inside .memsearch must not expose an outside directory.
+    const res3 = { writeHead: (s) => { res3.status = s }, end: (b) => { res3.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch?path=outside-link' }, res3)
+    assert.equal(res3.status, 400)
   } finally {
     if (prev === undefined) delete process.env.MEMSEARCH_DIR
     else process.env.MEMSEARCH_DIR = prev
@@ -862,10 +869,13 @@ test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks travers
 
 test('registerSkillReviewRoutes: read-file serves text, rejects binary/traversal/oversize', async () => {
   const tmp = fs.mkdtempSync(os.tmpdir() + '/msr-read-')
+  const outside = `${tmp}-outside.md`
   fs.mkdirSync(`${tmp}/skill-candidates/foo`, { recursive: true })
   fs.writeFileSync(`${tmp}/skill-candidates/foo/SKILL.md`, '# Foo\n\nDo the thing.\n')
   fs.writeFileSync(`${tmp}/skill-candidates/foo/meta.json`, '{"name":"foo"}')
   fs.writeFileSync(`${tmp}/blob.bin`, Buffer.from([0, 1, 2, 3]))
+  fs.writeFileSync(outside, 'outside secret')
+  fs.symlinkSync(outside, `${tmp}/escape.md`)
   const routes = {}
   const webServer = { register: (r) => { routes[r.path] = r } }
   const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
@@ -892,6 +902,11 @@ test('registerSkillReviewRoutes: read-file serves text, rejects binary/traversal
     const res3 = { writeHead: (s) => { res3.status = s }, end: (b) => { res3.body = JSON.parse(b) } }
     route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=..%2F..%2Fetc%2Fpasswd' }, res3)
     assert.equal(res3.status, 400)
+
+    // A text-looking symlink must not expose a file outside .memsearch.
+    const res4 = { writeHead: (s) => { res4.status = s }, end: (b) => { res4.body = JSON.parse(b) } }
+    route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=escape.md' }, res4)
+    assert.equal(res4.status, 400)
   } finally {
     if (prev === undefined) delete process.env.MEMSEARCH_DIR
     else process.env.MEMSEARCH_DIR = prev


### PR DESCRIPTION
## Summary

- prevent symlink traversal from escaping the configured .memsearch directory
- preserve the file-preview request sequence across React renders
- render Markdown inline formatting and reject unsafe link schemes
- add browser behavior and symlink regression coverage

## Testing

- npm test (plugins/dsh): 41 passed
- node --check client.js
- node --check index.js
- git diff --check