### PR TITLE
feat: add WorkBuddy plugin with memsearch memory hooks

### DIFF
--- a/plugins/workbuddy/.codebuddy-plugin/plugin.json
+++ b/plugins/workbuddy/.codebuddy-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "memsearch-workbuddy",
+  "version": "0.1.0",
+  "description": "Automatic semantic memory for WorkBuddy — turn capture → daily Markdown journals → Milvus index → top-2 memory injection on prompt submit, with due maintenance (PROJECT.md/USER.md, skill distillation) via the memsearch backend.",
+  "homepage": {
+    "url": "https://github.com/zilliztech/memsearch",
+    "type": "github"
+  },
+  "license": "MIT",
+  "keywords": ["memory", "semantic-search", "milvus", "markdown", "workbuddy"]
+}

--- a/plugins/workbuddy/.gitattributes
+++ b/plugins/workbuddy/.gitattributes
@@ -1,0 +1,5 @@
+*.sh text eol=lf
+*.py text eol=lf
+*.ps1 text eol=crlf
+*.json text eol=lf
+*.md text eol=lf

--- a/plugins/workbuddy/.gitignore
+++ b/plugins/workbuddy/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+scripts/.memsearch/
+scripts/diag.log
+.hook-review/
+.pytest_cache/

--- a/plugins/workbuddy/README.md
+++ b/plugins/workbuddy/README.md
@@ -1,0 +1,179 @@
+# memsearch — WorkBuddy Plugin
+
+Automatic semantic memory for WorkBuddy (CodeBuddy) — captures each finished turn, summarizes it into daily Markdown journals, and indexes them into Milvus for cross-session recall.
+
+Built on the [memsearch](https://github.com/zilliztech/memsearch) CLI backend. All heavy lifting (summarization routing, embedding, indexing) is delegated to `memsearch`; this plugin is a thin, hook-driven compat layer.
+
+## How the Pieces Fit Together
+
+```text
+WorkBuddy lifecycle events
+        │  stdin: hook payload JSON
+        ▼
+hooks/hooks.json ──► scripts/handler.py  (single-file dispatcher)
+        │                │
+        │                ├─ SessionStart ──► status line + recent-memory preview
+        │                │                   + background one-shot index
+        │                │                   (or watch daemon, opt-in)
+        │                │                   + lag-window hint (.last-index-completed)
+        │                ├─ Stop/SubagentStop ──► parse.py last-turn extraction
+        │                │                        → memsearch summarize (stdin, 110s)
+        │                │                        → append memory/YYYY-MM-DD.md
+        │                │                        → memsearch index → write timestamp
+        │                └─ UserPromptSubmit ──► search top-2 memories ──► inject
+        │                                        (marker fallback on any failure)
+        ▼
+memsearch CLI ──► ~/.memsearch/config.toml (global: embedding, llm.providers,
+                  plugins.openclaw.summarize) + Milvus (Lite file or Zilliz Cloud)
+```
+
+## Quick Start
+
+### Prerequisites
+
+- `memsearch` CLI on `PATH` (`pip install memsearch`)
+- Global config `~/.memsearch/config.toml` with an embedding provider and at least one `[llm.providers.<name>]` entry (type + model)
+- Summarize routing via the openclaw slot (WorkBuddy has no native plugin key yet):
+
+```bash
+memsearch config set plugins.openclaw.summarize.provider <name>
+memsearch config set plugins.openclaw.summarize.enabled true
+```
+
+### Install (development mount)
+
+Point a WorkBuddy plugin marketplace directory at this folder (symlink/junction recommended so edits hot-reload — only `hooks.json` changes require a WorkBuddy restart):
+
+```bash
+# example: junction on Windows
+mklink /J "%USERPROFILE%\.workbuddy\plugins\marketplaces\local-dev\memsearch-workbuddy" "<this-dir>"
+```
+
+Then restart WorkBuddy once to load `hooks/hooks.json`.
+
+## How It Works
+
+### Hook Summary
+
+| Hook | Timeout | What It Does |
+|------|---------|--------------|
+| **SessionStart** | 10s | Status line (summarize route + provider/model), inject recent-memory preview as `additionalContext`, skills hint when candidates exist, fire detached one-shot index (skip-if-running via `.index.pid`) — or start the watch daemon when `MEMSEARCH_WB_WATCH=1` (server mode only), lag-window hint when inside the freshness window |
+| **UserPromptSubmit** | 10s | For prompts ≥ 10 chars: `memsearch search -k 2 -j` against the project collection (6s budget), inject top-2 chunks as `additionalContext`; any failure falls back to the `"[memsearch] Memory available"` marker |
+| **Stop** | 120s | Parse last turn → summarize → append daily `.md` (lazy `## Session` heading + anchor) → index → write `.last-index-completed` → fire detached maintenance (due-state throttled) |
+| **SubagentStop** | 120s | Same pipeline as Stop |
+| **PreCompact** | 10s | Pass-through (`{"continue": true}`) |
+
+### What Each Hook Does
+
+#### SessionStart
+
+1. **Resolves the summarize provider** by reading `~/.memsearch/config.toml` directly (no CLI call; never echoes secrets). Missing provider produces a `NOT CONFIGURED` status instead of silent degradation.
+2. **Injects cold-start context**: up to 2 most recent daily journals, 40 lines each, headings + `-` bullets only (mirrors the claude-code plugin's awk filter).
+3. **Skills hint**: runs `memsearch skills status --hint` (5s timeout) only when `.memsearch/skill-candidates/` exists; empty output means no hint (contract-compatible with the claude-code plugin).
+4. **Background index**: spawns a detached `handler.py --index-and-stamp` child; a `.index.pid` liveness probe makes repeat SessionStarts skip while one is running. The child removes the pidfile and stamps `.last-index-completed` on completion. (Replaced by the watch daemon when `MEMSEARCH_WB_WATCH=1` — see below.)
+5. **Lag-window hint**: see below.
+
+#### Stop / SubagentStop
+
+1. **Guards**: `stop_hook_active=true`, `MEMSEARCH_DISABLE=1`, missing transcript, or transcript < 3 lines all exit silently with `{"continue": true}`.
+2. **Extracts the last real turn** via `parse.py`: reverse-scans the transcript for the last user message, unwraps `<user_query>`, strips system-reminder/user-context blocks, dedups and truncates file-history snapshots (20 paths + `…(+N more)`), and emits `[User]`/`[Assistant]` labeled text.
+3. **Summarizes** by piping the turn to `memsearch summarize --plugin openclaw --agent-name WorkBuddy` (stdin, 110s timeout). On any failure (CLI missing, no provider, timeout, empty output) a fallback bullet is written instead: `- Memory summary unavailable: <reason>; transcript content was omitted. Use the transcript anchor for progressive disclosure.` — the memory entry is never skipped.
+4. **Appends the daily journal**: creates `.memsearch/memory/YYYY-MM-DD.md` on demand; first turn of a session gets a `## Session HH:MM` heading; every turn gets `### HH:MM` plus an HTML anchor `<!-- session:<id> turn:<uuid> transcript:<path> -->`.
+5. **Indexes immediately**: `memsearch index .memsearch/memory -c <derived-collection>` (300s timeout), then writes `.last-index-completed`.
+6. **Fires maintenance** (detached, skip-if-running via `.maintenance.pid`): due tasks (`project_review` / `user_profile`) plus `memory_to_skill` skill distillation. See "Memory Maintenance" below.
+
+#### UserPromptSubmit
+
+1. **Skips short prompts** (< 10 chars) with a bare `{"continue": true}`.
+2. **Searches the project collection**: `memsearch search <prompt> -c <derived-collection> -k 2 -j` (query truncated to 500 chars; 6s timeout inside the 10s hook budget).
+3. **Injects hits as context**: a numbered `[memsearch] 相关历史记忆` list — `(memory-file › heading) content` with whitespace collapsed, 400 chars per hit — via `hookSpecificOutput.additionalContext`; `systemMessage` reports the hit count.
+4. **Never blocks**: CLI missing, timeout, non-zero exit, invalid JSON, or zero hits all fall back to the plain `"[memsearch] Memory available"` marker.
+
+The per-project collection name replicates `scripts/derive-collection.sh` byte-for-byte: `ms_<sanitized-basename>_<sha256[:8]>`, where the hash input is the MSYS-form absolute path (`D:\a\b` → `/d/a/b`). This keeps data continuity with previously indexed projects.
+
+## Memory Maintenance (opt-in, shared backend engine)
+
+Stop spawns a detached `handler.py --maintenance` child that delegates to the backend's own engine (`memsearch.maintenance.run_due_tasks` + `memsearch.skills.distill`) — the same machinery as upstream's `_shared/scripts/maintenance_runner.py`, minus the native-host-CLI branches WorkBuddy can't use:
+
+- **Config routes through the openclaw slot**: the backend's platform whitelist (`claude-code`/`codex`/`opencode`/`openclaw`/`dsh`) has no `workbuddy`, so tasks read `[plugins.openclaw.project_review|user_profile|memory_to_skill]` — same borrowing convention as `plugins.openclaw.summarize`.
+- **Provider**: set `provider = "siliconflow"` (or any `[llm.providers.*]` name). `native` has no meaning for WorkBuddy (no headless CLI) and falls back to the `plugins.openclaw.summarize` provider automatically.
+- **Throttling is free**: `min_interval_hours` (default 24) due-state in `.memsearch/.maintenance-state.json` makes non-due runs near no-ops; per-task `.maintenance-openclaw-<task>.lock` files prevent overlap.
+- **Prompts**: default to the sibling `_shared/prompts/*.txt` (same relative layout as upstream `plugins/_shared`); override globally via `[prompts]` keys.
+- **Output**: `PROJECT.md` / `USER.md` inside the memory dir; distilled candidates under `.memsearch/skill-candidates/` (git-backed store; installing into an agent's skills dir stays a human step).
+- **Provider/model caveat**: text-output tasks (project_review / user_profile) work fine with DeepSeek-V3.2, but memory_to_skill invites tool calls and DeepSeek's native DSML function-call markup can leak into `content` as text (endpoint doesn't convert it to structured `tool_calls`) → JSON parse error. Remedy: pin that one task to a tool-clean model — `memsearch config set plugins.openclaw.memory_to_skill.model Qwen/Qwen3.5-35B-A3B` (tested: emits raw JSON directly; Qwen2.5-32B also works but fences JSON; Qwen3-Omni-30B-A3B-Instruct and Qwen2.5-7B both fail). Task errors are recorded in due-state and retried per `min_interval_hours` — the hook never blocks.
+- **Constraint-decoding is the better fix (upstream OPEN)**: `benchmarks/siliconflow/probe_json_constrained.py` shows DeepSeek-V3.2 emits **clean, tool_calls=0 JSON** (3/3 stable) under SiliconFlow's `response_format: {type: json_schema, json_schema: {…}}` — it disables tools and forces schema-valid output, eliminating the DSML leak outright. memsearch's `_run_openai_with_tools` hard-codes `tools` + no `response_format`, so this needs upstream support for a per-provider custom request body before it can replace the model-pin above.
+
+## The Lag-Window Hint
+
+Zilliz Cloud serverless has eventually-consistent collection statistics: right after indexing, `memsearch search` can silently return zero hits for ~15 minutes even though the data is queryable (row_count lag). To make this window visible without any RPC:
+
+- Stop writes `.memsearch/.last-index-completed` (epoch seconds) **only after a successful index**.
+- SessionStart reads that single file; if its age is within `MEMSEARCH_WB_LAG_WINDOW` (default **1200s**), the status line gains: `远端索引统计追平中（上次索引完成于 N 分钟前），新记忆可能暂时查无结果……通常 ≤20 分钟自愈`.
+
+Pure file read, non-blocking, zero cost outside the window.
+
+## Watch Daemon (opt-in)
+
+Set `MEMSEARCH_WB_WATCH=1` to run a resident `memsearch watch <memory> -c <derived-collection>` instead of the one-shot background index — external edits to `memory/*.md` get re-indexed continuously, not just at turn end.
+
+- **Server mode only**: when `milvus.uri` is http(s) the daemon starts detached; with Milvus Lite it is skipped (the local `.db` file lock conflicts with watch — same rule as the claude-code plugin) and the one-shot index remains the fallback.
+- **Lifecycle**: pid in `.memsearch/.watch.pid` with a liveness probe (`os.kill(pid, 0)`); repeat SessionStarts adopt the running daemon instead of respawning it. Stderr (WARNING+) goes to `.memsearch/watch.log`, rotated to `watch.log.1` on restart.
+- **Stop**: stop is manual — send SIGTERM/SIGINT to the pid (or `os.kill`) and remove `.watch.pid`. On Windows a headless process has no console for Ctrl-C, so termination is direct (TerminateProcess); remote state is server-side and self-heals.
+
+## Memory Files
+
+`.memsearch/memory/YYYY-MM-DD.md` is the human-readable source of truth (append-only; never rewritten or deleted by the plugin):
+
+```markdown
+## Session 22:45
+
+### 22:45
+<!-- session:05b911c7-... turn:7d15e0e6-... transcript:C:\...\....jsonl -->
+- User asked about ...
+- WorkBuddy recommended ...
+```
+
+## Configuration
+
+| Setting | Where | Notes |
+|---|---|---|
+| `embedding.*` | global `~/.memsearch/config.toml` | e.g. openai/dashscope text-embedding-v4 |
+| `[llm.providers.<name>]` | global | provider used by summarize |
+| `plugins.openclaw.summarize.*` | global | WorkBuddy reuses the openclaw slot |
+| `milvus.uri` | global | Milvus Lite file or Zilliz Cloud endpoint |
+| project allowlist | `<project>/.memsearch.toml` | only 7 keys (e.g. `milvus.collection`) |
+
+Environment variables:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MEMSEARCH_DISABLE` | — | `1` makes every hook return `{"continue": true}` (recursion guard for maintenance chains) |
+| `MEMSEARCH_WB_LAG_WINDOW` | `1200` | Lag-hint window in seconds |
+| `MEMSEARCH_WB_WATCH` | — | `1` starts the watch daemon on SessionStart (server mode only; Lite falls back to one-shot index) |
+| `MEMSEARCH_NO_WATCH` | — | Set to `1` in all child processes spawned by the plugin |
+| `HOOK_REVIEW_DIR` | `<project>/.hook-review/` | Output dir for the dev capture tool below |
+
+## Development Tools: Payload Capture & Schema
+
+`scripts/review_capture.py` is a standalone, stdlib-only dev tool (not wired by default). Point hooks at it manually — see `hooks/hooks.review-example.json` — to capture real hook payloads from WorkBuddy or **any other agent framework** when developing new plugins:
+
+- `captures/<event>.jsonl` — sanitized raw payloads (strings > 500 chars, arrays > 50 items, depth > 8 truncated)
+- `hook-schema.json` — per-event JSON Schema inferred from all observations: `type` per field (unions as arrays), `x-present` counts, `required` = present in every observation, `x-examples` for scalars, recursive `properties`/`items`
+
+It always responds `{"continue": true}` and never blocks the session.
+
+## Data Governance
+
+The plugin writes these inside a project's `.memsearch/`: appended `memory/*.md`, `.last-index-completed`, `.index.pid`, and — when the watch daemon is enabled — `.watch.pid` + `watch.log(.1)` (all self-managed). The maintenance child additionally coordinates via `.maintenance.pid` (self-managed) while the backend engine owns `.maintenance-state.json`, `.maintenance-openclaw-*.lock`, `skill-candidates/`, and the `PROJECT.md`/`USER.md` outputs. It never touches backend-owned index internals (`.index-state.json`, locks) and never produces intermediate conversion artifacts.
+
+## Repository Layout
+
+```text
+.codebuddy-plugin/plugin.json   # WorkBuddy plugin manifest
+hooks/hooks.json                # event → scripts/handler.py wiring (production)
+hooks/hooks.review-example.json # manual capture wiring (dev only)
+scripts/handler.py              # dispatcher + backend calls + watch lifecycle
+scripts/parse.py                # transcript last-turn extraction
+scripts/review_capture.py       # payload capture + JSON Schema tool
+scripts/tests/                  # pytest suite (process mgmt + wiring)
+```

--- a/plugins/workbuddy/README.md
+++ b/plugins/workbuddy/README.md
@@ -40,16 +40,16 @@ memsearch config set plugins.openclaw.summarize.provider <name>
 memsearch config set plugins.openclaw.summarize.enabled true
 ```
 
-### Install (development mount)
+### Install
 
-Point a WorkBuddy plugin marketplace directory at this folder (symlink/junction recommended so edits hot-reload — only `hooks.json` changes require a WorkBuddy restart):
+Place this plugin into a WorkBuddy marketplace directory, then restart WorkBuddy once to load `hooks/hooks.json`:
 
 ```bash
-# example: junction on Windows
-mklink /J "%USERPROFILE%\.workbuddy\plugins\marketplaces\local-dev\memsearch-workbuddy" "<this-dir>"
+# example: copy the plugin into a marketplace
+cp -r . "<marketplace-dir>/memsearch-workbuddy"
 ```
 
-Then restart WorkBuddy once to load `hooks/hooks.json`.
+`hooks.json` changes require a WorkBuddy restart; `scripts/*.py` edits hot-reload without one.
 
 ## How It Works
 
@@ -117,7 +117,7 @@ Pure file read, non-blocking, zero cost outside the window.
 Set `MEMSEARCH_WB_WATCH=1` to run a resident `memsearch watch <memory> -c <derived-collection>` instead of the one-shot background index — external edits to `memory/*.md` get re-indexed continuously, not just at turn end.
 
 - **Server mode only**: when `milvus.uri` is http(s) the daemon starts detached; with Milvus Lite it is skipped (the local `.db` file lock conflicts with watch — same rule as the claude-code plugin) and the one-shot index remains the fallback.
-- **Lifecycle**: pid in `.memsearch/.watch.pid` with a liveness probe (`os.kill(pid, 0)`); repeat SessionStarts adopt the running daemon instead of respawning it. Stderr (WARNING+) goes to `.memsearch/watch.log`, rotated to `watch.log.1` on restart.
+- **Lifecycle**: pid in `.memsearch/.watch.pid` with a cross-platform liveness probe (WinAPI on Windows); repeat SessionStarts adopt the running daemon instead of respawning it. Stderr (WARNING+) goes to `.memsearch/watch.log`, rotated to `watch.log.1` on restart.
 - **Stop**: stop is manual — send SIGTERM/SIGINT to the pid (or `os.kill`) and remove `.watch.pid`. On Windows a headless process has no console for Ctrl-C, so termination is direct (TerminateProcess); remote state is server-side and self-heals.
 
 ## Memory Files

--- a/plugins/workbuddy/hooks/hooks.json
+++ b/plugins/workbuddy/hooks/hooks.json
@@ -1,0 +1,60 @@
+{
+  "description": "memsearch-workbuddy 对接层 —— 事件分派到 handler.py：SessionStart 注入 lag 提示+后台增量索引，Stop 摘要→写 memory/*.md→索引。遵循 spec §3.6.3 红线：不落 review/审阅文件。通用载荷抓取工具 review_capture.py 可手动换用（见 hooks.review-example.json）。源码在 D:\\Electronics\\agent-plugins\\workbuddy_plugin_memsearch\\workbuddy，经 junction 实时挂载",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pythonw ${CODEBUDDY_PLUGIN_ROOT}/scripts/handler.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pythonw ${CODEBUDDY_PLUGIN_ROOT}/scripts/handler.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pythonw ${CODEBUDDY_PLUGIN_ROOT}/scripts/handler.py",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pythonw ${CODEBUDDY_PLUGIN_ROOT}/scripts/handler.py",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pythonw ${CODEBUDDY_PLUGIN_ROOT}/scripts/handler.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workbuddy/hooks/hooks.json
+++ b/plugins/workbuddy/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "memsearch-workbuddy 对接层 —— 事件分派到 handler.py：SessionStart 注入 lag 提示+后台增量索引，Stop 摘要→写 memory/*.md→索引。遵循 spec §3.6.3 红线：不落 review/审阅文件。通用载荷抓取工具 review_capture.py 可手动换用（见 hooks.review-example.json）。源码在 D:\\Electronics\\agent-plugins\\workbuddy_plugin_memsearch\\workbuddy，经 junction 实时挂载",
+  "description": "memsearch-workbuddy 对接层 —— 事件分派到 handler.py：SessionStart 注入 lag 提示+后台增量索引，Stop 摘要→写 memory/*.md→索引。遵循 spec §3.6.3 红线：不落 review/审阅文件。通用载荷抓取工具 review_capture.py 可手动换用（见 hooks.review-example.json）。",
   "hooks": {
     "SessionStart": [
       {

--- a/plugins/workbuddy/hooks/hooks.review-example.json
+++ b/plugins/workbuddy/hooks/hooks.review-example.json
@@ -1,0 +1,60 @@
+{
+  "description": "【手动审阅配置样例】把全部事件指到 review_capture.py：抓取真实 stdin 载荷（<project>/.hook-review/captures/*.jsonl）并推导各节点带数据类型的 JSON Schema（.hook-review/hook-schema.json），供其他 agent 框架插件开发复用。用法：备份 hooks.json → 用本文件替换 → 跑几轮会话 → 换回原 hooks.json。仅开发用；HOOK_REVIEW_DIR 可改输出目录。",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CODEBUDDY_PLUGIN_ROOT}/scripts/review_capture.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CODEBUDDY_PLUGIN_ROOT}/scripts/review_capture.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CODEBUDDY_PLUGIN_ROOT}/scripts/review_capture.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CODEBUDDY_PLUGIN_ROOT}/scripts/review_capture.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CODEBUDDY_PLUGIN_ROOT}/scripts/review_capture.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workbuddy/pytest.ini
+++ b/plugins/workbuddy/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# 只收集 test_*.py；tests/ 内留档的遗留脚本（如 wb_live_e2e_test.py）不参与收集
+python_files = test_*.py

--- a/plugins/workbuddy/scripts/handler.py
+++ b/plugins/workbuddy/scripts/handler.py
@@ -177,20 +177,64 @@ def _lag_hint(memsearch_dir):
     return ""
 
 
+def _pid_alive(pid):
+    """跨平台进程存活判断。Windows 下 os.kill(pid,0) 会抛 ValueError，改走 WinAPI。
+
+    用 WaitForSingleObject(h, 0) 判存活：进程终止时句柄信号化，与退出码无关，
+    避免 GetExitCodeProcess 的 STILL_ACTIVE(259) 歧义。需 SYNCHRONIZE 权限。
+    边界：
+    - pid<=0 / 进程不存在（OpenProcess 返回 ERROR_INVALID_PARAMETER）→ False
+    - 打开被拒（ERROR_ACCESS_DENIED，如保护/提权进程）→ 保守视为存活，避免误判死亡重复点火
+    - WaitForSingleObject 失败（WAIT_FAILED）→ 保守存活
+    """
+    if not pid or pid <= 0:
+        return False
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            SYNCHRONIZE = 0x100000
+            WAIT_TIMEOUT = 0x102
+            WAIT_FAILED = 0xFFFFFFFF
+            ERROR_ACCESS_DENIED = 5
+            h = k32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, False, pid
+            )
+            if not h:
+                # 打开失败：进程不存在(87) → 死亡；权限不足(5) → 无法判定，保守存活
+                return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+            try:
+                st = k32.WaitForSingleObject(h, 0)
+                if st == WAIT_FAILED:
+                    return True  # 查询失败，保守视为存活
+                return st == WAIT_TIMEOUT  # 未终止→存活
+            finally:
+                k32.CloseHandle(h)
+        except Exception:  # noqa: BLE001
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _read_pid(pidfile):
+    """读 pidfile 内容为 int；缺失/损坏返回 0。"""
+    try:
+        with open(pidfile, encoding="utf-8") as f:
+            return int(f.read().strip() or "0")
+    except Exception:
+        return 0
+
+
 def _bg_run(pid_name, argv, memsearch_dir):
     """detached 子进程通用点火：pidfile 存活探针 skip-if-running（防抖）。"""
     pidfile = os.path.join(memsearch_dir, pid_name)
-    try:
-        if os.path.isfile(pidfile):
-            with open(pidfile, encoding="utf-8") as f:
-                old_pid = int(f.read().strip() or "0")
-            if old_pid > 0:
-                os.kill(old_pid, 0)  # 存活探测，进程不在则抛 OSError
-                return  # 上一个还在跑，跳过
-    except (OSError, ValueError):
-        pass  # 进程已死或 pidfile 损坏，继续起新进程
-    except Exception:
-        pass
+    if _pid_alive(_read_pid(pidfile)):
+        return  # 上一个还在跑，跳过
     try:
         creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
             subprocess, "DETACHED_PROCESS", 0
@@ -311,17 +355,9 @@ def _maintenance(project_dir, memsearch_dir):
 def _watch_pid(memsearch_dir):
     """探测 watch 存活并清理 stale pidfile。返回 pid，未运行返回 0。"""
     pidfile = os.path.join(memsearch_dir, WATCH_PID_NAME)
-    try:
-        with open(pidfile, encoding="utf-8") as f:
-            pid = int(f.read().strip() or "0")
-    except Exception:
-        return 0
-    if pid > 0:
-        try:
-            os.kill(pid, 0)  # 存活探测
-            return pid
-        except OSError:
-            pass
+    pid = _read_pid(pidfile)
+    if _pid_alive(pid):
+        return pid
     try:
         os.remove(pidfile)
     except Exception:
@@ -394,9 +430,7 @@ def _watch_stop(memsearch_dir, grace_s=3):
             pass
         for _ in range(grace_s):
             time.sleep(1)
-            try:
-                os.kill(pid, 0)
-            except OSError:
+            if not _pid_alive(pid):
                 break
         else:
             continue
@@ -413,20 +447,20 @@ def _watch_stop(memsearch_dir, grace_s=3):
 # ---------------------------------------------------------------------------
 
 def _resolve_summarize_provider():
-    """按 §3.4 规则从全局 ~/.memsearch/config.toml 解析 summarize 将用的 provider。
+    """按 openclaw summarize 配置解析 summarize 实际将用的 provider/model。
 
-    只读配置文件（不调用 memsearch config CLI）。返回 dict 供状态行与失败诊断。
-    安全约束：绝不回显 api_key / token 字段值。
+    对齐 memsearch cli.summarize：provider 取自 plugins.openclaw.summarize.provider，
+    空或 native → 无 memsearch 托管 provider（exit 2）；再校验对应
+    [llm.providers.<name>] 存在；model = summarize.model 或 provider.model。
+    只读配置文件（不调用 memsearch config CLI）。绝不回显 api_key / token。
     """
     result = {
-        "config_path": "",
         "provider": "",
         "model": "",
         "openclaw_summarize": {},
         "error": "",
     }
     cfg_path = os.path.expanduser(os.path.join("~", ".memsearch", "config.toml"))
-    result["config_path"] = cfg_path
     if not os.path.isfile(cfg_path):
         result["error"] = (
             "global config not found: %s — 请先创建 ~/.memsearch/config.toml "
@@ -445,25 +479,33 @@ def _resolve_summarize_provider():
         result["error"] = "config.toml 解析失败: %s" % e
         return result
 
-    providers = cfg.get("llm", {}).get("providers", {})
-    if isinstance(providers, dict):
-        for name, p in providers.items():
-            if isinstance(p, dict) and p.get("type") and p.get("model"):
-                result["provider"] = name
-                result["model"] = str(p.get("model"))
-                break
     oc_sum = cfg.get("plugins", {}).get("openclaw", {}).get("summarize", {})
-    if isinstance(oc_sum, dict):
-        # 只回显非敏感键
-        result["openclaw_summarize"] = {
-            k: v for k, v in oc_sum.items() if k not in ("api_key", "token")
-        }
-    if not result["provider"]:
+    if not isinstance(oc_sum, dict):
+        oc_sum = {}
+    result["openclaw_summarize"] = {
+        k: v for k, v in oc_sum.items() if k not in ("api_key", "token")
+    }
+
+    provider_name = str(oc_sum.get("provider") or "").strip()
+    if not provider_name or provider_name == "native":
         result["error"] = (
-            "~/.memsearch/config.toml 中无可用 [llm.providers.<name>]"
-            "（需 type 与 model 均非空）— summarize 将无 provider 可用，"
-            "按 §3.4 不静默降级"
+            "plugins.openclaw.summarize.provider 为空或 native — 无 memsearch 托管 "
+            "provider，summarize 走原生摘要（CLI 将 exit 2）"
         )
+        return result
+
+    providers = cfg.get("llm", {}).get("providers", {})
+    provider_cfg = providers.get(provider_name) if isinstance(providers, dict) else None
+    if not isinstance(provider_cfg, dict):
+        result["error"] = (
+            "Unknown LLM provider %r — 请配置 [llm.providers.%s]" % (provider_name, provider_name)
+        )
+        return result
+
+    result["provider"] = provider_name
+    result["model"] = str(
+        oc_sum.get("model") or provider_cfg.get("model") or ""
+    ).strip()
     return result
 
 
@@ -695,7 +737,9 @@ def _stop_live(ctx, meta, transcript, memory_dir, memory_file,
     if not ms:
         failure = "memsearch CLI not found on PATH"
     elif not prov["provider"]:
-        failure = "no LLM provider configured in ~/.memsearch/config.toml"
+        failure = (
+            "no memsearch-managed LLM provider for summarize: %s" % prov["error"]
+        )
     else:
         rc, out = _run(
             [ms, "summarize", "--plugin", "openclaw",

--- a/plugins/workbuddy/scripts/handler.py
+++ b/plugins/workbuddy/scripts/handler.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python3
+"""handler.py — memsearch × WorkBuddy 对接层主逻辑（事件分派 + 真实后端调用）。
+
+依据 docs/memsearch-workbuddy-spec.md §3.2 实现，接通真实 memsearch CLI 后端。
+
+事件分派：
+- SessionStart      → 状态行 + 最近记忆预览注入 additionalContext + skills hint
+                      + 后台一次性 index（skip-if-running）+ 远端索引滞后等待提示
+                      + 可选常驻 watch（MEMSEARCH_WB_WATCH=1，仅 server 模式）
+- UserPromptSubmit  → "[memsearch] Memory available" 记号
+- Stop/SubagentStop → parse.py 解析 → memsearch summarize（stdin，110s 超时）
+                      → 追加当日 memory/*.md（懒写 ## Session 标题 + 锚点）
+                      → memsearch index → 写 .last-index-completed 隐含时间戳
+- PreCompact/其他   → 静默放行
+
+隐含时间戳机制（spec §7-12）：Stop 索引完成后写 .memsearch/.last-index-completed
+（epoch 秒）；SessionStart 读它，处于 MEMSEARCH_WB_LAG_WINDOW（默认 1200s）内则在
+systemMessage 追加「远端索引统计追平中，新记忆可能暂时查无结果」提示。
+只读一个小文件，不发 RPC、不阻塞。
+
+输出契约：任何路径都向 stdout 打印恰好一个合法 JSON 并 exit 0（C2 不阻塞会话）。
+不依赖 CODEBUDDY_PLUGIN_ROOT（C3，路径一律用 __file__ 推导）。
+MEMSEARCH_DISABLE=1 时直接空响应（C4 防重入）。
+遵循 spec §3.6.3 防垃圾红线：除 memory/*.md 追加与自管理的
+.last-index-completed/.index.pid 外，不落任何中间/审阅文件。
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# spec §7-12：Zilliz serverless row_count 统计滞后实测 ~15 分钟，窗口默认 1200s
+LAG_WINDOW_S = int(os.environ.get("MEMSEARCH_WB_LAG_WINDOW", "1200") or 1200)
+INDEX_TS_NAME = ".last-index-completed"
+INDEX_PID_NAME = ".index.pid"
+MAINT_PID_NAME = ".maintenance.pid"
+WATCH_PID_NAME = ".watch.pid"
+WATCH_LOG_NAME = "watch.log"
+OPENCLAW_AGENT_NAME = "WorkBuddy"
+
+
+def _load_parse():
+    spec = importlib.util.spec_from_file_location(
+        "wb_parse", os.path.join(SCRIPT_DIR, "parse.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 基础工具
+# ---------------------------------------------------------------------------
+
+def _respond(obj):
+    """向 stdout 打印恰好一个 JSON 对象并 flush。"""
+    try:
+        sys.stdout.write(json.dumps(obj, ensure_ascii=False))
+        sys.stdout.flush()
+    except Exception:
+        try:
+            sys.stdout.write('{"continue":true}')
+            sys.stdout.flush()
+        except Exception:
+            pass
+
+
+def _project_dir(payload):
+    """工程根解析：stdin cwd 优先，其次宿主 env，最后进程 cwd（C3 不依赖 PLUGIN_ROOT）。"""
+    for cand in (
+        payload.get("cwd"),
+        os.environ.get("CODEBUDDY_PROJECT_DIR"),
+        os.environ.get("CLAUDE_PROJECT_DIR"),
+    ):
+        if cand and os.path.isdir(cand):
+            return os.path.abspath(cand)
+    return os.getcwd()
+
+
+def _write_text(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+# ---------------------------------------------------------------------------
+# 后端调用助手
+# ---------------------------------------------------------------------------
+
+def _find_memsearch():
+    return shutil.which("memsearch") or ""
+
+
+def _derive_collection(project_dir):
+    """复刻 derive-collection.sh：ms_<sanitized_basename>_<sha256前8位>。
+
+    实测钉死：哈希输入必须是 MSYS Unix 形态绝对路径（D:\\a\\b → /d/a/b，
+    盘符小写、无尾斜杠），否则与既有 collection 分裂。
+    """
+    p = os.path.abspath(project_dir).replace("\\", "/")
+    m = re.match(r"^([A-Za-z]):/(.*)$", p)
+    if m:
+        p = "/%s/%s" % (m.group(1).lower(), m.group(2))
+    base = os.path.basename(p.rstrip("/"))
+    sanitized = re.sub(r"_+", "_", re.sub(r"[^a-z0-9]", "_", base.lower())).strip("_")[:40]
+    digest = hashlib.sha256(p.encode("utf-8")).hexdigest()[:8]
+    return "ms_%s_%s" % (sanitized, digest)
+
+
+def _child_env(memsearch_dir):
+    env = os.environ.copy()
+    env["MEMSEARCH_NO_WATCH"] = "1"
+    env["MEMSEARCH_DIR"] = memsearch_dir
+    return env
+
+
+def _run(args, input_text=None, timeout=60, env=None):
+    """跑后端子进程，返回 (rc, stdout)；异常/超时返回 (负码, '')。绝不抛出。
+
+    Windows 下 pythonw（无控制台）父进程拉起的控制台子系统 exe 会新建黑色
+    控制台窗口，故必须带 CREATE_NO_WINDOW 抑制。
+    """
+    try:
+        r = subprocess.run(
+            args,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=env,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        return r.returncode, r.stdout or ""
+    except subprocess.TimeoutExpired:
+        return -124, ""
+    except Exception:
+        return -1, ""
+
+
+def _write_index_ts(memsearch_dir):
+    """隐含时间戳：索引完成后写 epoch 秒（单行文本，~0ms）。"""
+    try:
+        _write_text(
+            os.path.join(memsearch_dir, INDEX_TS_NAME), str(int(time.time()))
+        )
+    except Exception:
+        pass
+
+
+def _lag_hint(memsearch_dir):
+    """读隐含时间戳；处于滞后窗口内则返回等待提示，否则空串。纯文件读，零 RPC。"""
+    try:
+        with open(
+            os.path.join(memsearch_dir, INDEX_TS_NAME), encoding="utf-8"
+        ) as f:
+            ts = int(f.read().strip())
+    except Exception:
+        return ""
+    age = int(time.time()) - ts
+    if 0 <= age < LAG_WINDOW_S:
+        return (
+            "远端索引统计追平中（上次索引完成于 %d 分钟前），新记忆可能暂时"
+            "查无结果——Zilliz serverless 最终一致性延迟，通常 ≤%d 分钟自愈"
+            % (max(1, age // 60), LAG_WINDOW_S // 60)
+        )
+    return ""
+
+
+def _bg_run(pid_name, argv, memsearch_dir):
+    """detached 子进程通用点火：pidfile 存活探针 skip-if-running（防抖）。"""
+    pidfile = os.path.join(memsearch_dir, pid_name)
+    try:
+        if os.path.isfile(pidfile):
+            with open(pidfile, encoding="utf-8") as f:
+                old_pid = int(f.read().strip() or "0")
+            if old_pid > 0:
+                os.kill(old_pid, 0)  # 存活探测，进程不在则抛 OSError
+                return  # 上一个还在跑，跳过
+    except (OSError, ValueError):
+        pass  # 进程已死或 pidfile 损坏，继续起新进程
+    except Exception:
+        pass
+    try:
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
+            subprocess, "DETACHED_PROCESS", 0
+        )
+        p = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=creationflags,
+            close_fds=True,
+        )
+        _write_text(pidfile, str(p.pid))
+    except Exception:
+        pass
+
+
+def _bg_index(handler_path, memory_dir, collection, memsearch_dir):
+    """SessionStart 后台一次性索引：detached 子进程跑 --index-and-stamp。"""
+    _bg_run(
+        INDEX_PID_NAME,
+        [
+            sys.executable,
+            handler_path,
+            "--index-and-stamp",
+            memory_dir,
+            collection,
+            memsearch_dir,
+        ],
+        memsearch_dir,
+    )
+
+
+def _index_and_stamp(memory_dir, collection, memsearch_dir):
+    """隐藏子命令入口：同步 index 后写时间戳（供 _bg_index 以独立进程执行）。"""
+    ms = _find_memsearch()
+    if not ms:
+        return 1
+    args = [ms, "index", memory_dir]
+    if collection:
+        args += ["-c", collection]
+    _run(args, timeout=300, env=_child_env(memsearch_dir))
+    _write_index_ts(memsearch_dir)
+    try:
+        os.remove(os.path.join(memsearch_dir, INDEX_PID_NAME))
+    except Exception:
+        pass
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# maintenance：到期任务（project_review/user_profile）+ memory_to_skill 蒸馏。
+# config.py 的 platform 白名单无 workbuddy → 借 openclaw 槽（与 summarize 同约定）；
+# provider=native 时回落到 openclaw summarize provider（WorkBuddy 无 headless CLI）。
+# ---------------------------------------------------------------------------
+
+def _maintenance(project_dir, memsearch_dir):
+    """隐藏子命令：跑 due 的 maintenance 任务 + 技能蒸馏，清 pidfile。"""
+    try:
+        import dataclasses
+
+        from memsearch.config import resolve_config
+        from memsearch.maintenance import run_due_tasks, run_task_llm
+        from memsearch.skills import distill
+    except Exception:
+        return 1
+    cfg = resolve_config()
+    # prompt 缺省指向 _shared/prompts（与上游 plugins/_shared 同构）
+    shared = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "..", "_shared", "prompts"))
+    for task in ("project_review", "user_profile", "memory_to_skill"):
+        if not getattr(cfg.prompts, task, ""):
+            f = os.path.join(shared, task + ".txt")
+            if os.path.isfile(f):
+                setattr(cfg.prompts, task, f)
+    try:
+        fallback = cfg.plugins.openclaw.summarize.provider or ""
+    except Exception:
+        fallback = ""
+
+    def llm_runner(ctx, prompt):
+        if (ctx.task_config.provider or "native").strip() in ("", "native") and fallback:
+            ctx = dataclasses.replace(
+                ctx, task_config=dataclasses.replace(ctx.task_config, provider=fallback)
+            )
+        return run_task_llm(ctx, prompt, cfg)
+
+    try:
+        run_due_tasks(
+            platform="openclaw",
+            project_dir=project_dir,
+            memsearch_dir=memsearch_dir,
+            cfg=cfg,
+            llm_runner=llm_runner,
+        )
+    except Exception:
+        pass
+    try:
+        distill(
+            platform="openclaw",
+            project_dir=project_dir,
+            memsearch_dir=memsearch_dir,
+            cfg=cfg,
+            llm_runner=llm_runner,
+        )
+    except Exception:
+        pass
+    try:
+        os.remove(os.path.join(memsearch_dir, MAINT_PID_NAME))
+    except Exception:
+        pass
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# watch 常驻进程管理（吸收自 watch-manager.sh；仅 server 模式使用，Lite 跳过）
+# ---------------------------------------------------------------------------
+
+def _watch_pid(memsearch_dir):
+    """探测 watch 存活并清理 stale pidfile。返回 pid，未运行返回 0。"""
+    pidfile = os.path.join(memsearch_dir, WATCH_PID_NAME)
+    try:
+        with open(pidfile, encoding="utf-8") as f:
+            pid = int(f.read().strip() or "0")
+    except Exception:
+        return 0
+    if pid > 0:
+        try:
+            os.kill(pid, 0)  # 存活探测
+            return pid
+        except OSError:
+            pass
+    try:
+        os.remove(pidfile)
+    except Exception:
+        pass
+    return 0
+
+
+def _server_milvus(cfg_path=None):
+    """全局 config 的 milvus.uri 为 http(s) 即 server 模式；Lite 文件锁下 watch 有害（上游 common.sh 规则）。"""
+    if cfg_path is None:
+        cfg_path = os.path.join(os.path.expanduser("~"), ".memsearch", "config.toml")
+    try:
+        import tomllib
+
+        with open(cfg_path, "rb") as f:
+            uri = str(tomllib.load(f).get("milvus", {}).get("uri", ""))
+        return uri.startswith("http")
+    except Exception:
+        return False
+
+
+def _watch_start(cmd, memsearch_dir):
+    """启动 watch（detached，stderr→watch.log，轮转保留 .1）。已在跑返回现有 pid。"""
+    pid = _watch_pid(memsearch_dir)
+    if pid:
+        return pid
+    try:
+        os.makedirs(memsearch_dir, exist_ok=True)
+        log = os.path.join(memsearch_dir, WATCH_LOG_NAME)
+        if os.path.isfile(log):
+            os.replace(log, log + ".1")  # 只留最近一个旧日志
+        env = os.environ.copy()
+        env["MEMSEARCH_DIR"] = memsearch_dir
+        env.pop("MEMSEARCH_NO_WATCH", None)  # 显式 watch 不应带 NO_WATCH
+        err = open(log, "ab")
+        try:
+            p = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=err,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                | getattr(subprocess, "DETACHED_PROCESS", 0),
+                start_new_session=os.name != "nt",
+                close_fds=True,
+                env=env,
+            )
+        finally:
+            err.close()
+        _write_text(os.path.join(memsearch_dir, WATCH_PID_NAME), str(p.pid))
+        return p.pid
+    except Exception:
+        return 0
+
+
+def _watch_stop(memsearch_dir, grace_s=3):
+    """停止 watch：POSIX INT→KILL；Windows 无头进程无控制台可分派 INT，直接 TERM（TerminateProcess）。返回是否曾存活。"""
+    pid = _watch_pid(memsearch_dir)
+    if not pid:
+        return False
+    sigs = (
+        [signal.SIGTERM]
+        if os.name == "nt"
+        else [signal.SIGINT, getattr(signal, "SIGKILL", signal.SIGTERM)]
+    )
+    for sig in sigs:
+        try:
+            os.kill(pid, sig)
+        except Exception:
+            pass
+        for _ in range(grace_s):
+            time.sleep(1)
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                break
+        else:
+            continue
+        break
+    try:
+        os.remove(os.path.join(memsearch_dir, WATCH_PID_NAME))
+    except Exception:
+        pass
+    return True
+
+
+# ---------------------------------------------------------------------------
+# SessionStart：状态行 + 最近记忆预览（纯文件读，零后端调用）
+# ---------------------------------------------------------------------------
+
+def _resolve_summarize_provider():
+    """按 §3.4 规则从全局 ~/.memsearch/config.toml 解析 summarize 将用的 provider。
+
+    只读配置文件（不调用 memsearch config CLI）。返回 dict 供状态行与失败诊断。
+    安全约束：绝不回显 api_key / token 字段值。
+    """
+    result = {
+        "config_path": "",
+        "provider": "",
+        "model": "",
+        "openclaw_summarize": {},
+        "error": "",
+    }
+    cfg_path = os.path.expanduser(os.path.join("~", ".memsearch", "config.toml"))
+    result["config_path"] = cfg_path
+    if not os.path.isfile(cfg_path):
+        result["error"] = (
+            "global config not found: %s — 请先创建 ~/.memsearch/config.toml "
+            "并配置 [llm.providers.<name>]" % cfg_path
+        )
+        return result
+    try:
+        import tomllib
+
+        with open(cfg_path, "rb") as f:
+            cfg = tomllib.load(f)
+    except ImportError:
+        result["error"] = "tomllib unavailable (python<3.11) — provider 解析跳过"
+        return result
+    except Exception as e:
+        result["error"] = "config.toml 解析失败: %s" % e
+        return result
+
+    providers = cfg.get("llm", {}).get("providers", {})
+    if isinstance(providers, dict):
+        for name, p in providers.items():
+            if isinstance(p, dict) and p.get("type") and p.get("model"):
+                result["provider"] = name
+                result["model"] = str(p.get("model"))
+                break
+    oc_sum = cfg.get("plugins", {}).get("openclaw", {}).get("summarize", {})
+    if isinstance(oc_sum, dict):
+        # 只回显非敏感键
+        result["openclaw_summarize"] = {
+            k: v for k, v in oc_sum.items() if k not in ("api_key", "token")
+        }
+    if not result["provider"]:
+        result["error"] = (
+            "~/.memsearch/config.toml 中无可用 [llm.providers.<name>]"
+            "（需 type 与 model 均非空）— summarize 将无 provider 可用，"
+            "按 §3.4 不静默降级"
+        )
+    return result
+
+
+def _recent_memory_preview(memory_dir, max_files=2, max_lines=40):
+    """最近 daily 记忆预览：只保留 ##/###/#### 标题与 '- ' bullet 行（对齐 claude 版 awk 逻辑）。"""
+    if not os.path.isdir(memory_dir):
+        return ""
+    daily = [
+        f
+        for f in os.listdir(memory_dir)
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}\.md", f)
+    ]
+    if not daily:
+        return ""
+    daily.sort(reverse=True)
+    sections = []
+    for fname in daily[:max_files]:
+        kept = []
+        try:
+            with open(
+                os.path.join(memory_dir, fname), encoding="utf-8", errors="replace"
+            ) as f:
+                for line in f:
+                    s = line.rstrip("\n")
+                    if re.match(r"^#{2,4}\s", s) or s.startswith("- "):
+                        kept.append(s)
+        except Exception:
+            continue
+        kept = kept[-max_lines:]
+        if any(l.startswith("- ") for l in kept):
+            sections.append("## %s\n%s" % (fname, "\n".join(kept)))
+    if not sections:
+        return ""
+    return "# Recent Memory\n\n" + "\n\n".join(sections)
+
+
+def on_session_start(payload, ctx):
+    proj = ctx["project_dir"]
+    memsearch_dir = ctx["memsearch_dir"]
+    memory_dir = os.path.join(memsearch_dir, "memory")
+    collection = _derive_collection(proj)
+
+    prov = _resolve_summarize_provider()
+    if prov["provider"]:
+        prov_desc = "%s/%s" % (prov["provider"], prov["model"])
+    else:
+        prov_desc = "NOT CONFIGURED — %s" % prov["error"]
+
+    status = (
+        "[memsearch-wb] summarize route:"
+        " plugins.openclaw.summarize.* --agent-name WorkBuddy | provider: %s"
+        % prov_desc
+    )
+
+    ms = _find_memsearch()
+    if ms:
+        # skills hint（对齐 claude 插件契约：无候选时 exit=1 静默，空输出即无 hint）
+        if os.path.isdir(os.path.join(memsearch_dir, "skill-candidates")):
+            rc, hint = _run(
+                [ms, "skills", "status", "--hint"],
+                timeout=5,
+                env=_child_env(memsearch_dir),
+            )
+            if rc == 0 and hint.strip():
+                status += " | " + hint.strip()
+        # watch 管理：MEMSEARCH_WB_WATCH=1 且 server 模式时起常驻 watch（替代一次性索引）
+        watch_on = os.environ.get("MEMSEARCH_WB_WATCH", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        wpid = _watch_pid(memsearch_dir)
+        if watch_on and _server_milvus():
+            if not wpid and os.path.isdir(memory_dir):
+                wpid = _watch_start([ms, "watch", memory_dir, "-c", collection], memsearch_dir)
+            status += " | watch: %s" % ("running pid %d" % wpid if wpid else "start failed")
+        else:
+            if watch_on:
+                status += " | watch: skipped(Lite)"  # Lite 文件锁与 watch 冲突，退回一次性索引
+            elif wpid:
+                status += " | watch: running pid %d (unmanaged)" % wpid
+            # 后台一次性索引（detached，skip-if-running），完成后由子进程写时间戳
+            if os.path.isdir(memory_dir):
+                _bg_index(
+                    os.path.join(SCRIPT_DIR, "handler.py"),
+                    memory_dir,
+                    collection,
+                    memsearch_dir,
+                )
+    else:
+        status += " | ERROR: memsearch CLI not found on PATH"
+    # §7-12 滞后窗口等待提示（纯文件读，零 RPC）
+    lag = _lag_hint(memsearch_dir)
+    if lag:
+        status += " | " + lag
+
+    context = _recent_memory_preview(memory_dir)
+
+    response = {"continue": True, "systemMessage": status}
+    if context:
+        response["hookSpecificOutput"] = {
+            "hookEventName": "SessionStart",
+            "additionalContext": context,
+        }
+    return response
+
+
+# ---------------------------------------------------------------------------
+# UserPromptSubmit：后端搜索 top-2 记忆注入；任何失败退回轻量记号，绝不阻塞
+# ---------------------------------------------------------------------------
+
+PROMPT_MIN_LEN = 10
+SEARCH_TOP_K = 2
+SEARCH_TIMEOUT_S = 6  # hook 预算 10s，给 WorkBuddy 侧留余量
+SEARCH_QUERY_MAX = 500  # 查询截断，约束 embedding 成本
+MEM_CTX_MAX = 400  # 单条注入正文上限
+
+
+def _search_memories(query, collection, memsearch_dir, timeout=SEARCH_TIMEOUT_S):
+    """memsearch search -j → [(text, heading, source)]；任何失败返回 []。"""
+    ms = _find_memsearch()
+    if not ms:
+        return []
+    rc, out = _run(
+        [ms, "search", query[:SEARCH_QUERY_MAX], "-c", collection,
+         "-k", str(SEARCH_TOP_K), "-j"],
+        timeout=timeout,
+        env=_child_env(memsearch_dir),
+    )
+    if rc != 0 or not out.strip():
+        return []
+    try:
+        rows = json.loads(out)
+    except ValueError:
+        return []
+    hits = []
+    for r in rows if isinstance(rows, list) else []:
+        text = re.sub(r"\s+", " ", str(r.get("content", ""))).strip()
+        if text:
+            hits.append(
+                (
+                    text[:MEM_CTX_MAX],
+                    str(r.get("heading") or ""),
+                    os.path.basename(str(r.get("source") or "")),
+                )
+            )
+    return hits
+
+
+def on_user_prompt_submit(payload, ctx):
+    prompt = (payload.get("prompt") or "").strip()
+    if len(prompt) < PROMPT_MIN_LEN:
+        return {"continue": True}
+    resp = {"continue": True, "systemMessage": "[memsearch] Memory available"}
+    hits = _search_memories(
+        prompt, _derive_collection(ctx["project_dir"]), ctx["memsearch_dir"]
+    )
+    if not hits:
+        return resp
+    lines = ["[memsearch] 相关历史记忆（按相关度排序，仅供参考）:"]
+    for i, (text, heading, source) in enumerate(hits, 1):
+        where = source + (" › " + heading if heading else "")
+        lines.append("%d. (%s) %s" % (i, where, text))
+    resp["systemMessage"] = "[memsearch] %d related memories" % len(hits)
+    resp["hookSpecificOutput"] = {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": "\n".join(lines),
+    }
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Stop / SubagentStop：parse → summarize → 追加 memory/*.md → index → 时间戳
+# ---------------------------------------------------------------------------
+
+def on_stop(payload, ctx, event):
+    if payload.get("stop_hook_active") is True:
+        return {"continue": True}
+
+    transcript = payload.get("transcript_path") or ""
+    if not transcript or not os.path.isfile(transcript):
+        return {"continue": True}
+
+    try:
+        with open(transcript, encoding="utf-8", errors="replace") as f:
+            line_count = sum(1 for _ in f)
+    except Exception:
+        line_count = 0
+    if line_count < 3:
+        return {"continue": True}
+
+    meta = ctx["parse_mod"].parse_last_turn(transcript)
+    if meta["sentinel"] or not meta["text"]:
+        return {"continue": True}
+
+    session_id = os.path.splitext(os.path.basename(transcript))[0]
+    today = time.strftime("%Y-%m-%d")
+    now = time.strftime("%H:%M")
+    memory_dir = os.path.join(ctx["memsearch_dir"], "memory")
+    memory_file = os.path.join(memory_dir, "%s.md" % today)
+
+    # 懒写标题判定（只读检查 memory 文件）：无本 session 锚点则先补 ## Session 标题
+    need_session_heading = True
+    if os.path.isfile(memory_file):
+        try:
+            with open(memory_file, encoding="utf-8", errors="replace") as f:
+                if ("session:%s" % session_id) in f.read():
+                    need_session_heading = False
+        except Exception:
+            pass
+
+    _stop_live(ctx, meta, transcript, memory_dir, memory_file,
+               session_id, now, need_session_heading)
+    return {"continue": True}
+
+
+def _stop_live(ctx, meta, transcript, memory_dir, memory_file,
+               session_id, now, need_session_heading):
+    """Stop 主流程：summarize → 追加 memory/*.md → index → 写隐含时间戳。"""
+    memsearch_dir = ctx["memsearch_dir"]
+    collection = _derive_collection(ctx["project_dir"])
+    ms = _find_memsearch()
+
+    # --- summarize（provider 缺失给清晰错误 bullet，不静默降级 — §3.4/A4）---
+    summary = ""
+    failure = ""
+    prov = _resolve_summarize_provider()
+    if not ms:
+        failure = "memsearch CLI not found on PATH"
+    elif not prov["provider"]:
+        failure = "no LLM provider configured in ~/.memsearch/config.toml"
+    else:
+        rc, out = _run(
+            [ms, "summarize", "--plugin", "openclaw",
+             "--agent-name", OPENCLAW_AGENT_NAME],
+            input_text=meta["text"],
+            timeout=110,
+            env=_child_env(memsearch_dir),
+        )
+        if rc in (-124, 124):
+            failure = "summarizer timed out"
+        elif rc != 0:
+            failure = "summarizer exited with status %d" % rc
+        elif not out.strip():
+            failure = "summarizer returned empty output"
+        else:
+            summary = out.strip()
+    if failure:
+        summary = (
+            "- Memory summary unavailable: %s; transcript content was omitted."
+            " Use the transcript anchor for progressive disclosure." % failure
+        )
+
+    # --- 追加当日 memory/*.md（懒写 ## Session 标题 + 锚点）---
+    parts = []
+    if need_session_heading:
+        parts.append("\n## Session %s\n" % now)
+    parts.append("### %s" % now)
+    parts.append(
+        "<!-- session:%s turn:%s transcript:%s -->"
+        % (session_id, meta["last_user_id"], transcript)
+    )
+    parts.append(summary)
+    parts.append("")
+    try:
+        os.makedirs(memory_dir, exist_ok=True)
+        with open(memory_file, "a", encoding="utf-8") as f:
+            f.write("\n".join(parts))
+    except Exception:
+        return  # 写不进记忆就不索引（无增量）
+
+    # --- index（同步）→ 成功后写隐含时间戳（§7-12）---
+    if ms:
+        rc, _ = _run(
+            [ms, "index", memory_dir, "-c", collection],
+            timeout=300,
+            env=_child_env(memsearch_dir),
+        )
+        if rc == 0:
+            _write_index_ts(memsearch_dir)
+            # detached 点火到期 maintenance（due-state 节流，未到期近似 no-op）
+            _bg_run(
+                MAINT_PID_NAME,
+                [
+                    sys.executable,
+                    os.path.join(SCRIPT_DIR, "handler.py"),
+                    "--maintenance",
+                    ctx["project_dir"],
+                    memsearch_dir,
+                ],
+                memsearch_dir,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 主入口
+# ---------------------------------------------------------------------------
+
+def main():
+    # 隐藏子命令：SessionStart 的后台索引进程（detached，独立执行后写时间戳）
+    if len(sys.argv) > 1 and sys.argv[1] == "--index-and-stamp":
+        if len(sys.argv) >= 5:
+            return _index_and_stamp(sys.argv[2], sys.argv[3], sys.argv[4])
+        return 1
+
+    # 隐藏子命令：Stop 后的到期 maintenance + 技能蒸馏（detached）
+    if len(sys.argv) > 1 and sys.argv[1] == "--maintenance":
+        if len(sys.argv) >= 4:
+            return _maintenance(sys.argv[2], sys.argv[3])
+        return 1
+
+    # C4 防重入：维护/摘要点火链里的子进程不再触发本插件
+    if os.environ.get("MEMSEARCH_DISABLE") == "1":
+        _respond({"continue": True})
+        return 0
+
+    try:
+        raw = sys.stdin.read() or ""
+    except Exception:
+        raw = ""
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        payload = {}
+
+    event = payload.get("hook_event_name") or "unknown"
+    project_dir = _project_dir(payload)
+    memsearch_dir = os.path.join(project_dir, ".memsearch")
+    ctx = {
+        "project_dir": project_dir,
+        "memsearch_dir": memsearch_dir,
+        "parse_mod": None,
+    }
+
+    try:
+        if event in ("Stop", "SubagentStop"):
+            ctx["parse_mod"] = _load_parse()
+            response = on_stop(payload, ctx, event)
+        elif event == "SessionStart":
+            response = on_session_start(payload, ctx)
+        elif event == "UserPromptSubmit":
+            response = on_user_prompt_submit(payload, ctx)
+        else:
+            response = {"continue": True}
+    except Exception:
+        # C2：任何解析/分派异常都不卡死会话
+        response = {"continue": True}
+
+    _respond(response)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/workbuddy/scripts/parse.py
+++ b/plugins/workbuddy/scripts/parse.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""parse.py — WorkBuddy transcript JSONL → 扁平 turn 文本（L1 正则化核心，独立可测）。
+
+依据 docs/memsearch-workbuddy-spec.md §0.2 / §3.3 实现：
+- 只处理顶层 type=="message" 的行；role 取自顶层（不是嵌套 message.role）。
+- content 为 OpenAI content-array：user→input_text / assistant→output_text，
+  取各 block 的 text；兜底接受 "text" block 与纯字符串 content。
+- 剥除 user 文本中嵌套的注入块：<system-reminder ...>、<user_context>、
+  <additional_data>、<current_time>、<user_references>、<user_info>、
+  <identity_context>（含配对块 / 自闭合 / 截断残留三种形态）。
+- 只取末尾回合：最后一条真实 user 消息起，到文件尾。
+- file-history-snapshot 行不硬丢弃（§3.3 保留策略）：能提取出有效正文
+  （如 trackedFileBackups 的文件清单）才保留为 [System] 行，为空则自然跳过。
+- reasoning / ai-title / function_call / function_call_result /
+  resend-fork-notice 等行一律视为噪音跳过。
+
+CLI:  python parse.py <transcript.jsonl>   → stdout 扁平文本（供 pipe）
+API:  parse_last_turn(path) -> dict(text, last_user_id, line_count, kept, skipped_noise)
+"""
+
+import json
+import os
+import re
+import sys
+
+AGENT_LABEL = "WorkBuddy"
+
+# 注入块标签黑名单（WorkBuddy 特有噪音，§0.2.3 / §3.3）
+STRIP_TAGS = (
+    "system-reminder",
+    "user_context",
+    "additional_data",
+    "current_time",
+    "user_references",
+    "user_info",
+    "identity_context",
+)
+
+# 配对块：<tag ...>...</tag>（DOTALL，非贪婪；同名块不嵌套，安全）
+_RE_PAIRED = re.compile(
+    r"<(%s)\b[^>]*>.*?<\s*/\s*\1\s*>" % "|".join(STRIP_TAGS),
+    re.DOTALL,
+)
+# 截断残留：孤立的 <tag ...> 到文本末尾（transcript 写入截断时的兜底）
+_RE_DANGLING = re.compile(
+    r"<(?:%s)\b[^>]*>.*$" % "|".join(STRIP_TAGS),
+    re.DOTALL,
+)
+# 自闭合或孤立标签：<tag .../> / <tag ...>（配对块已删后剩下的标签本身）
+_RE_SELFCLOSE = re.compile(r"<(?:%s)\b[^>]*/?>" % "|".join(STRIP_TAGS))
+
+# WorkBuddy 用 <user_query> 包裹真实用户话——属定界符而非噪音，只剥标签留正文
+_RE_USER_QUERY = re.compile(r"</?user_query\s*>")
+
+# snapshot 的 trackedFileBackups 清单可能极长（实测 100+ 路径），限长防爆 token
+_SNAPSHOT_MAX_PATHS = 20
+
+
+def strip_injected_blocks(text):
+    """剥除 user 文本里的系统注入块，返回真实用户话（可能为空串）。"""
+    if not text:
+        return ""
+    out = _RE_PAIRED.sub("", text)
+    out = _RE_DANGLING.sub("", out)
+    out = _RE_SELFCLOSE.sub("", out)
+    out = _RE_USER_QUERY.sub("", out)
+    return out.strip()
+
+
+def extract_message_text(obj):
+    """从 type=='message' 行提取 (role, text)；无法提取返回 (None, '')。"""
+    if obj.get("type") != "message":
+        return None, ""
+    role = obj.get("role")
+    if role not in ("user", "assistant"):
+        return None, ""
+    content = obj.get("content")
+    parts = []
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            # user: input_text；assistant: output_text；兜底接受 text
+            if block.get("type") in ("input_text", "output_text", "text"):
+                t = block.get("text")
+                if isinstance(t, str) and t.strip():
+                    parts.append(t)
+    text = "\n".join(p.strip() for p in parts if p.strip())
+    if role == "user":
+        text = strip_injected_blocks(text)
+    return role, text.strip()
+
+
+def snapshot_text(obj):
+    """file-history-snapshot 行的有效正文（§3.3 保留策略）；无正文返回 ''。"""
+    snap = obj.get("snapshot")
+    if isinstance(snap, dict):
+        backups = snap.get("trackedFileBackups")
+        if isinstance(backups, dict) and backups:
+            paths = sorted(str(k) for k in backups)
+            shown = paths[:_SNAPSHOT_MAX_PATHS]
+            suffix = ""
+            if len(paths) > _SNAPSHOT_MAX_PATHS:
+                suffix = " ... (+%d more)" % (len(paths) - _SNAPSHOT_MAX_PATHS)
+            return "tracked files: " + ", ".join(shown) + suffix
+    content = obj.get("content")
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    return ""
+
+
+def parse_last_turn(path, agent_label=AGENT_LABEL):
+    """解析 transcript，只取末尾回合，返回扁平文本与元数据。"""
+    with open(path, encoding="utf-8", errors="replace") as f:
+        lines = f.readlines()
+
+    meta = {
+        "text": "",
+        "last_user_id": "",
+        "line_count": len(lines),
+        "kept": 0,
+        "skipped_noise": 0,
+        "sentinel": "",
+    }
+    if not lines:
+        meta["sentinel"] = "(empty transcript)"
+        return meta
+
+    # 反向扫：找最后一条剥噪后仍有正文的 user 消息
+    start_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        line = lines[i].strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        role, text = extract_message_text(obj)
+        if role == "user" and text:
+            start_idx = i
+            meta["last_user_id"] = obj.get("id", "") or ""
+            break
+
+    if start_idx is None:
+        meta["sentinel"] = "(no user message found)"
+        return meta
+
+    out = [
+        "=== Transcript of a conversation between User and %s ===" % agent_label
+    ]
+    seen_snapshots = set()  # 同一回合内完全重复的 snapshot 行只保留首次出现
+    for raw in lines[start_idx:]:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            meta["skipped_noise"] += 1
+            continue
+        if obj.get("type") == "file-history-snapshot":
+            snap = snapshot_text(obj)
+            if snap:
+                snap_line = "[System]: file-history-snapshot: %s" % snap
+                if snap_line not in seen_snapshots:
+                    seen_snapshots.add(snap_line)
+                    out.append(snap_line)
+                    meta["kept"] += 1
+                else:
+                    meta["skipped_noise"] += 1
+            else:
+                meta["skipped_noise"] += 1
+            continue
+        role, text = extract_message_text(obj)
+        if role and text:
+            label = "User" if role == "user" else "Assistant"
+            out.append("[%s]: %s" % (label, text))
+            meta["kept"] += 1
+        elif obj.get("type") != "message":
+            meta["skipped_noise"] += 1
+
+    if len(out) == 1:  # 只有 header，没有任何有效正文
+        meta["sentinel"] = "(empty turn)"
+        return meta
+    meta["text"] = "\n".join(out)
+    return meta
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else ""
+    if not path or not os.path.isfile(path):
+        sys.stderr.write("ERROR: transcript not found: %s\n" % path)
+        return 1
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    meta = parse_last_turn(path)
+    print(meta["sentinel"] or meta["text"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/plugins/workbuddy/scripts/review_capture.py
+++ b/plugins/workbuddy/scripts/review_capture.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""review_capture.py — 通用 agent hook 载荷抓取 + JSON Schema 推导（开发工具）。
+
+独立于 handler.py，不参与 memsearch 管线：把 hooks.json（或任何 agent 框架的
+hook 配置）手动指向本脚本，即可抓取真实事件 stdin 载荷并推导结构。
+
+    python <path>/review_capture.py          # 由 hook 框架以 stdin 喂载荷
+
+每次调用：
+1. 从 stdin 读一个 hook 载荷 JSON（缺失/损坏/非对象均不抛错）；
+2. 向 stdout 打印恰好一个 {"continue": true} 并 exit 0（绝不阻塞会话）；
+3. 追加一条截断后的捕获记录到 <out>/captures/<event>.jsonl；
+4. 重新推导并覆写 <out>/hook-schema.json —— 各事件节点的 JSON Schema：
+   每个字段含数据类型 type（联合类型为数组）、出现次数 x-present、
+   required（在该节点全部观测中出现）、x-examples（标量样例）。
+
+产物目录：<project>/.hook-review/（HOOK_REVIEW_DIR 可覆盖）。
+project 解析：payload.cwd → CODEBUDDY_PROJECT_DIR → CLAUDE_PROJECT_DIR → 进程 cwd。
+仅标准库，无 memsearch 依赖，可拷到任意插件工程独立使用。
+"""
+
+import json
+import os
+import re
+import sys
+import time
+
+MAX_STR = 500        # 捕获记录中单字符串最大长度
+MAX_ITEMS = 50       # 捕获记录中单数组最大元素数
+MAX_DEPTH = 8        # 捕获记录最大嵌套深度
+MAX_EXAMPLES = 2     # schema 节点保留的标量样例数
+EXAMPLE_STR = 80     # 样例字符串最大长度
+STATS_NAME = "capture-stats.json"
+SCHEMA_NAME = "hook-schema.json"
+
+
+def _respond():
+    try:
+        sys.stdout.write('{"continue": true}')
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
+def _project_dir(payload):
+    for cand in (
+        payload.get("cwd"),
+        os.environ.get("CODEBUDDY_PROJECT_DIR"),
+        os.environ.get("CLAUDE_PROJECT_DIR"),
+    ):
+        if isinstance(cand, str) and cand and os.path.isdir(cand):
+            return os.path.abspath(cand)
+    return os.getcwd()
+
+
+def _safe_name(event):
+    return re.sub(r"[^A-Za-z0-9_-]", "_", str(event))[:60] or "unknown"
+
+
+def _truncate(value, depth=0):
+    """捕获记录净化：超长字符串/数组/深度截断，非 JSON 原生类型转字符串。"""
+    if depth > MAX_DEPTH:
+        return "…[MAX-DEPTH]"
+    if isinstance(value, str):
+        if len(value) > MAX_STR:
+            return value[:MAX_STR] + "…[TRUNCATED %d chars total]" % len(value)
+        return value
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, dict):
+        return {str(k)[:120]: _truncate(v, depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        items = [_truncate(v, depth + 1) for v in value[:MAX_ITEMS]]
+        if len(value) > MAX_ITEMS:
+            items.append("…[TRUNCATED +%d more items]" % (len(value) - MAX_ITEMS))
+        return items
+    return str(value)[:MAX_STR]
+
+
+# ---------------------------------------------------------------------------
+# Schema 推导：stats 树 → JSON Schema
+# ---------------------------------------------------------------------------
+
+def _type_name(v):
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "boolean"
+    if isinstance(v, int):
+        return "integer"
+    if isinstance(v, float):
+        return "number"
+    if isinstance(v, str):
+        return "string"
+    if isinstance(v, dict):
+        return "object"
+    if isinstance(v, list):
+        return "array"
+    return "string"
+
+
+def _new_node():
+    # present=本节点被观测次数；props=object 子字段；items=array 元素合并节点
+    return {"types": [], "present": 0, "examples": [], "props": {}, "items": None}
+
+
+def _merge(node, value):
+    t = _type_name(value)
+    if t not in node["types"]:
+        node["types"].append(t)
+        node["types"].sort()
+    node["present"] += 1
+    if t in ("string", "boolean", "integer", "number", "null"):
+        ex = value[:EXAMPLE_STR] if isinstance(value, str) else value
+        ex_keys = [json.dumps(e, ensure_ascii=False, sort_keys=True) for e in node["examples"]]
+        if len(node["examples"]) < MAX_EXAMPLES and json.dumps(
+            ex, ensure_ascii=False, sort_keys=True
+        ) not in ex_keys:
+            node["examples"].append(ex)
+    if t == "object":
+        for k, v in value.items():
+            _merge(node["props"].setdefault(k, _new_node()), v)
+    if t == "array":
+        if node["items"] is None:
+            node["items"] = _new_node()
+        for item in value[:MAX_ITEMS]:
+            _merge(node["items"], item)
+
+
+def _node_schema(node):
+    types = node["types"] or ["null"]
+    out = {"type": types[0] if len(types) == 1 else types}
+    out["x-present"] = node["present"]
+    if node["examples"]:
+        out["x-examples"] = node["examples"]
+    if "object" in node["types"] and node["props"]:
+        out["properties"] = {
+            k: _node_schema(v) for k, v in sorted(node["props"].items())
+        }
+        out["required"] = sorted(
+            k for k, v in node["props"].items() if v["present"] == node["present"]
+        )
+    if "array" in node["types"] and node["items"]:
+        out["items"] = _node_schema(node["items"])
+    return out
+
+
+def _emit_schema(stats):
+    events = {}
+    for ev in sorted(stats["events"]):
+        node = stats["events"][ev]
+        body = _node_schema(node)
+        body["x-observations"] = node["present"]
+        events[ev] = body
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Agent hook stdin payloads — observed JSON Schema (auto-generated)",
+        "x-generator": "review_capture.py (memsearch-workbuddy plugin dev tool)",
+        "x-updated": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "x-note": "required=该字段在本节点全部观测中出现；x-present=出现次数；"
+                  "type 为数组时表示观测到联合类型；由截断后的捕获推导（类型不受影响）",
+        "events": events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 主入口
+# ---------------------------------------------------------------------------
+
+def main():
+    try:
+        raw = sys.stdin.read() or ""
+    except Exception:
+        raw = ""
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+        if not isinstance(payload, dict):
+            payload = {"_nonobject_payload": payload}
+    except Exception:
+        payload = {"_unparsed_stdin": raw[:MAX_STR]}
+
+    event = payload.get("hook_event_name") or "unknown"
+    out_dir = os.environ.get("HOOK_REVIEW_DIR") or os.path.join(
+        _project_dir(payload), ".hook-review"
+    )
+
+    _respond()  # 先响应再落盘，不阻塞 hook 调用方
+
+    try:
+        captures_dir = os.path.join(out_dir, "captures")
+        os.makedirs(captures_dir, exist_ok=True)
+
+        capture = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "event": event,
+            "payload": _truncate(payload),
+        }
+        with open(
+            os.path.join(captures_dir, _safe_name(event) + ".jsonl"),
+            "a",
+            encoding="utf-8",
+        ) as f:
+            f.write(json.dumps(capture, ensure_ascii=False) + "\n")
+
+        stats_path = os.path.join(out_dir, STATS_NAME)
+        try:
+            with open(stats_path, encoding="utf-8") as f:
+                stats = json.load(f)
+            if not isinstance(stats.get("events"), dict):
+                raise ValueError
+        except Exception:
+            stats = {"events": {}}
+
+        node = stats["events"].setdefault(event, _new_node())
+        _merge(node, capture["payload"])
+
+        with open(stats_path, "w", encoding="utf-8") as f:
+            json.dump(stats, f, ensure_ascii=False, indent=1)
+        with open(os.path.join(out_dir, SCHEMA_NAME), "w", encoding="utf-8") as f:
+            json.dump(_emit_schema(stats), f, ensure_ascii=False, indent=1)
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/workbuddy/scripts/tests/conftest.py
+++ b/plugins/workbuddy/scripts/tests/conftest.py
@@ -1,0 +1,6 @@
+"""pytest 引导：使 hooks/ 目录下的 handler/parse 可被 import。"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/plugins/workbuddy/scripts/tests/test_maintenance.py
+++ b/plugins/workbuddy/scripts/tests/test_maintenance.py
@@ -1,0 +1,126 @@
+"""maintenance 迁移（run_due_tasks + distill，platform 借 openclaw 槽）留档。
+
+memsearch 包级 API 一律 mock，不触真实 LLM/后端。
+"""
+
+import dataclasses
+import os
+import types
+
+import pytest
+
+import handler
+
+
+@dataclasses.dataclass
+class _TC:
+    provider: str = "native"
+
+
+@dataclasses.dataclass
+class _Ctx:
+    task_config: _TC
+
+
+def _fake_cfg(provider="siliconflow"):
+    return types.SimpleNamespace(
+        prompts=types.SimpleNamespace(
+            project_review="", user_profile="", memory_to_skill=""
+        ),
+        plugins=types.SimpleNamespace(
+            openclaw=types.SimpleNamespace(
+                summarize=types.SimpleNamespace(provider=provider)
+            )
+        ),
+    )
+
+
+@pytest.fixture
+def mock_pkg(monkeypatch, tmp_path):
+    """mock memsearch 包级 API；返回调用记录。"""
+    rec = {"due": None, "distill": None, "llm": []}
+    cfg = _fake_cfg()
+    monkeypatch.setattr("memsearch.config.resolve_config", lambda: cfg)
+
+    def fake_due(**kw):
+        rec["due"] = kw
+        return []
+
+    def fake_distill(**kw):
+        rec["distill"] = kw
+        return types.SimpleNamespace(__dict__={})
+
+    def fake_llm(ctx, prompt, _cfg):
+        rec["llm"].append(ctx.task_config.provider)
+        return "{}"
+
+    monkeypatch.setattr("memsearch.maintenance.run_due_tasks", fake_due)
+    monkeypatch.setattr("memsearch.maintenance.run_task_llm", fake_llm)
+    monkeypatch.setattr("memsearch.skills.distill", fake_distill)
+    return rec, cfg
+
+
+def test_platform_openclaw_and_paths(mock_pkg, tmp_path):
+    rec, _ = mock_pkg
+    mdir = str(tmp_path / ".memsearch")
+    handler._maintenance(str(tmp_path), mdir)
+    assert rec["due"]["platform"] == "openclaw"  # 白名单无 workbuddy，借槽
+    assert rec["due"]["project_dir"] == str(tmp_path)
+    assert rec["due"]["memsearch_dir"] == mdir
+    assert rec["distill"]["platform"] == "openclaw"
+
+
+def test_native_provider_falls_back_to_summarize(mock_pkg, tmp_path):
+    rec, _ = mock_pkg
+    handler._maintenance(str(tmp_path), str(tmp_path / ".memsearch"))
+    runner = rec["due"]["llm_runner"]
+    runner(_Ctx(_TC("native")), "p")
+    assert rec["llm"] == ["siliconflow"]  # native → summarize provider 回落
+
+
+def test_explicit_provider_passthrough(mock_pkg, tmp_path):
+    rec, _ = mock_pkg
+    handler._maintenance(str(tmp_path), str(tmp_path / ".memsearch"))
+    rec["due"]["llm_runner"](_Ctx(_TC("other-prov")), "p")
+    assert rec["llm"] == ["other-prov"]
+
+
+def test_prompt_defaults_point_to_shared(mock_pkg, tmp_path):
+    _, cfg = mock_pkg
+    handler._maintenance(str(tmp_path), str(tmp_path / ".memsearch"))
+    for task in ("project_review", "user_profile", "memory_to_skill"):
+        p = getattr(cfg.prompts, task)
+        assert p.endswith(os.path.join("_shared", "prompts", task + ".txt"))
+        assert os.path.isfile(p)  # 仓内 _shared/prompts 真实存在
+
+
+def test_pidfile_cleaned_and_errors_swallowed(mock_pkg, monkeypatch, tmp_path):
+    rec, _ = mock_pkg
+    mdir = tmp_path / ".memsearch"
+    mdir.mkdir()
+    pidfile = mdir / handler.MAINT_PID_NAME
+    pidfile.write_text("123", encoding="utf-8")
+
+    def boom(**kw):
+        raise RuntimeError("task exploded")
+
+    monkeypatch.setattr("memsearch.maintenance.run_due_tasks", boom)
+    assert handler._maintenance(str(tmp_path), str(mdir)) == 0
+    assert rec["distill"] is not None  # due 炸了不影响 distill
+    assert not pidfile.exists()
+
+
+def test_bg_run_skip_if_running(monkeypatch, tmp_path):
+    mdir = str(tmp_path)
+    with open(os.path.join(mdir, handler.MAINT_PID_NAME), "w", encoding="utf-8") as f:
+        f.write(str(os.getpid()))  # 本进程必然存活
+    spawned = []
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            spawned.append(a)
+            self.pid = 1
+
+    monkeypatch.setattr(handler.subprocess, "Popen", FakePopen)
+    handler._bg_run(handler.MAINT_PID_NAME, ["x"], mdir)
+    assert not spawned  # 存活中不重复点火

--- a/plugins/workbuddy/scripts/tests/test_prompt_search.py
+++ b/plugins/workbuddy/scripts/tests/test_prompt_search.py
@@ -1,0 +1,118 @@
+"""UserPromptSubmit 搜索注入的 pytest 留档。
+
+后端交互一律 mock；opt-in E2E（MEMSEARCH_SEARCH_E2E=1）用只读集合
+cherry_memory 验证真实 memsearch search -j 往返。
+"""
+
+import json
+import os
+
+import pytest
+
+import handler
+
+ROWS = [
+    {
+        "content": "line1\r\nline2   spaced",
+        "heading": "Session 22:45",
+        "source": "D:\\proj\\.memsearch\\memory\\2026-08-26.md",
+        "score": 0.42,
+    },
+    {
+        "content": "second hit",
+        "heading": "",
+        "source": "D:\\proj\\.memsearch\\memory\\2026-08-25.md",
+        "score": 0.41,
+    },
+]
+
+
+def _ctx(tmp_path):
+    return {
+        "project_dir": str(tmp_path),
+        "memsearch_dir": os.path.join(str(tmp_path), ".memsearch"),
+        "parse_mod": None,
+    }
+
+
+@pytest.fixture
+def mock_run(monkeypatch):
+    """替换 CLI 层；返回可编程的 (rc, stdout) 与调用记录。"""
+    calls = []
+    state = {"rc": 0, "out": json.dumps(ROWS)}
+
+    def fake(args, input_text=None, timeout=60, env=None):
+        calls.append(args)
+        return state["rc"], state["out"]
+
+    monkeypatch.setattr(handler, "_find_memsearch", lambda: "C:/fake/memsearch.exe")
+    monkeypatch.setattr(handler, "_run", fake)
+    return calls, state
+
+
+def test_injects_top2_as_context(mock_run, tmp_path):
+    calls, _ = mock_run
+    out = handler.on_user_prompt_submit(
+        {"prompt": "how does watch work?"}, _ctx(tmp_path)
+    )
+    assert out["systemMessage"] == "[memsearch] 2 related memories"
+    ctx_text = out["hookSpecificOutput"]["additionalContext"]
+    assert "line1 line2 spaced" in ctx_text  # 空白折叠
+    assert "second hit" in ctx_text
+    assert "2026-08-26.md › Session 22:45" in ctx_text  # basename › heading
+    assert "2026-08-25.md" in ctx_text  # 无 heading 只有 basename
+    args = calls[0]
+    assert args[1:2] == ["search"]
+    assert args[2] == "how does watch work?"
+    assert "-c" in args and handler._derive_collection(str(tmp_path)) in args
+    assert args[args.index("-k") + 1] == "2"
+    assert "-j" in args
+
+
+def test_query_truncated_to_500(mock_run, tmp_path):
+    calls, _ = mock_run
+    handler.on_user_prompt_submit({"prompt": "x" * 900}, _ctx(tmp_path))
+    assert len(calls[0][2]) == 500
+
+
+@pytest.mark.parametrize(
+    "rc,out_text",
+    [(1, "[]"), (0, "not-json"), (0, "[]"), (-124, ""), (0, '{"x":1}')],
+)
+def test_failures_fall_back_to_marker(mock_run, tmp_path, rc, out_text):
+    _, state = mock_run
+    state["rc"], state["out"] = rc, out_text
+    out = handler.on_user_prompt_submit({"prompt": "a long enough prompt"}, _ctx(tmp_path))
+    assert out == {"continue": True, "systemMessage": "[memsearch] Memory available"}
+
+
+def test_cli_missing_falls_back(monkeypatch, tmp_path):
+    monkeypatch.setattr(handler, "_find_memsearch", lambda: "")
+    out = handler.on_user_prompt_submit({"prompt": "a long enough prompt"}, _ctx(tmp_path))
+    assert out == {"continue": True, "systemMessage": "[memsearch] Memory available"}
+
+
+def test_short_prompt_skips_search(mock_run, tmp_path):
+    calls, _ = mock_run
+    out = handler.on_user_prompt_submit({"prompt": "短"}, _ctx(tmp_path))
+    assert out == {"continue": True}
+    assert not calls
+
+
+def test_content_capped_at_400(mock_run, tmp_path):
+    _, state = mock_run
+    state["out"] = json.dumps([{"content": "y" * 800, "heading": "", "source": "a.md"}])
+    out = handler.on_user_prompt_submit({"prompt": "a long enough prompt"}, _ctx(tmp_path))
+    assert "y" * 400 in out["hookSpecificOutput"]["additionalContext"]
+    assert "y" * 401 not in out["hookSpecificOutput"]["additionalContext"]
+
+
+@pytest.mark.skipif(
+    os.environ.get("MEMSEARCH_SEARCH_E2E") != "1",
+    reason="opt-in: 命中真实后端（MEMSEARCH_SEARCH_E2E=1 启用）",
+)
+def test_real_search_roundtrip(tmp_path):
+    """只读探测：cherry_memory 为既有填充集合，top-2 应非空。"""
+    hits = handler._search_memories("memory", "cherry_memory", str(tmp_path))
+    assert len(hits) == 2
+    assert all(h[0] for h in hits)

--- a/plugins/workbuddy/scripts/tests/test_watch_manager.py
+++ b/plugins/workbuddy/scripts/tests/test_watch_manager.py
@@ -1,0 +1,212 @@
+"""watch 进程管理 + SessionStart 接线的 pytest 留档。
+
+进程管理用无害 sleeper 子进程替身；E2E（真实 memsearch watch + 远端集合）
+默认跳过，MEMSEARCH_WATCH_E2E=1 时启用并自清理远端测试集合。
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+import pytest
+
+import handler
+
+SLEEPER = [sys.executable, "-c", "import time; time.sleep(300)"]
+
+
+@pytest.fixture
+def mdir(tmp_path):
+    return str(tmp_path / ".memsearch")
+
+
+def _pidfile(mdir):
+    return os.path.join(mdir, handler.WATCH_PID_NAME)
+
+
+# ---------------------------------------------------------------------------
+# 进程管理（sleeper 替身，无外部依赖）
+# ---------------------------------------------------------------------------
+
+def test_start_writes_pid_and_log(mdir):
+    pid = handler._watch_start(SLEEPER, mdir)
+    try:
+        assert pid > 0
+        assert open(_pidfile(mdir), encoding="utf-8").read().strip() == str(pid)
+        assert handler._watch_pid(mdir) == pid
+        assert os.path.isfile(os.path.join(mdir, handler.WATCH_LOG_NAME))
+    finally:
+        handler._watch_stop(mdir)
+    assert handler._watch_pid(mdir) == 0
+
+
+def test_start_idempotent(mdir):
+    p1 = handler._watch_start(SLEEPER, mdir)
+    p2 = handler._watch_start(SLEEPER, mdir)
+    try:
+        assert p1 == p2 > 0
+    finally:
+        handler._watch_stop(mdir)
+
+
+def test_stale_pid_cleaned(mdir):
+    os.makedirs(mdir)
+    with open(_pidfile(mdir), "w", encoding="utf-8") as f:
+        f.write("99999999")
+    assert handler._watch_pid(mdir) == 0
+    assert not os.path.exists(_pidfile(mdir))
+
+
+def test_stop_terminates_and_cleans(mdir):
+    pid = handler._watch_start(SLEEPER, mdir)
+    assert pid > 0
+    assert handler._watch_stop(mdir) is True
+    assert handler._watch_pid(mdir) == 0  # pidfile 已清
+
+
+def test_stop_when_not_running(mdir):
+    assert handler._watch_stop(mdir) is False
+
+
+def test_log_rotation_keeps_one_old(mdir):
+    os.makedirs(mdir)
+    log = os.path.join(mdir, handler.WATCH_LOG_NAME)
+    with open(log, "w", encoding="utf-8") as f:
+        f.write("old")
+    pid = handler._watch_start(SLEEPER, mdir)
+    try:
+        with open(log + ".1", encoding="utf-8") as f:
+            assert f.read() == "old"
+    finally:
+        handler._watch_stop(mdir)
+
+
+def test_server_milvus_detection(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[milvus]\nuri = "https://x.zillizcloud.com"\n', encoding="utf-8")
+    assert handler._server_milvus(str(cfg)) is True
+    cfg.write_text('[milvus]\nuri = "./lite.db"\n', encoding="utf-8")
+    assert handler._server_milvus(str(cfg)) is False
+    cfg.write_text("[other]\n", encoding="utf-8")
+    assert handler._server_milvus(str(cfg)) is False
+
+
+# ---------------------------------------------------------------------------
+# SessionStart 接线（monkeypatch 隔离真实 CLI / 进程）
+# ---------------------------------------------------------------------------
+
+def _ctx(project_dir):
+    return {
+        "project_dir": str(project_dir),
+        "memsearch_dir": os.path.join(str(project_dir), ".memsearch"),
+        "parse_mod": None,
+    }
+
+
+def _wire_mocks(monkeypatch, server):
+    monkeypatch.setattr(handler, "_find_memsearch", lambda: "C:/fake/memsearch.exe")
+    monkeypatch.setattr(handler, "_server_milvus", lambda *a, **k: server)
+    calls = {"start": [], "bg": []}
+    monkeypatch.setattr(
+        handler, "_watch_start", lambda cmd, d: calls["start"].append(cmd) or 4242
+    )
+    monkeypatch.setattr(
+        handler, "_bg_index", lambda *a: calls["bg"].append(a) or None
+    )
+    return calls
+
+
+def _status_line(out):
+    return out.get("systemMessage", "")  # 无 preview 时状态行在 systemMessage
+
+
+def test_sessionstart_watch_server_replaces_bg_index(monkeypatch, tmp_path):
+    memory = tmp_path / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    calls = _wire_mocks(monkeypatch, server=True)
+    monkeypatch.setenv("MEMSEARCH_WB_WATCH", "1")
+    out = handler.on_session_start({"cwd": str(tmp_path)}, _ctx(tmp_path))
+    assert "watch: running pid 4242" in _status_line(out)
+    assert calls["start"] and calls["start"][0][1:3] == ["watch", str(memory)]
+    assert "-c" in calls["start"][0]
+    assert not calls["bg"]  # watch 取代一次性索引
+
+
+def test_sessionstart_watch_lite_falls_back(monkeypatch, tmp_path):
+    memory = tmp_path / ".memsearch" / "memory"
+    memory.mkdir(parents=True)
+    calls = _wire_mocks(monkeypatch, server=False)
+    monkeypatch.setenv("MEMSEARCH_WB_WATCH", "1")
+    out = handler.on_session_start({"cwd": str(tmp_path)}, _ctx(tmp_path))
+    assert "watch: skipped(Lite)" in _status_line(out)
+    assert not calls["start"]
+    assert calls["bg"]  # Lite 退回一次性索引
+
+
+def test_sessionstart_default_no_watch(monkeypatch, tmp_path):
+    (tmp_path / ".memsearch" / "memory").mkdir(parents=True)
+    calls = _wire_mocks(monkeypatch, server=True)
+    monkeypatch.delenv("MEMSEARCH_WB_WATCH", raising=False)
+    out = handler.on_session_start({"cwd": str(tmp_path)}, _ctx(tmp_path))
+    assert "watch:" not in _status_line(out)
+    assert not calls["start"]
+    assert calls["bg"]
+
+
+# ---------------------------------------------------------------------------
+# E2E：真实 memsearch watch，验证外部文件变更被重索引（opt-in）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.environ.get("MEMSEARCH_WATCH_E2E") != "1",
+    reason="opt-in: 命中真实后端（MEMSEARCH_WATCH_E2E=1 启用）",
+)
+def test_watch_reindexes_external_edit(tmp_path):
+    ms = handler._find_memsearch()
+    if not ms or not handler._server_milvus():
+        pytest.skip("memsearch CLI 或 server milvus 不可用")
+    mdir = str(tmp_path / ".memsearch")
+    memory = os.path.join(mdir, "memory")
+    os.makedirs(memory)
+    md = os.path.join(memory, "2026-01-01.md")
+    with open(md, "w", encoding="utf-8") as f:
+        f.write("# seed\n\n- seed bullet\n")
+    coll = "wb_watch_e2e_" + hashlib.sha256(str(tmp_path).encode()).hexdigest()[:8]
+    pid = handler._watch_start([ms, "watch", memory, "-c", coll], mdir)
+    assert pid > 0
+    try:
+        time.sleep(5)  # 启动未即崩
+        assert handler._watch_pid(mdir) == pid
+        with open(md, "a", encoding="utf-8") as f:
+            f.write("\n- external edit %d\n" % time.time())
+        deadline = time.time() + 60
+        indexed = False
+        while time.time() < deadline:  # 任一证据：index-state 出现/更新
+            for root, _dirs, files in os.walk(mdir):
+                if ".index-state.json" in files:
+                    indexed = True
+            if indexed:
+                break
+            time.sleep(2)
+        assert indexed, "60s 内未见 .index-state.json（外部变更未被重索引）"
+    finally:
+        handler._watch_stop(mdir)
+        _drop_collection(coll)
+
+
+def _drop_collection(name):
+    """best-effort 清理远端测试集合（凭据取自全局 config）。"""
+    try:
+        import tomllib
+
+        cfg = os.path.join(os.path.expanduser("~"), ".memsearch", "config.toml")
+        with open(cfg, "rb") as f:
+            m = tomllib.load(f).get("milvus", {})
+        from pymilvus import MilvusClient
+
+        c = MilvusClient(uri=m.get("uri"), token=m.get("token") or None)
+        if c.has_collection(name):
+            c.drop_collection(name)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Adds a **WorkBuddy (CodeBuddy)** plugin — hook-driven semantic memory built on the `memsearch` CLI. Captures finished turns, summarizes them into daily Markdown journals, indexes into Milvus, and injects the top-2 related memories back into context on prompt submit. Due maintenance (PROJECT.md/USER.md + skill distillation) runs via the shared backend engine through the existing `openclaw` config slot.

## What it does
- **SessionStart** — status line, recent-memory preview, detached one-shot index (skip-if-running), opt-in watch daemon (server mode only), lag-window hint.
- **Stop / SubagentStop** — parse last turn → `memsearch summarize` → append `memory/YYYY-MM-DD.md` (lazy session heading + anchor) → index → write `.last-index-completed` → fire detached due maintenance.
- **UserPromptSubmit** — `memsearch search -k 2 -j` against the project collection; inject hits as `additionalContext`; falls back to a non-blocking marker on any failure.
- **Maintenance** — `handler.py --maintenance` delegates to `memsearch.maintenance.run_due_tasks` + `memsearch.skills.distill`. Config routes through the `openclaw` slot (the backend platform whitelist has no `workbuddy`); prompts resolve to the shared `_shared/prompts`.

## Design notes
- **Thin compat layer** — all heavy lifting (summarize routing, embedding, indexing) is delegated to the CLI; the plugin is stdlib-only Python + JSON hook wiring.
- **Never blocks the session** — every failure path returns `{"continue": true}`.
- Per-project collection derivation matches the existing `derive-collection.sh` convention.

## Tests
- `scripts/tests/` — 26 pytest cases (watch lifecycle, prompt-search injection, maintenance routing) using subprocess doubles / mocked backend; opt-in backend E2E skipped by default.

## Notes
- New plugin dir: `plugins/workbuddy/`. No changes to `plugins/_shared` (prompts are byte-identical).
