### PR TITLE
docs: use Codex product name consistently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ When modifying hooks/skills, keep in mind:
 | **Claude Code plugin** | `plugins/claude-code/.claude-plugin/plugin.json` | Marketplace (`.claude-plugin/marketplace.json`) |
 | **OpenClaw plugin** | `plugins/openclaw/package.json` | ClawHub (`clawhub package publish`) |
 | **OpenCode plugin** | `plugins/opencode/package.json` | npm (`@zilliz/memsearch-opencode`) |
-| **Codex CLI plugin** | *(none)* | `install.sh` (no version management) |
+| **Codex plugin** | *(none)* | `install.sh` (no version management) |
 
 See `CLAUDE.local.md` for detailed release procedures, current versions, and operational details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ plugins/
 │   ├── index.ts            # Tools + experimental hooks
 │   ├── scripts/            # capture-daemon.py (SQLite polling), parse-transcript.py
 │   └── skills/             # memory-recall SKILL.md
-└── codex/                  # Codex CLI plugin (shell hooks + SKILL.md)
+└── codex/                  # Codex plugin (shell hooks + SKILL.md)
     ├── hooks/              # SessionStart, Stop, UserPromptSubmit
     ├── skills/             # memory-recall skill
     └── scripts/            # install.sh, parse-rollout.sh, derive-collection.sh
@@ -136,7 +136,7 @@ ln -sf $(pwd)/plugins/opencode/index.ts ~/.config/opencode/plugins/memsearch.ts
 # Restart opencode to load
 ```
 
-### Codex CLI
+### Codex
 
 ```bash
 bash plugins/codex/scripts/install.sh   # copies skill + generates hooks.json

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://pypi.org/project/memsearch/"><img src="https://img.shields.io/pypi/v/memsearch?style=flat-square&color=blue" alt="PyPI"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/claude-code/"><img src="https://img.shields.io/badge/Claude_Code-plugin-c97539?style=flat-square&logo=claude&logoColor=white" alt="Claude Code"></a>
-  <a href="https://zilliztech.github.io/memsearch/platforms/codex/"><img src="https://img.shields.io/badge/Codex_CLI-plugin-ff6b35?style=flat-square" alt="Codex CLI"></a>
+  <a href="https://zilliztech.github.io/memsearch/platforms/codex/"><img src="https://img.shields.io/badge/Codex-plugin-ff6b35?style=flat-square" alt="Codex"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/dsh/"><img src="https://img.shields.io/badge/DeepSeek_Harness-plugin-4d6bfe?style=flat-square" alt="DeepSeek Harness"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/openclaw/"><img src="https://img.shields.io/badge/OpenClaw-plugin-4a9eff?style=flat-square" alt="OpenClaw"></a>
   <a href="https://zilliztech.github.io/memsearch/platforms/opencode/"><img src="https://img.shields.io/badge/OpenCode-plugin-22c55e?style=flat-square" alt="OpenCode"></a>
@@ -38,7 +38,7 @@
 
 ### Why memsearch?
 
