### PR TITLE
docs: add DeepSeek Harness plugin documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ When modifying hooks/skills, keep in mind:
 - **ONNX bge-m3 as plugin default.** The Claude Code plugin hooks default to `onnx` provider (bge-m3, CPU, no API key). The Python API still defaults to `openai`.
 - **Hybrid search by default.** Every collection has both dense vector and BM25 sparse fields. Search uses RRF to combine them. RRF scores are normalized to `[0, 1]` (theoretical max = `num_retrievers / (k + 1)`).
 - **`[llm]` + `[prompts]` config.** New config sections for LLM provider selection and custom prompt templates. `[compact]` is deprecated but still works (fallback: `[llm]` > `[compact]` > defaults). Plugins read `prompts.summarize` for custom session summarization prompts. **Migration plan:** `[compact]` will be removed in the next major version (1.0). During the transition, `resolve_config()` emits a `DeprecationWarning` when user config files contain `[compact]`. The compact CLI command resolves LLM settings as `cfg.llm.* or cfg.compact.*`.
-- **Shared prompt template.** All four plugins share a single `summarize.txt` template (maintained in `plugins/_shared/prompts/`, synced via `scripts/sync-prompts.sh`). Template uses `{{AGENT_NAME}}` placeholder.
+- **Shared prompt template.** All five plugins share a single `summarize.txt` template (maintained in `plugins/_shared/prompts/`, synced via `scripts/sync-prompts.sh`). Template uses `{{AGENT_NAME}}` placeholder.
 - **Remote Milvus `query()` requires a filter.** Use `chunk_hash != ""` as a "match all" filter when no filter is provided (Milvus Lite doesn't enforce this, but Milvus Server does).
 
 ## Versioning & Release

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 <p align="center">
   <a href="https://pypi.org/project/memsearch/"><img src="https://img.shields.io/pypi/v/memsearch?style=flat-square&color=blue" alt="PyPI"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/claude-code/"><img src="https://img.shields.io/badge/Claude_Code-plugin-c97539?style=flat-square&logo=claude&logoColor=white" alt="Claude Code"></a>
+  <a href="https://zilliztech.github.io/memsearch/platforms/codex/"><img src="https://img.shields.io/badge/Codex_CLI-plugin-ff6b35?style=flat-square" alt="Codex CLI"></a>
+  <a href="https://zilliztech.github.io/memsearch/platforms/dsh/"><img src="https://img.shields.io/badge/DeepSeek_Harness-plugin-4d6bfe?style=flat-square" alt="DeepSeek Harness"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/openclaw/"><img src="https://img.shields.io/badge/OpenClaw-plugin-4a9eff?style=flat-square" alt="OpenClaw"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/opencode/"><img src="https://img.shields.io/badge/OpenCode-plugin-22c55e?style=flat-square" alt="OpenCode"></a>
-  <a href="https://zilliztech.github.io/memsearch/platforms/codex/"><img src="https://img.shields.io/badge/Codex_CLI-plugin-ff6b35?style=flat-square" alt="Codex CLI"></a>
   <a href="https://pypi.org/project/memsearch/"><img src="https://img.shields.io/badge/python-%3E%3D3.10-blue?style=flat-square&logo=python&logoColor=white" alt="Python"></a>
   <a href="https://github.com/zilliztech/memsearch/blob/main/LICENSE"><img src="https://img.shields.io/github/license/zilliztech/memsearch?style=flat-square" alt="License"></a>
   <a href="https://github.com/zilliztech/memsearch/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/zilliztech/memsearch/test.yml?branch=main&style=flat-square" alt="Tests"></a>
@@ -29,6 +30,7 @@
 
 ## 📰 What's New
 
+- **DeepSeek Harness support** — MemSearch now brings automatic capture, pre-step memory injection, native skill-based recall, background maintenance, and a read-only memory browser to [DeepSeek Harness (DSH)](https://zilliztech.github.io/memsearch/platforms/dsh/).
 - **Skills from memory** — MemSearch now distills the workflows you repeat into reusable, installable agent skills (a third "procedural memory" layer) and keeps them up to date in the background. See [Skills from Memory](#skills-from-memory).
 - **Advanced memory maintenance** — optional background tasks keep durable `PROJECT.md` and `USER.md` notes current across sessions. See [Advanced Memory Maintenance](#advanced-memory-maintenance).
 
@@ -36,7 +38,7 @@
 
 ### Why memsearch?
 
-- 🌐 **All Platforms, One Memory** — memories flow across [Claude Code](plugins/claude-code/README.md), [OpenClaw](plugins/openclaw/README.md), [OpenCode](plugins/opencode/README.md), and [Codex CLI](plugins/codex/README.md). A conversation in one agent becomes searchable context in all others — no extra setup
+- 🌐 **All Platforms, One Memory** — memories flow across [Claude Code](plugins/claude-code/README.md), [Codex CLI](plugins/codex/README.md), [DeepSeek Harness](plugins/dsh/README.md), [OpenClaw](plugins/openclaw/README.md), and [OpenCode](plugins/opencode/README.md). A conversation in one agent becomes searchable context in all others — no extra setup
 - 👥 **For Agent Users**, install a plugin and get persistent memory with zero effort; **for Agent Developers**, use the full [CLI](https://zilliztech.github.io/memsearch/cli/) and [Python API](https://zilliztech.github.io/memsearch/python-api/) to build memory and harness engineering into your own agents
 - 📄 **Markdown is the source of truth** — inspired by [OpenClaw](https://github.com/openclaw/openclaw). Your memories are just `.md` files — human-readable, editable, version-controllable. Milvus is a "shadow index": a derived, rebuildable cache
 - 🔍 **Progressive retrieval, hybrid search, smart dedup, live sync** — 3-layer recall (search → expand → transcript); dense vector + BM25 sparse + RRF reranking; SHA-256 content hashing skips unchanged content; file watcher auto-indexes in real time
@@ -105,6 +107,36 @@ $memory-recall what did we discuss about deployment?
 ```
 
 > 📖 [Codex CLI Plugin docs](https://zilliztech.github.io/memsearch/platforms/codex/)
+
+</details>
+
+<details open>
+<summary><h3>For DeepSeek Harness Users</h3></summary>
+
+```bash
+# Install the published plugin into your DSH profile
+uv tool install "memsearch[onnx]"
+dsh plugin --profile web add @zilliz/memsearch-dsh
+# Restart that DSH profile, or start a new session
+```
+
+After installing, use DSH normally. Completed turns are captured automatically, and relevant memories are injected before the first model step only when they are useful.
+
+**Verify it's working:**
+
+```bash
+ls .memsearch/memory/
+```
+
+**Recall memories** — ask naturally or tell DSH to use the registered `memory-recall` skill:
+
+```
+Use memory-recall to find what we decided about the deployment architecture.
+```
+
+The web profile also adds a compact MemSearch dock where you can review skill candidates and browse supported files under `.memsearch/` without editing them.
+
+> 📖 [DeepSeek Harness Plugin docs](https://zilliztech.github.io/memsearch/platforms/dsh/)
 
 </details>
 
@@ -248,7 +280,7 @@ memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
 memsearch config set plugins.codex.summarize.provider openai
 ```
 
-Leave `plugins.<platform>.summarize.provider` empty or set it to `native` to preserve the default behavior. Plugin-specific summarize settings do not fall back to `llm.model`.
+Leave `plugins.<platform>.summarize.provider` empty to preserve the platform's default behavior. Claude Code, Codex, OpenClaw, and OpenCode also accept `native`; DSH selects its headless-agent backend when the provider is unset. Plugin-specific summarize settings do not fall back to `llm.model`.
 
 You can also disable automatic capture globally for a platform while keeping the plugin installed:
 
@@ -275,7 +307,7 @@ Beyond the episodic journals and the semantic `PROJECT.md` / `USER.md` notes, Me
   <img width="1086" height="752" alt="MemSearch skill distillation demo" src="https://github.com/user-attachments/assets/39a90f1c-54e3-4c7a-b168-051f0e096d39">
 </p>
 
-Under the hood, candidates live in a git-tracked `.memsearch/skill-candidates/` store — diffable and revertible, and **inert until you install one** (that step is always yours). An optional background pass can also mine recurring workflows from your history on its own. Distilled skills follow the [Agent Skills](https://agentskills.io) open standard, so one capture is portable across Claude Code, Codex, OpenCode, and others.
+Under the hood, candidates live in a git-tracked `.memsearch/skill-candidates/` store — diffable and revertible, and **inert until you install one** (that step is always yours). An optional background pass can also mine recurring workflows from your history on its own. Distilled skills follow the [Agent Skills](https://agentskills.io) open standard, so one capture is portable across Claude Code, Codex, DSH, OpenClaw, OpenCode, and other compatible agents.
 
 **Turning it on is also just a sentence:** ask your agent *"enable MemSearch skill distillation"* (or *"make it more eager"*) and it configures things through the `memory-config` skill — it's off by default. Prefer editing files? The same settings live under `[plugins.<agent>.memory_to_skill]` in your MemSearch config. Full guide: **[Skills from Memory](https://zilliztech.github.io/memsearch/home/skills-from-memory/)**.
 
@@ -286,7 +318,7 @@ Under the hood, candidates live in a git-tracked `.memsearch/skill-candidates/` 
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ---
 
@@ -299,11 +331,8 @@ Beyond ready-to-use plugins, memsearch provides a complete **CLI and Python API*
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                  🧑‍💻 For Agent Users (Plugins)                │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐ ┌──────┐ │
-│  │ Claude   │ │ OpenClaw │ │ OpenCode │ │ Codex  │ │ Your │ │
-│  │ Code     │ │ Plugin   │ │ Plugin   │ │ Plugin │ │ App  │ │
-│  └────┬─────┘ └────┬─────┘ └────┬─────┘ └───┬────┘ └──┬───┘ │
-│       └─────────────┴────────────┴───────────┴────────┘     │
+│ Claude Code · Codex CLI · DSH · OpenClaw · OpenCode · Your App │
+│                              │                               │
 ├────────────────────────────┬─────────────────────────────────┤
 │  🛠️ For Agent Developers   │  Build your own with ↓          │
 │  ┌─────────────────────────┴──────────────────────────────┐  │
@@ -395,7 +424,7 @@ User: "What did we discuss about batch size?"
 ```bash
 # Install as a global CLI tool — recommended when you mainly use the
 # `memsearch` command or any of the agent plugins (Claude Code, Codex,
-# OpenClaw, OpenCode), which all shell out to the CLI.
+# DSH, OpenClaw, OpenCode), which all shell out to the CLI.
 uv tool install memsearch       # via uv
 pipx install memsearch          # via pipx
 pip install memsearch           # plain pip
@@ -646,7 +675,7 @@ Settings priority: Built-in defaults → `~/.memsearch/config.toml` → `.memsea
 ## 🔗 Links
 
 - 📖 [Documentation](https://zilliztech.github.io/memsearch/) — full guides, API reference, and architecture details
-- 🔌 [Platform Plugins](https://zilliztech.github.io/memsearch/platforms/) — Claude Code, OpenClaw, OpenCode, Codex CLI
+- 🔌 [Platform Plugins](https://zilliztech.github.io/memsearch/platforms/) — Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, OpenCode
 - 💡 [Design Philosophy](https://zilliztech.github.io/memsearch/design-philosophy/) — why markdown, why Milvus, competitor comparison
 - 🦞 [OpenClaw](https://github.com/openclaw/openclaw) — the memory architecture that inspired memsearch
 - 🗄️ [Milvus](https://milvus.io/) | [Zilliz Cloud](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-readme) — the vector database powering memsearch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,15 +6,16 @@ This page explains the technical architecture and key implementation decisions b
 
 ## Cross-Platform Memory Sharing
 
-memsearch supports 4 AI coding agent platforms: [Claude Code](platforms/claude-code/index.md), [OpenClaw](platforms/openclaw/index.md), [OpenCode](platforms/opencode/index.md), and [Codex CLI](platforms/codex/index.md). All plugins write to the same markdown format and use the same Milvus index, making memories portable across platforms.
+memsearch supports 5 AI coding agent platforms: [Claude Code](platforms/claude-code/index.md), [Codex CLI](platforms/codex/index.md), [DeepSeek Harness](platforms/dsh/index.md), [OpenClaw](platforms/openclaw/index.md), and [OpenCode](platforms/opencode/index.md). All plugins write to the same markdown format and use the same Milvus index, making memories portable across platforms.
 
 ```mermaid
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
+        CX["Codex CLI<br/>(Stop hook + Codex)"]
+        DSH["DeepSeek Harness<br/>(turn event + headless agent)"]
         OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]
-        CX["Codex CLI<br/>(Stop hook + Codex)"]
     end
 
     subgraph "Shared Memory"
@@ -22,7 +23,7 @@ graph TB
         MIL[("Milvus<br/>(shared index)")]
     end
 
-    CC & OC & OO & CX --> MD
+    CC & CX & DSH & OC & OO --> MD
     MD --> MIL
 
     style MD fill:#2a3a5c,stroke:#e0976b,color:#a8b2c1
@@ -260,7 +261,7 @@ graph LR
 | **L2: Expand** | Full markdown section around a chunk, including anchor metadata | Medium -- one file section |
 | **L3: Transcript** | Original conversation turns verbatim (user messages, assistant responses, tool calls) | High -- raw dialogue |
 
-The L3 transcript format varies by platform (Claude Code JSONL, OpenClaw JSONL, OpenCode SQLite, Codex rollout JSONL), but the L1/L2 layers are shared across all platforms via the `memsearch` CLI.
+The L3 transcript format varies by platform (Claude Code JSONL, Codex rollout JSONL, DSH session database, OpenClaw JSONL, OpenCode SQLite), but the L1/L2 layers are shared across all platforms via the `memsearch` CLI.
 
 **Session anchors** in memory files enable the L2-to-L3 bridge:
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -43,9 +43,10 @@ This is memsearch's key differentiator: **memories written by one agent are sear
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
+        CX["Codex CLI<br/>(Stop hook + Codex)"]
+        DSH["DeepSeek Harness<br/>(turn event + headless agent)"]
         OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]
-        CX["Codex CLI<br/>(Stop hook + Codex)"]
     end
 
     subgraph "Shared Memory"
@@ -53,14 +54,14 @@ graph TB
         MIL[("Milvus<br/>(shared index)")]
     end
 
-    CC & OC & OO & CX --> MD
+    CC & CX & DSH & OC & OO --> MD
     MD --> MIL
 
     style MD fill:#2a3a5c,stroke:#e0976b,color:#a8b2c1
     style MIL fill:#2a3a5c,stroke:#6ba3d6,color:#a8b2c1
 ```
 
-All 4 platform plugins write to the same markdown format and use the same Milvus backend. This means:
+All 5 platform plugins write to the same markdown format and use the same Milvus backend. This means:
 
 - You can switch between Claude Code and Codex CLI and keep your memories
 - Team members using different agents can share a knowledge base

--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -8,7 +8,7 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 
 | | memsearch | Claude Code native | claude-mem | qmd | MemPalace | mem0 | Letta |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Shape** | Engine + 4 native CLI plugins | Built-in (Claude Code only) | Plugin (Claude Code / Gemini CLI / OpenClaw) | Engine + MCP + Claude Code plugin | Claude Code plugin + MCP | Library + native plugins + MCP | Agent runtime (own CLI: Letta Code) |
+| **Shape** | Engine + 5 native agent plugins | Built-in (Claude Code only) | Plugin (Claude Code / Gemini CLI / OpenClaw) | Engine + MCP + Claude Code plugin | Claude Code plugin + MCP | Library + native plugins + MCP | Agent runtime (own CLI: Letta Code) |
 | **Source of truth** | Plain `.md` | Plain `.md` (`CLAUDE.md` + auto-memory) | SQLite + ChromaDB | Plain `.md` | ChromaDB | Vector DB (+ optional graph) | Postgres / git-backed MemFS (Letta Code) |
 | **Write** | Append-only | User edits `CLAUDE.md`; auto-memory appended by Claude | LLM-compressed transcripts | — (read-only) | Raw transcripts | LLM-extracted facts, LLM add/update/delete | Agent self-edits via tools |
 | **Search** | Dense + BM25 + RRF | **None** — whole file loaded every session | Chroma vector + FTS5 | BM25 + dense + LLM rerank | Dense | Dense (+ optional rerank, + optional graph) | Dense archival |
@@ -45,7 +45,7 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 
 ## Where memsearch is different
 
-- **Covers Claude Code + OpenClaw + OpenCode + Codex CLI in one project.** No other entry covers all four.
+- **Covers Claude Code + Codex CLI + DeepSeek Harness + OpenClaw + OpenCode in one project.** No other entry covers all five.
 - **Retrieves on demand** instead of stuffing the whole file into every session like Claude Code's built-in memory.
 - **Markdown + Milvus, not an opaque DB.** qmd and Letta's MemFS share the markdown-canonical approach; claude-mem / MemPalace / mem0 keep state in a DB.
 - **Append-only writes, no LLM curation on the write path.** mem0 and Letta's traditional memory depend on LLM write-time curation (powerful but can silently mutate past writes).

--- a/docs/home/for-developers.md
+++ b/docs/home/for-developers.md
@@ -53,7 +53,7 @@ See the full [CLI Reference →](../cli.md) and [Python API →](../python-api.m
 
 ## How Plugins Use the API
 
-All 4 platform plugins are built on top of the same CLI/API:
+All 5 platform plugins are built on top of the same CLI/API:
 
 ```
 Plugin Capture:  conversation → LLM summary → append daily.md → memsearch index

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -9,16 +9,17 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ## Choose Your Platform
 
 | Platform | Install | Maturity |
 |----------|---------|----------|
 | [**Claude Code**](../platforms/claude-code/index.md) | Marketplace or `--plugin-dir` | Most mature |
+| [**Codex CLI**](../platforms/codex/index.md) | `bash install.sh` | Stable |
+| [**DeepSeek Harness**](../platforms/dsh/index.md) | `dsh plugin --profile <name> add @zilliz/memsearch-dsh` | Stable |
 | [**OpenClaw**](../platforms/openclaw/index.md) | `openclaw plugins install --force` + hook permissions | Stable |
 | [**OpenCode**](../platforms/opencode/index.md) | Add to `opencode.json` plugin array | Stable |
-| [**Codex CLI**](../platforms/codex/index.md) | `bash install.sh` | Stable |
 
 ## What Happens Automatically
 
@@ -45,8 +46,9 @@ Simple questions stop at L1. Complex questions go deeper.
 Each platform adapts the same architecture to its own plugin system:
 
 - **Claude Code**: [Full guide →](../platforms/claude-code/index.md)
+- **Codex CLI**: [Full guide →](../platforms/codex/index.md)
+- **DeepSeek Harness**: [Full guide →](../platforms/dsh/index.md)
 - **OpenClaw**: [Full guide →](../platforms/openclaw/index.md)
 - **OpenCode**: [Full guide →](../platforms/opencode/index.md)
-- **Codex CLI**: [Full guide →](../platforms/codex/index.md)
 
 See the [Platform Comparison](../platforms/index.md) for a detailed feature matrix.

--- a/docs/home/why.md
+++ b/docs/home/why.md
@@ -2,9 +2,9 @@
 
 ## One Memory, Every Agent
 
-memsearch provides persistent memory plugins for **4 major AI coding agent platforms**: [Claude Code](../platforms/claude-code/index.md), [OpenClaw](../platforms/openclaw/index.md), [OpenCode](../platforms/opencode/index.md), and [Codex CLI](../platforms/codex/index.md).
+memsearch provides persistent memory plugins for **5 major AI coding agent platforms**: [Claude Code](../platforms/claude-code/index.md), [Codex CLI](../platforms/codex/index.md), [DeepSeek Harness](../platforms/dsh/index.md), [OpenClaw](../platforms/openclaw/index.md), and [OpenCode](../platforms/opencode/index.md).
 
-Memories written in one platform are searchable from any other. A conversation in Claude Code becomes available context in OpenClaw, Codex, and OpenCode — no extra setup, no manual export.
+Memories written in one platform are searchable from any other. A conversation in Claude Code becomes available context in Codex, DSH, OpenClaw, and OpenCode — no extra setup, no manual export.
 
 ## Both for Agent Users and Agent Developers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ### Claude Code Plugin
 
@@ -33,6 +33,30 @@ Shell hooks + SKILL.md with `context: fork` subagent. Conversations are auto-sum
 
 [:octicons-arrow-right-24: Claude Code Plugin docs](platforms/claude-code/index.md){ .md-button .md-button--primary }
 [:octicons-arrow-right-24: Troubleshooting](platforms/claude-code/troubleshooting.md){ .md-button }
+
+### Codex CLI Plugin
+
+Shell hooks and a native memory-recall skill for terminal coding workflows.
+
+```bash
+bash memsearch/plugins/codex/scripts/install.sh
+codex --yolo
+```
+
+[:octicons-arrow-right-24: Codex CLI Plugin docs](platforms/codex/index.md){ .md-button }
+
+### DeepSeek Harness Plugin
+
+Native DSH integration with automatic capture, selective pre-step injection, skill-based recall, background maintenance, and a compact web memory browser.
+
+```bash
+uv tool install "memsearch[onnx]"
+dsh plugin --profile web add @zilliz/memsearch-dsh
+```
+
+Use any DSH profile name in place of `web`, then restart that profile or begin a new session.
+
+[:octicons-arrow-right-24: DeepSeek Harness Plugin docs](platforms/dsh/index.md){ .md-button .md-button--primary }
 
 ### OpenClaw Plugin
 
@@ -60,27 +84,16 @@ bash memsearch/plugins/opencode/install.sh
 
 [:octicons-arrow-right-24: OpenCode Plugin docs](platforms/opencode/index.md){ .md-button }
 
-### Codex CLI Plugin
-
-Shell hooks, similar architecture to Claude Code. Requires `--yolo` mode.
-
-```bash
-bash memsearch/plugins/codex/scripts/install.sh
-codex --yolo
-```
-
-[:octicons-arrow-right-24: Codex CLI Plugin docs](platforms/codex/index.md){ .md-button }
-
 ### One Memory, All Platforms
 
 All platforms share the same markdown memory format and derive collection names from the project directory using the same algorithm. A conversation in one agent becomes searchable context in all others -- no extra setup needed.
 
-| | [Claude Code](platforms/claude-code/index.md) | [OpenClaw](platforms/openclaw/index.md) | [OpenCode](platforms/opencode/index.md) | [Codex CLI](platforms/codex/index.md) |
-|---|:---:|:---:|:---:|:---:|
-| **Plugin type** | Shell hooks | TS plugin | TS plugin | Shell hooks |
-| **Capture** | Stop hook + Haiku | agent_end hook | SQLite daemon | Stop hook + Codex |
-| **Recall** | SKILL.md (fork) | memory_search tool | memory_search tool | SKILL.md |
-| **Install** | Plugin marketplace | `openclaw plugins install --force` + hook permissions | npm + opencode.json | `install.sh` |
+| | [Claude Code](platforms/claude-code/index.md) | [Codex CLI](platforms/codex/index.md) | [DeepSeek Harness](platforms/dsh/index.md) | [OpenClaw](platforms/openclaw/index.md) | [OpenCode](platforms/opencode/index.md) |
+|---|:---:|:---:|:---:|:---:|:---:|
+| **Plugin type** | Shell hooks | Shell hooks | Native ESM plugin | TS plugin | TS plugin |
+| **Capture** | Stop hook + Haiku | Stop hook + Codex | DSH turn events + headless agent | agent_end hook | SQLite daemon |
+| **Recall** | SKILL.md (fork) | SKILL.md | Native skill | memory_search tool | memory_search tool |
+| **Install** | Plugin marketplace | `install.sh` | `dsh plugin add` | `openclaw plugins install --force` + hook permissions | npm + opencode.json |
 
 [:octicons-arrow-right-24: Platform comparison](platforms/index.md){ .md-button }
 

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -221,7 +221,7 @@ This design choice has several important consequences:
 - **Portable.** Copy `.memsearch/memory/` to another machine, run `memsearch index`, and all your memories are searchable there.
 - **Auditable.** You can read, edit, or delete any memory entry with a text editor. Bad summary? Fix it. Sensitive information captured? Delete the line.
 - **Git-friendly.** Commit your memory files to version control for a complete project history. Diff, blame, and revert all work naturally.
-- **Cross-platform.** Memories written by the Claude Code plugin are searchable from [OpenClaw](../openclaw/index.md), [OpenCode](../opencode/index.md), or [Codex](../codex/index.md) -- just point them at the same `.memsearch/memory/` directory.
+- **Cross-platform.** Memories written by the Claude Code plugin are searchable from [Codex](../codex/index.md), [DeepSeek Harness](../dsh/index.md), [OpenClaw](../openclaw/index.md), or [OpenCode](../opencode/index.md) -- just point them at the same `.memsearch/memory/` directory.
 
 This contrasts with solutions that store memories in opaque databases (SQLite, ChromaDB, LanceDB). With memsearch, if you can open a text editor, you can read your memories.
 

--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -12,7 +12,7 @@ memsearch fills this gap with a shell-hook-based plugin that gives Codex the sam
 
 - **First-class memory for Codex** -- no other solution provides hybrid semantic search with progressive disclosure
 - **Same architecture as the Claude Code plugin** -- if you're familiar with one, you understand both
-- **Cross-platform portability** -- memories captured in Codex are searchable from Claude Code, OpenClaw, or OpenCode
+- **Cross-platform portability** -- memories captured in Codex are searchable from Claude Code, DSH, OpenClaw, or OpenCode
 - **ONNX embedding default** -- no OpenAI API key needed for the memory system itself (Codex uses OpenAI for the agent, but memsearch's embeddings are independent)
 
 ---

--- a/docs/platforms/dsh/how-it-works.md
+++ b/docs/platforms/dsh/how-it-works.md
@@ -1,0 +1,98 @@
+# How the DeepSeek Harness Plugin Works
+
+The DSH plugin connects MemSearch to native DSH lifecycle events and services. It does not poll the UI or require the user to save notes manually.
+
+## Lifecycle
+
+```mermaid
+flowchart LR
+    TURN[DSH turn completes] --> CAPTURE[Render and summarize turn]
+    CAPTURE --> MD[".memsearch/memory/YYYY-MM-DD.md"]
+    MD --> INDEX[Milvus hybrid index]
+
+    PROMPT[Next user prompt] --> SEARCH[Search project memory]
+    SEARCH -->|relevant results| INJECT[Inject before model step 1]
+    SEARCH -->|no relevant results| CLEAN[Leave context unchanged]
+
+    QUESTION[History question] --> SKILL[memory-recall skill]
+    SKILL --> SEARCH
+    SKILL --> EXPAND[Expand markdown section]
+    EXPAND --> TRANSCRIPT[Read original DSH transcript]
+```
+
+## Capture
+
+The plugin listens for DSH `session/event` notifications and handles completed turns. It:
+
+1. resolves the durable project directory from the session;
+2. renders user, assistant, and tool activity into a bounded transcript;
+3. summarizes the turn without blocking the active conversation;
+4. appends the result to `.memsearch/memory/YYYY-MM-DD.md` with a session anchor;
+5. lets the shared MemSearch index make the new entry searchable.
+
+Capture jobs are serialized so summarizers do not overlap. Session and turn anchors make writes idempotent if DSH replays an event.
+
+## Selective Pre-Step Injection
+
+At the first model step of a new turn, the plugin searches memory using the user's question. When useful matches exist, it injects a small set of relevant snippets and a `[memsearch] Memory available.` hint. When the search has no relevant result, the model context is left unchanged.
+
+This keeps routine turns lightweight while still surfacing past decisions when they matter.
+
+## Native Memory Recall
+
+The plugin registers `memory-recall` through DSH's native skill service. The agent can use three levels of progressive disclosure:
+
+| Layer | Result | Typical use |
+|-------|--------|-------------|
+| **Search** | Ranked memory snippets | Find likely sessions or decisions |
+| **Expand** | Full markdown section around a result | Recover surrounding rationale and outcomes |
+| **Transcript** | Original DSH conversation and tool activity | Confirm exact commands, paths, or wording |
+
+The same markdown journal can contain entries produced by Claude Code, Codex CLI, DSH, OpenClaw, and OpenCode. Recall is not limited to the platform that wrote a memory.
+
+## Summarization
+
+`summarizeMode` selects the capture backend:
+
+- **`auto`** (default) uses a configured `[plugins.dsh.summarize]` provider when present; otherwise it uses `dsh-headless`.
+- **`dsh-headless`** starts a one-shot headless DSH agent using the model selected by the DSH deployment. The child process disables the MemSearch plugin to prevent recursive capture.
+- **`custom-llm`** calls a provider from the shared MemSearch configuration directly, which is useful for assigning a small dedicated summarization model.
+
+There is no silent fallback to a different backend. If the selected summarizer is unavailable, the journal records a short unavailable note with the original transcript anchor instead of writing an unsummarized conversation dump.
+
+## Project Isolation and Sharing
+
+The memory directory defaults to `<project>/.memsearch`; `MEMSEARCH_DIR` can explicitly select a global location. Collections are derived from the project path, so a long-running DSH web process can serve multiple projects without mixing them.
+
+Point another supported plugin at the same project and it sees the same markdown history and collection.
+
+## Web Memory Dock
+
+Web profiles receive a compact MemSearch capsule above the composer. Expanding it provides:
+
+- pending and installed skill candidates;
+- actions that queue a candidate for agent review or start a user-approved installation;
+- a lazily loaded directory tree for `.memsearch`;
+- rendered Markdown and plain-text previews for supported files.
+
+The browser is read-only, restricts access to the session project's real `.memsearch` tree, rejects path and symlink escapes, and caps preview payloads at 256 KB. TUI and headless profiles do not register the browser routes; their capture and recall behavior is unchanged.
+
+## Background Maintenance
+
+When enabled, maintenance runs after a session closes and on a periodic fallback timer:
+
+- **Project review** keeps `.memsearch/PROJECT.md` aligned with durable project state.
+- **User profile** maintains `.memsearch/USER.md` with reusable preferences and working patterns.
+- **Memory to skill** distills recurring workflows into `.memsearch/skill-candidates/`.
+
+Each task runs only when new journal content exists and its minimum interval has elapsed. Candidates are reviewable but never installed automatically.
+
+## Source Layout
+
+| Path | Purpose |
+|------|---------|
+| `plugins/dsh/index.js` | DSH lifecycle integration, host routes, capture, injection, and maintenance |
+| `plugins/dsh/client.js` | Web dock, candidate review UI, and read-only memory browser |
+| `plugins/dsh/skills/` | Native `memory-recall`, `memory-config`, and memory-to-skill instructions |
+| `plugins/dsh/scripts/` | Summarization, transcript parsing, collection derivation, and maintenance helpers |
+| `plugins/dsh/cordis.patch.yml` | DSH bundle-layer insertion |

--- a/docs/platforms/dsh/index.md
+++ b/docs/platforms/dsh/index.md
@@ -1,0 +1,74 @@
+# DeepSeek Harness Plugin
+
+**Persistent semantic memory for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).** The native DSH plugin captures completed turns, recalls relevant work before the agent starts reasoning, and keeps the same markdown memory available to every other MemSearch platform plugin.
+
+---
+
+## Why MemSearch for DSH?
+
+DSH can host long-running web, TUI, and headless agent sessions across multiple projects. MemSearch adds a durable memory layer that follows each project instead of disappearing with the current conversation:
+
+- **Automatic capture** -- completed turns are summarized and appended to `.memsearch/memory/YYYY-MM-DD.md`
+- **Selective recall** -- relevant memories are injected before the first model step; unrelated turns add no context
+- **Native skill integration** -- DSH registers the `memory-recall` skill for search, expansion, and transcript drill-down
+- **Cross-agent continuity** -- memories are shared with Claude Code, Codex CLI, OpenClaw, and OpenCode when they use the same project
+- **Web memory dock** -- the web profile provides a compact skill-candidate review panel and a read-only `.memsearch` browser
+- **Background maintenance** -- optional tasks keep `PROJECT.md`, `USER.md`, and reusable skill candidates current
+
+## Quick Start
+
+```bash
+# Install the MemSearch CLI and local ONNX embedding model support
+uv tool install "memsearch[onnx]"
+
+# Attach the plugin to a DSH profile
+dsh plugin --profile web add @zilliz/memsearch-dsh
+```
+
+Replace `web` with the DSH profile you use, then restart that profile or start a new session. Continue chatting normally; there is no save command to remember.
+
+After a completed turn, confirm that the daily memory journal exists:
+
+```bash
+ls .memsearch/memory/
+```
+
+To recall previous work, ask naturally or name the registered skill:
+
+```text
+Use memory-recall to find what we decided about the deployment architecture.
+```
+
+[:octicons-arrow-right-24: Installation](installation.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: How It Works](how-it-works.md){ .md-button }
+
+## What Happens Automatically
+
+| Event | MemSearch behavior |
+|-------|--------------------|
+| **A turn completes** | Summarizes the user, assistant, and tool activity into the project's daily markdown journal |
+| **A new turn begins** | Searches the project memory and injects only relevant results before the first model step |
+| **The agent needs exact history** | Uses `memory-recall` to search, expand a section, and inspect the original DSH transcript |
+| **A DSH session closes** | Runs enabled maintenance tasks when their configured interval is due |
+| **You open the web dock** | Lists skill candidates and previews supported `.memsearch` files without modifying them |
+
+## Memory Stays Portable
+
+The markdown files are the source of truth; Milvus is a rebuildable search index. A project that moves between supported agents keeps the same memory history:
+
+```text
+Claude Code ─┐
+Codex CLI ───┤
+DSH ─────────┼──> .memsearch/memory/*.md ──> Milvus hybrid search
+OpenClaw ────┤
+OpenCode ────┘
+```
+
+No export step or proprietary memory format is required.
+
+## Next Steps
+
+- [Installation](installation.md) -- profiles, verification, configuration, updating, and uninstalling
+- [How It Works](how-it-works.md) -- capture, injection, recall, summarization, maintenance, and the web dock
+- [Platform Comparison](../index.md) -- compare DSH with the other supported plugins
+- [Configuration](../../home/configuration.md) -- embedding providers, Milvus, and shared MemSearch settings

--- a/docs/platforms/dsh/installation.md
+++ b/docs/platforms/dsh/installation.md
@@ -1,0 +1,126 @@
+# Install the DeepSeek Harness Plugin
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 22.19 or newer, as required by DSH
+- A DSH profile such as `web`, `tui`, or `headless`
+- The `dsh` command available on `PATH`
+
+## 1. Install MemSearch
+
+The default ONNX embedding provider runs locally and does not require an API key:
+
+```bash
+uv tool install "memsearch[onnx]"
+```
+
+The embedding model downloads from Hugging Face the first time it is used and is cached afterward.
+
+## 2. Add the Plugin to a DSH Profile
+
+Install the published npm package into the profile you use:
+
+```bash
+dsh plugin --profile web add @zilliz/memsearch-dsh
+```
+
+Replace `web` with another profile name when appropriate. The command adds the package to that profile and inserts the MemSearch plugin into its bundle layers.
+
+Restart the profile, or begin a new DSH session, so the plugin mounts.
+
+### Install from Source
+
+Use a local checkout when developing the plugin:
+
+```bash
+git clone https://github.com/zilliztech/memsearch.git
+dsh plugin --profile web add /absolute/path/to/memsearch/plugins/dsh
+```
+
+The plugin is plain ESM with no build step. Restart the profile after changing the plugin source.
+
+## 3. Verify the Installation
+
+Complete a normal DSH turn, then check the project memory directory:
+
+```bash
+ls .memsearch/memory/
+cat .memsearch/memory/$(date +%Y-%m-%d).md
+```
+
+You can also ask DSH to use the registered skill:
+
+```text
+Use memory-recall to search for our earlier database migration decision.
+```
+
+In a web profile, look for the compact **MemSearch** capsule above the composer. Expanding it shows skill candidates and the read-only `.memsearch` browser.
+
+## Plugin Settings
+
+The plugin works without configuration. Its DSH profile settings control lifecycle behavior:
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `captureEnabled` | `true` | Capture completed turns into the daily memory journal |
+| `injectEnabled` | `true` | Search and inject relevant memory before the first model step |
+| `summarizeEnabled` | `true` | Summarize turns before writing them |
+| `summarizeMode` | `auto` | Use a configured API provider when present; otherwise use a one-shot DSH headless agent |
+
+To override these settings, patch the `memsearch` row in the profile's `cordis.patch.yml`:
+
+```yaml
+- id: memsearch
+  config:
+    captureEnabled: true
+    injectEnabled: true
+    summarizeMode: auto
+```
+
+Embedding, Milvus, and provider settings continue to live in the shared MemSearch configuration. For example, to route DSH capture summarization through a configured provider:
+
+```bash
+memsearch config set llm.providers.openai.type openai
+memsearch config set llm.providers.openai.model gpt-5-mini
+memsearch config set llm.providers.openai.api_key env:OPENAI_API_KEY
+memsearch config set plugins.dsh.summarize.provider openai
+```
+
+Leave `plugins.dsh.summarize.provider` unset to use the DSH headless-agent default. Setting a provider selects the direct `custom-llm` route. See [How It Works](how-it-works.md#summarization) for the backend behavior.
+
+## Optional Maintenance
+
+These background tasks are disabled by default:
+
+```bash
+memsearch config set plugins.dsh.project_review.enabled true
+memsearch config set plugins.dsh.user_profile.enabled true
+memsearch config set plugins.dsh.memory_to_skill.enabled true
+```
+
+They maintain `.memsearch/PROJECT.md`, `.memsearch/USER.md`, and `.memsearch/skill-candidates/`. Skill candidates remain inert until you choose to install one.
+
+## Update
+
+Update the package in the selected profile, then restart that profile:
+
+```bash
+dsh plugin --profile web update @zilliz/memsearch-dsh
+```
+
+## Uninstall
+
+```bash
+dsh plugin --profile web remove @zilliz/memsearch-dsh
+```
+
+Removing the plugin does not delete `.memsearch` markdown files or the Milvus index.
+
+## Troubleshooting
+
+- **No memory file appears:** confirm the plugin mounted in the DSH session log and that `captureEnabled` is still `true`.
+- **The recall skill is missing:** restart the profile after installation and confirm `@zilliz/memsearch-dsh` is present in that profile.
+- **Summarization reports an unavailable note:** verify `dsh` is on `PATH`, or check the configured `[plugins.dsh.summarize]` provider.
+- **The web dock is absent:** the dock requires a web profile; capture, injection, and recall still work in TUI and headless profiles.
+- **First search cannot download the model:** pre-cache the ONNX model from an environment with access to Hugging Face, or configure another [embedding provider](../../home/configuration.md).

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -1,28 +1,31 @@
 # Platform Overview
 
-memsearch provides plugins for 4 AI coding agent platforms. All plugins share the same core architecture: capture conversations to markdown, index with Milvus, recall via semantic search.
+memsearch provides plugins for 5 AI coding agent platforms. All plugins share the same core architecture: capture conversations to markdown, index with Milvus, recall via semantic search.
 
 ---
 
 ## Comparison Table
 
-| Feature | [Claude Code](claude-code/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) | [Codex CLI](codex/index.md) |
-|---------|:---:|:---:|:---:|:---:|
-| **Plugin type** | Shell hooks | TS registerTool | TS npm plugin | Shell hooks |
-| **Capture method** | Stop hook (async) | agent_end hook | SQLite daemon | Stop hook (async) |
-| **Summarization** | `claude -p --model haiku` | OpenClaw agent | `opencode run` | `codex exec` |
-| **Recall mechanism** | SKILL.md (context: fork) | memory_search tool | memory_search tool | SKILL.md |
-| **L3 transcript format** | Claude Code JSONL | OpenClaw JSONL | OpenCode SQLite | Codex rollout JSONL |
-| **Isolation** | Per-project collection | Per-workspace collection | Per-project collection | Per-project collection |
-| **Install method** | Plugin marketplace | `openclaw plugins install --force` + hook permissions | npm + opencode.json | `install.sh` |
-| **Embedding default** | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) |
-| **API key required** | No (ONNX default) | No (ONNX default) | No (ONNX default) | No (ONNX default) |
+| Feature | [Claude Code](claude-code/index.md) | [Codex CLI](codex/index.md) | [DeepSeek Harness](dsh/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) |
+|---------|:---:|:---:|:---:|:---:|:---:|
+| **Plugin type** | Shell hooks | Shell hooks | Native ESM + web client | TS registerTool | TS npm plugin |
+| **Capture method** | Stop hook (async) | Stop hook (async) | `session/event` turn end | agent_end hook | SQLite daemon |
+| **Summarization** | `claude -p --model haiku` | `codex exec` | DSH headless agent | OpenClaw agent | `opencode run` |
+| **Recall mechanism** | SKILL.md (context: fork) | SKILL.md | Native skill | memory_search tool | memory_search tool |
+| **L3 transcript format** | Claude Code JSONL | Codex rollout JSONL | DSH session database | OpenClaw JSONL | OpenCode SQLite |
+| **Isolation** | Per-project collection | Per-project collection | Per-project collection | Per-workspace collection | Per-project collection |
+| **Install method** | Plugin marketplace | `install.sh` | `dsh plugin add` | `openclaw plugins install --force` + hook permissions | npm + opencode.json |
+| **Embedding default** | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) | ONNX bge-m3 (CPU) |
+| **API key required** | No (ONNX default) | No (ONNX default) | No (ONNX default) | No (ONNX default) | No (ONNX default) |
 
 Each plugin keeps its current native summarizer when the plugin-specific
-provider setting is empty or `native`. To override one plugin's native model,
-set `plugins.<platform>.summarize.model`, for example
+provider setting is empty. Claude Code, Codex, OpenClaw, and OpenCode also
+accept `native`; DSH selects its headless-agent backend when the provider is
+unset. To override one plugin's native model, set
+`plugins.<platform>.summarize.model`, for example
 `plugins.claude-code.summarize.model`, `plugins.codex.summarize.model`,
-`plugins.opencode.summarize.model`, or `plugins.openclaw.summarize.model`.
+`plugins.dsh.summarize.model`, `plugins.openclaw.summarize.model`, or
+`plugins.opencode.summarize.model`.
 To route summarization through a memsearch-managed API provider, define
 `[llm.providers.<name>]` and set `plugins.<platform>.summarize.provider` to that
 name. These plugin settings do not fall back to `llm.model`.
@@ -87,7 +90,7 @@ All plugins write to the same markdown format:
 
 All plugins write standard markdown and derive collection names from the project directory using the same algorithm. Memories are automatically shared across platforms -- no manual configuration needed:
 
-- Memories written in **Claude Code** are searchable from **Codex**, **OpenCode**, or **OpenClaw**
+- Memories written in **Claude Code** are searchable from **Codex**, **DSH**, **OpenClaw**, or **OpenCode**
 - Same project directory = same collection name = shared memories
 - Different project directories are naturally isolated
 
@@ -98,9 +101,10 @@ All plugins write standard markdown and derive collection names from the project
 | Scenario | Recommended Platform |
 |----------|---------------------|
 | Primary Claude Code user | [Claude Code plugin](claude-code/index.md) -- most mature, marketplace install |
+| Codex CLI user | [Codex plugin](codex/index.md) -- shell hooks, similar to Claude Code |
+| DeepSeek Harness user | [DSH plugin](dsh/index.md) -- native lifecycle events, skill recall, and web memory browser |
 | OpenClaw agent development | [OpenClaw plugin](openclaw/index.md) -- native TS integration, multi-agent isolation |
 | OpenCode user | [OpenCode plugin](opencode/index.md) -- npm package, SQLite-native capture |
-| Codex CLI user | [Codex plugin](codex/index.md) -- shell hooks, similar to Claude Code |
 | Using multiple platforms | Install plugins on each -- they share the same memory backend |
 
 ---

--- a/docs/platforms/openclaw/how-it-works.md
+++ b/docs/platforms/openclaw/how-it-works.md
@@ -134,7 +134,7 @@ OpenClaw supports multiple agents (e.g., `main`, `work`). The plugin provides au
 | `work` | `~/.openclaw/workspace-work/.memsearch/memory/` | `ms_workspace_work_<hash>` |
 | custom | `<workspace-dir>/.memsearch/memory/` | `ms_<basename>_<hash>` |
 
-Collection names are derived from the workspace path using the same algorithm as Claude Code, Codex, and OpenCode. This means when an agent's workspace points to a project directory used by other platforms, memories are automatically shared across platforms.
+Collection names are derived from the workspace path using the same algorithm as Claude Code, Codex, DSH, and OpenCode. This means when an agent's workspace points to a project directory used by other platforms, memories are automatically shared across platforms.
 
 ---
 

--- a/docs/platforms/openclaw/index.md
+++ b/docs/platforms/openclaw/index.md
@@ -20,7 +20,7 @@ OpenClaw ships with **memory-core**, a built-in memory plugin backed by SQLite +
 | **Progressive disclosure** | Single-layer (search only) | Three-layer: search → expand → transcript drill-down |
 | **Embedding model** | Depends on configuration | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Jina, Mistral, Ollama |
 | **Data portability** | Locked in SQLite | Copy `.md` files, rebuild index anywhere |
-| **Cross-platform** | OpenClaw only | Same memories accessible from Claude Code, Codex, OpenCode |
+| **Cross-platform** | OpenClaw only | Same memories accessible from Claude Code, Codex, DSH, OpenCode |
 
 ### When to stay with memory-core
 
@@ -37,12 +37,12 @@ Switch when you need: hybrid search (keyword + semantic), cross-platform memory 
 OpenClaw supports multiple agents (e.g., `main`, `work`, custom agents). memsearch provides **automatic per-agent memory isolation** based on workspace directories:
 
 - **Separate memory directories**: each agent's workspace has its own `.memsearch/memory/`
-- **Directory-based collections**: collection names are derived from the workspace path using the same algorithm as Claude Code, Codex, and OpenCode (`ms_<basename>_<hash>`)
+- **Directory-based collections**: collection names are derived from the workspace path using the same algorithm as Claude Code, Codex, DSH, and OpenCode (`ms_<basename>_<hash>`)
 - **Cross-platform sharing**: when an agent's workspace points to the same project directory used by other platforms, memories are automatically shared
 
 This means agents with different workspaces have isolated memories, while agents pointing to the same project directory share memories -- even across platforms.
 
-!!! tip "Cross-platform sharing with Claude Code / Codex / OpenCode"
+!!! tip "Cross-platform sharing with Claude Code / Codex / DSH / OpenCode"
 
     To share memories with other platforms on the same project, set your agent's workspace to the project directory:
 
@@ -70,7 +70,7 @@ This means agents with different workspaces have isolated memories, while agents
 - **Multi-agent isolation** -- each agent gets its own memory directory and Milvus collection
 - **Cold-start context** -- recent memories injected on agent start via `before_agent_start` hook
 - **ONNX embedding by default** -- no API key required, runs locally on CPU
-- **Cross-platform sharing** -- same collection names as Claude Code, Codex, and OpenCode for seamless memory portability
+- **Cross-platform sharing** -- same collection names as Claude Code, Codex, DSH, and OpenCode for seamless memory portability
 
 ---
 

--- a/docs/platforms/openclaw/memory-tools.md
+++ b/docs/platforms/openclaw/memory-tools.md
@@ -117,7 +117,7 @@ The three-layer model is particularly valuable for OpenClaw because agents often
 | **Search quality** | Hybrid search fuses semantic + keyword | Dense similarity only |
 | **Per-agent isolation** | Built-in (automatic) | Not in default version (fixed in memory-lancedb-pro) |
 | **Storage** | Plain `.md` files + Milvus index | LanceDB tables (Arrow format) |
-| **Cross-platform** | Memories accessible from Claude Code, Codex, OpenCode | OpenClaw only |
+| **Cross-platform** | Memories accessible from Claude Code, Codex, DSH, OpenCode | OpenClaw only |
 | **Embedding** | Pluggable (ONNX, OpenAI, etc.) | Typically fixed to one provider |
 
 memsearch's key advantages are hybrid search (BM25 catches exact identifiers that dense search misses), automatic per-agent isolation (which memory-lancedb only offers in its pro variant), and cross-platform portability.

--- a/docs/platforms/opencode/index.md
+++ b/docs/platforms/opencode/index.md
@@ -13,7 +13,7 @@ OpenCode does not ship with a built-in memory system. Several third-party option
 | **Vector backend** | [Milvus](https://milvus.io/) -- hybrid search (dense + BM25 + RRF) | SQLite + [USearch](https://github.com/unum-cloud/usearch) (dense only) | Varies by implementation |
 | **Search quality** | Hybrid: semantic similarity + keyword matching fused with RRF | Dense vector similarity only | Typically dense only |
 | **Storage format** | Plain `.md` files (human-readable, git-friendly) | SQLite database (opaque) | Varies |
-| **Cross-platform** | Same memories accessible from Claude Code, OpenClaw, Codex | OpenCode only | Single platform |
+| **Cross-platform** | Same memories accessible from Claude Code, Codex, DSH, OpenClaw | OpenCode only | Single platform |
 | **Capture method** | Background daemon polls SQLite | Hook-based | Varies |
 | **Progressive disclosure** | Three-layer: search → expand → transcript | Typically single-layer | Typically single-layer |
 | **Embedding model** | Pluggable: ONNX bge-m3 (default), OpenAI, Google, Voyage, Jina, Mistral, Ollama | Typically fixed | Varies |
@@ -38,7 +38,7 @@ If you use multiple AI coding agents (e.g., OpenCode for some projects, Claude C
 ## When Is This Useful?
 
 - **Multi-day projects.** OpenCode sessions are ephemeral by default. memsearch captures every conversation so you can pick up where you left off without re-explaining context.
-- **Cross-platform workflows.** You switch between OpenCode, Claude Code, or Codex depending on the task. memsearch provides continuous memory across all of them.
+- **Cross-platform workflows.** You switch between Claude Code, Codex, DSH, OpenClaw, or OpenCode depending on the task. memsearch provides continuous memory across all of them.
 - **Team environments.** Commit `.memsearch/memory/` to git and team members can search the project's decision history.
 - **Debugging trails.** When a bug resurfaces, memsearch can recall what was tried before -- which approaches failed, what worked, and why.
 

--- a/docs/platforms/opencode/memory-tools.md
+++ b/docs/platforms/opencode/memory-tools.md
@@ -115,7 +115,7 @@ This is useful for scripting, CI/CD pipelines, or quick lookups without starting
 | **Capture method** | Background daemon (automatic) | Hook-based or manual | N/A |
 | **Storage** | Plain `.md` files (human-readable) | SQLite (opaque) | N/A |
 | **Progressive disclosure** | Three-layer (search → expand → transcript) | Single-layer | N/A |
-| **Cross-platform** | Yes -- Claude Code, OpenClaw, Codex | OpenCode only | N/A |
+| **Cross-platform** | Yes -- Claude Code, Codex, DSH, OpenClaw | OpenCode only | N/A |
 | **Keyword search** | BM25 catches exact terms | Dense-only may miss specific terms | N/A |
 | **Embedding model** | Pluggable (ONNX default, no API key) | Typically fixed | N/A |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,15 @@ nav:
     - How It Works: platforms/claude-code/how-it-works.md
     - Memory Recall: platforms/claude-code/memory-recall.md
     - Troubleshooting: platforms/claude-code/troubleshooting.md
+  - Codex CLI Plugin:
+    - Overview: platforms/codex/index.md
+    - Installation: platforms/codex/installation.md
+    - How It Works: platforms/codex/how-it-works.md
+    - Memory Recall: platforms/codex/memory-recall.md
+  - DeepSeek Harness Plugin:
+    - Overview: platforms/dsh/index.md
+    - Installation: platforms/dsh/installation.md
+    - How It Works: platforms/dsh/how-it-works.md
   - OpenClaw Plugin:
     - Overview: platforms/openclaw/index.md
     - Installation: platforms/openclaw/installation.md
@@ -60,11 +69,6 @@ nav:
     - Installation: platforms/opencode/installation.md
     - How It Works: platforms/opencode/how-it-works.md
     - Memory Tools: platforms/opencode/memory-tools.md
-  - Codex CLI Plugin:
-    - Overview: platforms/codex/index.md
-    - Installation: platforms/codex/installation.md
-    - How It Works: platforms/codex/how-it-works.md
-    - Memory Recall: platforms/codex/memory-recall.md
   - For Agent Developers:
     - CLI Reference: cli.md
     - Python API: python-api.md

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -25,7 +25,7 @@ review   ── web UI dock panel ──> GET/POST /memsearch-dsh/* ──> list
 
 ## Install
 
-### From npm (recommended, once published)
+### From npm (recommended)
 
 ```bash
 dsh plugin --profile web add @zilliz/memsearch-dsh
@@ -226,7 +226,7 @@ through the DSH logger.
 ## Uninstall
 
 ```bash
-dsh plugin --profile web rm @zilliz/memsearch-dsh
+dsh plugin --profile web remove @zilliz/memsearch-dsh
 ```
 
 Removing the dependency drops the profile-layer entry; the memory markdown


### PR DESCRIPTION
## Summary

- announce DeepSeek Harness support in the README and add a complete quick-start section
- add DSH overview, installation, and architecture documentation
- place DSH after Codex across navigation, platform lists, comparisons, and architecture diagrams
- update cross-platform references from four plugins to five
- refresh the published DSH package install and removal commands

## Validation

- uv run --frozen --group docs mkdocs build --strict
- git diff --check