### PR TITLE
ci: automate DSH plugin releases

### DIFF
--- a/.github/workflows/release-dsh.yml
+++ b/.github/workflows/release-dsh.yml
@@ -1,0 +1,81 @@
+name: Release DSH plugin
+
+on:
+  push:
+    tags:
+      - "dsh-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-dsh:
+    name: Publish DSH package to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    defaults:
+      run:
+        working-directory: plugins/dsh
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Use npm 11
+        run: |
+          npm install -g npm@11
+          npm --version
+
+      - name: Read package metadata
+        id: package
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag
+        if: github.event_name == 'push'
+        run: |
+          tag_version="${GITHUB_REF_NAME#dsh-v}"
+          if [[ "$tag_version" != "${{ steps.package.outputs.version }}" ]]; then
+            echo "Tag version $tag_version does not match package version ${{ steps.package.outputs.version }}" >&2
+            exit 1
+          fi
+
+      - name: Check published version
+        id: registry
+        run: |
+          if npm view "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test package
+        if: steps.registry.outputs.exists == 'false'
+        run: npm test
+
+      - name: Check package syntax
+        if: steps.registry.outputs.exists == 'false'
+        run: |
+          node --check index.js
+          node --check client.js
+
+      - name: Pack package
+        if: steps.registry.outputs.exists == 'false'
+        run: npm pack --dry-run
+
+      - name: Publish package
+        if: steps.registry.outputs.exists == 'false'
+        run: npm publish --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,15 +109,16 @@ When modifying hooks/skills, keep in mind:
 
 ## Versioning & Release
 
-**Five independent version numbers** — bump only the ones that changed:
+**Six release components** — bump only the versioned components that changed:
 
 | Component | Version file | Publish channel |
 |-----------|-------------|-----------------|
 | **memsearch** (PyPI) | `pyproject.toml` | PyPI (automated via GitHub Actions on tag push) |
 | **Claude Code plugin** | `plugins/claude-code/.claude-plugin/plugin.json` | Marketplace (`.claude-plugin/marketplace.json`) |
-| **OpenClaw plugin** | `plugins/openclaw/package.json` | ClawHub (`clawhub package publish`) |
-| **OpenCode plugin** | `plugins/opencode/package.json` | npm (`@zilliz/memsearch-opencode`) |
 | **Codex plugin** | *(none)* | `install.sh` (no version management) |
+| **DeepSeek Harness plugin** | `plugins/dsh/package.json` | npm (`@zilliz/memsearch-dsh`, trusted publishing via `release-dsh.yml`) |
+| **OpenClaw plugin** | `plugins/openclaw/package.json` | ClawHub (`clawhub package publish`) |
+| **OpenCode plugin** | `plugins/opencode/package.json` | npm (`@zilliz/memsearch-opencode`, trusted publishing via `release.yml`) |
 
 See `CLAUDE.local.md` for detailed release procedures, current versions, and operational details.
 

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -25,6 +25,11 @@
     "scripts/maintenance-runner.py"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zilliztech/memsearch",
+    "directory": "plugins/dsh"
+  },
   "keywords": [
     "memsearch",
     "memory",


### PR DESCRIPTION
## Summary
- add an independent dsh-v* npm trusted-publishing workflow
- validate tag and package versions before publishing
- skip versions already present in the registry
- document DSH as a release component and add repository metadata required by npm OIDC

## Validation
- DSH test suite (41 passed)
- node syntax checks
- npm pack dry run
- workflow YAML parse