-- 🌐 **All Platforms, One Memory** — memories flow across [Claude Code](plugins/claude-code/README.md), [Codex CLI](plugins/codex/README.md), [DeepSeek Harness](plugins/dsh/README.md), [OpenClaw](plugins/openclaw/README.md), and [OpenCode](plugins/opencode/README.md). A conversation in one agent becomes searchable context in all others — no extra setup
+- 🌐 **All Platforms, One Memory** — memories flow across [Claude Code](plugins/claude-code/README.md), [Codex](plugins/codex/README.md), [DeepSeek Harness](plugins/dsh/README.md), [OpenClaw](plugins/openclaw/README.md), and [OpenCode](plugins/opencode/README.md). A conversation in one agent becomes searchable context in all others — no extra setup
 - 👥 **For Agent Users**, install a plugin and get persistent memory with zero effort; **for Agent Developers**, use the full [CLI](https://zilliztech.github.io/memsearch/cli/) and [Python API](https://zilliztech.github.io/memsearch/python-api/) to build memory and harness engineering into your own agents
 - 📄 **Markdown is the source of truth** — inspired by [OpenClaw](https://github.com/openclaw/openclaw). Your memories are just `.md` files — human-readable, editable, version-controllable. Milvus is a "shadow index": a derived, rebuildable cache
 - 🔍 **Progressive retrieval, hybrid search, smart dedup, live sync** — 3-layer recall (search → expand → transcript); dense vector + BM25 sparse + RRF reranking; SHA-256 content hashing skips unchanged content; file watcher auto-indexes in real time
@@ -83,7 +83,7 @@ We discussed Redis caching before, what was the TTL we chose?
 </details>
 
 <details open>
-<summary><h3>For Codex CLI Users</h3></summary>
+<summary><h3>For Codex Users</h3></summary>
 
 ```bash
 # Install
@@ -106,7 +106,7 @@ ls .memsearch/memory/
 $memory-recall what did we discuss about deployment?
 ```
 
-> 📖 [Codex CLI Plugin docs](https://zilliztech.github.io/memsearch/platforms/codex/)
+> 📖 [Codex Plugin docs](https://zilliztech.github.io/memsearch/platforms/codex/)
 
 </details>
 
@@ -318,7 +318,7 @@ Under the hood, candidates live in a git-tracked `.memsearch/skill-candidates/` 
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ---
 
@@ -331,7 +331,7 @@ Beyond ready-to-use plugins, memsearch provides a complete **CLI and Python API*
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                  🧑‍💻 For Agent Users (Plugins)                │
-│ Claude Code · Codex CLI · DSH · OpenClaw · OpenCode · Your App │
+│ Claude Code · Codex · DSH · OpenClaw · OpenCode · Your App   │
 │                              │                               │
 ├────────────────────────────┬─────────────────────────────────┤
 │  🛠️ For Agent Developers   │  Build your own with ↓          │
@@ -675,7 +675,7 @@ Settings priority: Built-in defaults → `~/.memsearch/config.toml` → `.memsea
 ## 🔗 Links
 
 - 📖 [Documentation](https://zilliztech.github.io/memsearch/) — full guides, API reference, and architecture details
-- 🔌 [Platform Plugins](https://zilliztech.github.io/memsearch/platforms/) — Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, OpenCode
+- 🔌 [Platform Plugins](https://zilliztech.github.io/memsearch/platforms/) — Claude Code, Codex, DeepSeek Harness, OpenClaw, OpenCode
 - 💡 [Design Philosophy](https://zilliztech.github.io/memsearch/design-philosophy/) — why markdown, why Milvus, competitor comparison
 - 🦞 [OpenClaw](https://github.com/openclaw/openclaw) — the memory architecture that inspired memsearch
 - 🗄️ [Milvus](https://milvus.io/) | [Zilliz Cloud](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=memsearch-readme) — the vector database powering memsearch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,13 +6,13 @@ This page explains the technical architecture and key implementation decisions b
 
 ## Cross-Platform Memory Sharing
 
-memsearch supports 5 AI coding agent platforms: [Claude Code](platforms/claude-code/index.md), [Codex CLI](platforms/codex/index.md), [DeepSeek Harness](platforms/dsh/index.md), [OpenClaw](platforms/openclaw/index.md), and [OpenCode](platforms/opencode/index.md). All plugins write to the same markdown format and use the same Milvus index, making memories portable across platforms.
+memsearch supports 5 AI coding agent platforms: [Claude Code](platforms/claude-code/index.md), [Codex](platforms/codex/index.md), [DeepSeek Harness](platforms/dsh/index.md), [OpenClaw](platforms/openclaw/index.md), and [OpenCode](platforms/opencode/index.md). All plugins write to the same markdown format and use the same Milvus index, making memories portable across platforms.
 
 ```mermaid
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
-        CX["Codex CLI<br/>(Stop hook + Codex)"]
+        CX["Codex<br/>(Stop hook + Codex)"]
         DSH["DeepSeek Harness<br/>(turn event + headless agent)"]
         OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -43,7 +43,7 @@ This is memsearch's key differentiator: **memories written by one agent are sear
 graph TB
     subgraph "Capture (per-platform)"
         CC["Claude Code<br/>(Stop hook + Haiku)"]
-        CX["Codex CLI<br/>(Stop hook + Codex)"]
+        CX["Codex<br/>(Stop hook + Codex)"]
         DSH["DeepSeek Harness<br/>(turn event + headless agent)"]
         OC["OpenClaw<br/>(agent_end)"]
         OO["OpenCode<br/>(SQLite daemon)"]
@@ -63,7 +63,7 @@ graph TB
 
 All 5 platform plugins write to the same markdown format and use the same Milvus backend. This means:
 
-- You can switch between Claude Code and Codex CLI and keep your memories
+- You can switch between Claude Code and Codex and keep your memories
 - Team members using different agents can share a knowledge base
 - There is no per-agent silo -- one memory, every agent
 

--- a/docs/home/comparison.md
+++ b/docs/home/comparison.md
@@ -23,7 +23,7 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 | Claude Code | ✅ | ✅ built-in | ✅ | ✅ | ✅ | ✅ | ❌ |
 | OpenClaw | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | OpenCode | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Codex CLI | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Codex | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Cursor | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
 | Gemini CLI | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
 | Generic MCP | — | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
@@ -45,7 +45,7 @@ memsearch is both a CLI engine and a set of native plugins for four coding CLIs,
 
 ## Where memsearch is different
 
-- **Covers Claude Code + Codex CLI + DeepSeek Harness + OpenClaw + OpenCode in one project.** No other entry covers all five.
+- **Covers Claude Code + Codex + DeepSeek Harness + OpenClaw + OpenCode in one project.** No other entry covers all five.
 - **Retrieves on demand** instead of stuffing the whole file into every session like Claude Code's built-in memory.
 - **Markdown + Milvus, not an opaque DB.** qmd and Letta's MemFS share the markdown-canonical approach; claude-mem / MemPalace / mem0 keep state in a DB.
 - **Append-only writes, no LLM curation on the write path.** mem0 and Letta's traditional memory depend on LLM write-time curation (powerful but can silently mutate past writes).

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -286,4 +286,4 @@ Each plugin may have additional configuration. See:
 - [Claude Code Plugin](../platforms/claude-code/index.md)
 - [OpenClaw Plugin](../platforms/openclaw/index.md)
 - [OpenCode Plugin](../platforms/opencode/index.md)
-- [Codex CLI Plugin](../platforms/codex/index.md)
+- [Codex Plugin](../platforms/codex/index.md)

--- a/docs/home/for-users.md
+++ b/docs/home/for-users.md
@@ -9,14 +9,14 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ## Choose Your Platform
 
 | Platform | Install | Maturity |
 |----------|---------|----------|
 | [**Claude Code**](../platforms/claude-code/index.md) | Marketplace or `--plugin-dir` | Most mature |
-| [**Codex CLI**](../platforms/codex/index.md) | `bash install.sh` | Stable |
+| [**Codex**](../platforms/codex/index.md) | `bash install.sh` | Stable |
 | [**DeepSeek Harness**](../platforms/dsh/index.md) | `dsh plugin --profile <name> add @zilliz/memsearch-dsh` | Stable |
 | [**OpenClaw**](../platforms/openclaw/index.md) | `openclaw plugins install --force` + hook permissions | Stable |
 | [**OpenCode**](../platforms/opencode/index.md) | Add to `opencode.json` plugin array | Stable |
@@ -46,7 +46,7 @@ Simple questions stop at L1. Complex questions go deeper.
 Each platform adapts the same architecture to its own plugin system:
 
 - **Claude Code**: [Full guide →](../platforms/claude-code/index.md)
-- **Codex CLI**: [Full guide →](../platforms/codex/index.md)
+- **Codex**: [Full guide →](../platforms/codex/index.md)
 - **DeepSeek Harness**: [Full guide →](../platforms/dsh/index.md)
 - **OpenClaw**: [Full guide →](../platforms/openclaw/index.md)
 - **OpenCode**: [Full guide →](../platforms/opencode/index.md)

--- a/docs/home/why.md
+++ b/docs/home/why.md
@@ -2,7 +2,7 @@
 
 ## One Memory, Every Agent
 
-memsearch provides persistent memory plugins for **5 major AI coding agent platforms**: [Claude Code](../platforms/claude-code/index.md), [Codex CLI](../platforms/codex/index.md), [DeepSeek Harness](../platforms/dsh/index.md), [OpenClaw](../platforms/openclaw/index.md), and [OpenCode](../platforms/opencode/index.md).
+memsearch provides persistent memory plugins for **5 major AI coding agent platforms**: [Claude Code](../platforms/claude-code/index.md), [Codex](../platforms/codex/index.md), [DeepSeek Harness](../platforms/dsh/index.md), [OpenClaw](../platforms/openclaw/index.md), and [OpenCode](../platforms/opencode/index.md).
 
 Memories written in one platform are searchable from any other. A conversation in Claude Code becomes available context in Codex, DSH, OpenClaw, and OpenCode — no extra setup, no manual export.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Pick your platform, install the plugin, and you're done. memsearch captures conv
 - **Trace feature history** — understand how a feature evolved across sessions, including the files changed and tradeoffs discussed.
 - **Do code archaeology** — ask when and why a module, config, or workflow was changed before touching it again.
 - **Find the right session to resume** — ask which previous conversation covered a topic, recover the relevant context, and continue from there.
-- **Carry context across agents** — keep Claude Code, Codex CLI, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
+- **Carry context across agents** — keep Claude Code, Codex, DeepSeek Harness, OpenClaw, and OpenCode working from the same project memory.
 
 ### Claude Code Plugin
 
@@ -34,7 +34,7 @@ Shell hooks + SKILL.md with `context: fork` subagent. Conversations are auto-sum
 [:octicons-arrow-right-24: Claude Code Plugin docs](platforms/claude-code/index.md){ .md-button .md-button--primary }
 [:octicons-arrow-right-24: Troubleshooting](platforms/claude-code/troubleshooting.md){ .md-button }
 
-### Codex CLI Plugin
+### Codex Plugin
 
 Shell hooks and a native memory-recall skill for terminal coding workflows.
 
@@ -43,7 +43,7 @@ bash memsearch/plugins/codex/scripts/install.sh
 codex --yolo
 ```
 
-[:octicons-arrow-right-24: Codex CLI Plugin docs](platforms/codex/index.md){ .md-button }
+[:octicons-arrow-right-24: Codex Plugin docs](platforms/codex/index.md){ .md-button }
 
 ### DeepSeek Harness Plugin
 
@@ -88,7 +88,7 @@ bash memsearch/plugins/opencode/install.sh
 
 All platforms share the same markdown memory format and derive collection names from the project directory using the same algorithm. A conversation in one agent becomes searchable context in all others -- no extra setup needed.
 
-| | [Claude Code](platforms/claude-code/index.md) | [Codex CLI](platforms/codex/index.md) | [DeepSeek Harness](platforms/dsh/index.md) | [OpenClaw](platforms/openclaw/index.md) | [OpenCode](platforms/opencode/index.md) |
+| | [Claude Code](platforms/claude-code/index.md) | [Codex](platforms/codex/index.md) | [DeepSeek Harness](platforms/dsh/index.md) | [OpenClaw](platforms/openclaw/index.md) | [OpenCode](platforms/opencode/index.md) |
 |---|:---:|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | Shell hooks | Native ESM plugin | TS plugin | TS plugin |
 | **Capture** | Stop hook + Haiku | Stop hook + Codex | DSH turn events + headless agent | agent_end hook | SQLite daemon |

--- a/docs/platforms/codex/how-it-works.md
+++ b/docs/platforms/codex/how-it-works.md
@@ -154,7 +154,7 @@ This ensures memory capture works even when the summarization model is unavailab
 
 ## hooks.json Format
 
-Codex CLI uses a `hooks.json` file (at `~/.codex/hooks.json`) to define hook scripts. The installer updates the nested `hooks` object, replacing only older memsearch Codex entries and preserving unrelated hooks:
+Codex uses a `hooks.json` file (at `~/.codex/hooks.json`) to define hook scripts. The installer updates the nested `hooks` object, replacing only older memsearch Codex entries and preserving unrelated hooks:
 
 ```json
 {

--- a/docs/platforms/codex/index.md
+++ b/docs/platforms/codex/index.md
@@ -1,12 +1,12 @@
-# Codex CLI Plugin
+# Codex Plugin
 
-**Semantic memory for [Codex CLI](https://github.com/openai/codex).** Shell hooks and a memory-recall skill, similar in architecture to the Claude Code plugin.
+**Semantic memory for [Codex](https://github.com/openai/codex).** Shell hooks and a memory-recall skill, similar in architecture to the Claude Code plugin.
 
 ---
 
 ## Why memsearch for Codex?
 
-Codex CLI is OpenAI's open-source terminal coding agent. Unlike Claude Code (which has a mature plugin marketplace) or OpenClaw (which has a built-in memory system), Codex has **no native memory plugin ecosystem**. Hooks support is experimental, and there are few third-party memory solutions available.
+Codex is OpenAI's open-source terminal coding agent. Unlike Claude Code (which has a mature plugin marketplace) or OpenClaw (which has a built-in memory system), Codex has **no native memory plugin ecosystem**. Hooks support is experimental, and there are few third-party memory solutions available.
 
 memsearch fills this gap with a shell-hook-based plugin that gives Codex the same persistent memory capabilities as other platforms:
 
@@ -19,7 +19,7 @@ memsearch fills this gap with a shell-hook-based plugin that gives Codex the sam
 
 ## Full-Access Mode and Sandbox
 
-Codex CLI runs in a sandboxed environment by default. The memsearch plugin requires file system access to write memory files and run the `memsearch` CLI. The recommended approach:
+Codex runs in a sandboxed environment by default. The memsearch plugin requires file system access to write memory files and run the `memsearch` CLI. The recommended approach:
 
 - **Install option**: The `install.sh` script configures `hooks.json` which works in any mode
 - **Stop hook isolation**: The Stop hook uses `codex exec --ephemeral -s read-only -c features.hooks=false` so summarization reuses normal auth without recursing into hooks
@@ -42,7 +42,7 @@ If you experience issues with the Stop hook in strict sandbox mode, see [Trouble
 
 ## When Is This Useful?
 
-- **Codex as your daily driver.** If you use Codex CLI for everyday coding, memsearch gives it memory that persists across sessions -- no more re-explaining context.
+- **Codex as your daily driver.** If you use Codex for everyday coding, memsearch gives it memory that persists across sessions -- no more re-explaining context.
 - **Codex + Claude Code workflows.** Some developers use Codex for quick tasks and Claude Code for complex ones. memsearch provides unified memory across both.
 - **Long debugging sessions.** Codex sessions tend to be focused but context-heavy. memsearch captures the debugging trail so you can pick up where you left off.
 - **Evaluating Codex.** If you're comparing coding agents, having consistent memory across all of them provides a fair evaluation baseline.

--- a/docs/platforms/codex/installation.md
+++ b/docs/platforms/codex/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Codex CLI v0.116.0+
+- Codex v0.116.0+
 - Python 3.10+
 - memsearch installed: `uv tool install "memsearch[onnx]"`
 

--- a/docs/platforms/codex/memory-recall.md
+++ b/docs/platforms/codex/memory-recall.md
@@ -101,7 +101,7 @@ The key architectural difference is in **skill execution context**:
 
 ### Why No Fork Context?
 
-Codex CLI does not support `context: fork` for skills. This means the `$memory-recall` skill runs in the **main conversation context** -- all intermediate search results, chunk expansions, and rollout parsing steps are visible to the user and consume main context tokens.
+Codex does not support `context: fork` for skills. This means the `$memory-recall` skill runs in the **main conversation context** -- all intermediate search results, chunk expansions, and rollout parsing steps are visible to the user and consume main context tokens.
 
 In practice, this works well for targeted queries but is less efficient for broad searches (where many intermediate results would clutter the context). For the best experience with large memory histories, consider using [Milvus Server](../../getting-started.md#milvus-backends) for faster search responses.
 

--- a/docs/platforms/dsh/how-it-works.md
+++ b/docs/platforms/dsh/how-it-works.md
@@ -48,7 +48,7 @@ The plugin registers `memory-recall` through DSH's native skill service. The age
 | **Expand** | Full markdown section around a result | Recover surrounding rationale and outcomes |
 | **Transcript** | Original DSH conversation and tool activity | Confirm exact commands, paths, or wording |
 
-The same markdown journal can contain entries produced by Claude Code, Codex CLI, DSH, OpenClaw, and OpenCode. Recall is not limited to the platform that wrote a memory.
+The same markdown journal can contain entries produced by Claude Code, Codex, DSH, OpenClaw, and OpenCode. Recall is not limited to the platform that wrote a memory.
 
 ## Summarization
 

--- a/docs/platforms/dsh/index.md
+++ b/docs/platforms/dsh/index.md
@@ -11,7 +11,7 @@ DSH can host long-running web, TUI, and headless agent sessions across multiple 
 - **Automatic capture** -- completed turns are summarized and appended to `.memsearch/memory/YYYY-MM-DD.md`
 - **Selective recall** -- relevant memories are injected before the first model step; unrelated turns add no context
 - **Native skill integration** -- DSH registers the `memory-recall` skill for search, expansion, and transcript drill-down
-- **Cross-agent continuity** -- memories are shared with Claude Code, Codex CLI, OpenClaw, and OpenCode when they use the same project
+- **Cross-agent continuity** -- memories are shared with Claude Code, Codex, OpenClaw, and OpenCode when they use the same project
 - **Web memory dock** -- the web profile provides a compact skill-candidate review panel and a read-only `.memsearch` browser
 - **Background maintenance** -- optional tasks keep `PROJECT.md`, `USER.md`, and reusable skill candidates current
 
@@ -58,7 +58,7 @@ The markdown files are the source of truth; Milvus is a rebuildable search index
 
 ```text
 Claude Code ─┐
-Codex CLI ───┤
+Codex ───────┤
 DSH ─────────┼──> .memsearch/memory/*.md ──> Milvus hybrid search
 OpenClaw ────┤
 OpenCode ────┘

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -6,7 +6,7 @@ memsearch provides plugins for 5 AI coding agent platforms. All plugins share th
 
 ## Comparison Table
 
-| Feature | [Claude Code](claude-code/index.md) | [Codex CLI](codex/index.md) | [DeepSeek Harness](dsh/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) |
+| Feature | [Claude Code](claude-code/index.md) | [Codex](codex/index.md) | [DeepSeek Harness](dsh/index.md) | [OpenClaw](openclaw/index.md) | [OpenCode](opencode/index.md) |
 |---------|:---:|:---:|:---:|:---:|:---:|
 | **Plugin type** | Shell hooks | Shell hooks | Native ESM + web client | TS registerTool | TS npm plugin |
 | **Capture method** | Stop hook (async) | Stop hook (async) | `session/event` turn end | agent_end hook | SQLite daemon |
@@ -101,7 +101,7 @@ All plugins write standard markdown and derive collection names from the project
 | Scenario | Recommended Platform |
 |----------|---------------------|
 | Primary Claude Code user | [Claude Code plugin](claude-code/index.md) -- most mature, marketplace install |
-| Codex CLI user | [Codex plugin](codex/index.md) -- shell hooks, similar to Claude Code |
+| Codex user | [Codex plugin](codex/index.md) -- shell hooks, similar to Claude Code |
 | DeepSeek Harness user | [DSH plugin](dsh/index.md) -- native lifecycle events, skill recall, and web memory browser |
 | OpenClaw agent development | [OpenClaw plugin](openclaw/index.md) -- native TS integration, multi-agent isolation |
 | OpenCode user | [OpenCode plugin](opencode/index.md) -- npm package, SQLite-native capture |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
     - How It Works: platforms/claude-code/how-it-works.md
     - Memory Recall: platforms/claude-code/memory-recall.md
     - Troubleshooting: platforms/claude-code/troubleshooting.md
-  - Codex CLI Plugin:
+  - Codex Plugin:
     - Overview: platforms/codex/index.md
     - Installation: platforms/codex/installation.md
     - How It Works: platforms/codex/how-it-works.md

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -1,10 +1,10 @@
-# memsearch — Codex CLI Plugin
+# memsearch — Codex Plugin
 
-Automatic persistent memory for [Codex CLI](https://github.com/openai/codex). Every conversation turn is summarized and indexed — your next session picks up where you left off.
+Automatic persistent memory for [Codex](https://github.com/openai/codex). Every conversation turn is summarized and indexed — your next session picks up where you left off.
 
 ## Prerequisites
 
-- [Codex CLI](https://github.com/openai/codex) v0.116.0+
+- [Codex](https://github.com/openai/codex) v0.116.0+
 - Python 3.10+
 
 ## Install


### PR DESCRIPTION
## Summary
- replace Codex CLI with Codex across user-facing documentation
- update navigation, badges, platform tables, and plugin guides
- keep command names and technical CLI references unchanged

## Validation
- uv run --group docs mkdocs build --strict