### PR TITLE
fix: scope index-process cleanup to the running harness

### DIFF
--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -243,7 +243,53 @@ run_maintenance() {
 
 # --- Index process cleanup ---
 
-INDEX_PIDFILE="$MEMSEARCH_DIR/.index.pid"
+# Which harness is running these hooks. Claude Code, Codex, and third-party
+# clients that load these Claude-compatible plugin hooks can all share a single
+# MEMSEARCH_DIR. Tagging the index pidfile per harness -- and skipping PIDs that
+# another harness owns -- stops one harness's session start from reaping an
+# index another harness still has in flight. Override when a harness reuses
+# another plugin's hooks verbatim.
+MEMSEARCH_HARNESS_ID="${MEMSEARCH_HARNESS:-claude-code}"
+
+INDEX_PIDFILE="$MEMSEARCH_DIR/.index.${MEMSEARCH_HARNESS_ID}.pid"
+# Pidfile format from before harness tagging. No harness owns it, so whichever
+# cleanup runs first reaps it.
+INDEX_PIDFILE_LEGACY="$MEMSEARCH_DIR/.index.pid"
+
+# Is $1 present in the newline-separated list $2?
+_pid_in_list() {
+  [ -n "$2" ] || return 1
+  printf '%s\n' "$2" | grep -qx "$1"
+}
+
+# PIDs owned by *other* harnesses: each live recorded index PID plus its
+# descendants. milvus_lite is spawned by `memsearch index` and outlives it, so
+# the whole subtree has to be spared, not just the recorded root.
+_other_harness_pids() {
+  local f pid frontier next p kid depth snapshot
+  frontier=""
+  for f in "$MEMSEARCH_DIR"/.index.*.pid; do
+    [ -e "$f" ] || continue
+    [ "$f" = "$INDEX_PIDFILE" ] && continue
+    pid=$(cat "$f" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      frontier="$frontier $pid"
+    fi
+  done
+  [ -n "${frontier// /}" ] || return 0
+  snapshot=$(ps -Ao pid=,ppid= 2>/dev/null || true)
+  depth=0
+  while [ -n "${frontier// /}" ] && [ "$depth" -lt 10 ]; do
+    next=""
+    for p in $frontier; do
+      printf '%s\n' "$p"
+      kid=$(printf '%s\n' "$snapshot" | awk -v pp="$p" '$2 == pp {print $1}')
+      [ -n "$kid" ] && next="$next $kid"
+    done
+    frontier="$next"
+    depth=$((depth + 1))
+  done
+}
 
 # Kill any previously spawned background index processes for this project.
 # Also sweeps orphaned milvus_lite processes, which outlive `memsearch index`
@@ -259,29 +305,39 @@ kill_orphaned_index() {
     return 0
   fi
 
-  # 1. Kill PID recorded from previous background index launch
-  if [ -f "$INDEX_PIDFILE" ]; then
-    local pid
-    pid=$(cat "$INDEX_PIDFILE" 2>/dev/null || true)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  local protected f pid orphans opid
+  protected=$(_other_harness_pids | sort -u)
+
+  # 1. Kill PIDs this harness recorded for a previous background index launch,
+  #    plus the untagged legacy pidfile.
+  for f in "$INDEX_PIDFILE" "$INDEX_PIDFILE_LEGACY"; do
+    [ -f "$f" ] || continue
+    pid=$(cat "$f" 2>/dev/null || true)
+    if [ -n "$pid" ] && ! _pid_in_list "$pid" "$protected" && kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null || true
     fi
-    rm -f "$INDEX_PIDFILE"
-  fi
+    rm -f "$f"
+  done
 
-  # 2. Sweep any orphaned memsearch index processes for this MEMORY_DIR
-  local orphans
+  # 2. Sweep orphaned memsearch index processes for this MEMORY_DIR. Every
+  #    harness sharing MEMSEARCH_DIR indexes the same MEMORY_DIR, so the
+  #    pattern alone cannot tell them apart -- skip what another harness owns.
   orphans=$(pgrep -f "memsearch index $MEMORY_DIR" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
-    echo "$orphans" | while read -r opid; do
+    printf '%s\n' "$orphans" | while read -r opid; do
+      [ -n "$opid" ] || continue
+      if _pid_in_list "$opid" "$protected"; then continue; fi
       kill "$opid" 2>/dev/null || true
     done
   fi
 
-  # 3. Kill orphaned milvus_lite processes (they don't exit when memsearch index exits)
+  # 3. Kill orphaned milvus_lite processes (they don't exit when memsearch index
+  #    exits). This pattern is global, so the protected set matters most here.
   orphans=$(pgrep -f "milvus_lite/lib/milvus" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
-    echo "$orphans" | while read -r opid; do
+    printf '%s\n' "$orphans" | while read -r opid; do
+      [ -n "$opid" ] || continue
+      if _pid_in_list "$opid" "$protected"; then continue; fi
       kill "$opid" 2>/dev/null || true
     done
   fi

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -256,7 +256,53 @@ run_maintenance() {
 
 # --- Index process cleanup ---
 
-INDEX_PIDFILE="$MEMSEARCH_DIR/.index.pid"
+# Which harness is running these hooks. Claude Code, Codex, and third-party
+# clients that load these Claude-compatible plugin hooks can all share a single
+# MEMSEARCH_DIR. Tagging the index pidfile per harness -- and skipping PIDs that
+# another harness owns -- stops one harness's session start from reaping an
+# index another harness still has in flight. Override when a harness reuses
+# another plugin's hooks verbatim.
+MEMSEARCH_HARNESS_ID="${MEMSEARCH_HARNESS:-codex}"
+
+INDEX_PIDFILE="$MEMSEARCH_DIR/.index.${MEMSEARCH_HARNESS_ID}.pid"
+# Pidfile format from before harness tagging. No harness owns it, so whichever
+# cleanup runs first reaps it.
+INDEX_PIDFILE_LEGACY="$MEMSEARCH_DIR/.index.pid"
+
+# Is $1 present in the newline-separated list $2?
+_pid_in_list() {
+  [ -n "$2" ] || return 1
+  printf '%s\n' "$2" | grep -qx "$1"
+}
+
+# PIDs owned by *other* harnesses: each live recorded index PID plus its
+# descendants. milvus_lite is spawned by `memsearch index` and outlives it, so
+# the whole subtree has to be spared, not just the recorded root.
+_other_harness_pids() {
+  local f pid frontier next p kid depth snapshot
+  frontier=""
+  for f in "$MEMSEARCH_DIR"/.index.*.pid; do
+    [ -e "$f" ] || continue
+    [ "$f" = "$INDEX_PIDFILE" ] && continue
+    pid=$(cat "$f" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      frontier="$frontier $pid"
+    fi
+  done
+  [ -n "${frontier// /}" ] || return 0
+  snapshot=$(ps -Ao pid=,ppid= 2>/dev/null || true)
+  depth=0
+  while [ -n "${frontier// /}" ] && [ "$depth" -lt 10 ]; do
+    next=""
+    for p in $frontier; do
+      printf '%s\n' "$p"
+      kid=$(printf '%s\n' "$snapshot" | awk -v pp="$p" '$2 == pp {print $1}')
+      [ -n "$kid" ] && next="$next $kid"
+    done
+    frontier="$next"
+    depth=$((depth + 1))
+  done
+}
 
 # Kill any previously spawned background index processes for this project.
 # Also sweeps orphaned milvus_lite processes.
@@ -266,29 +312,39 @@ kill_orphaned_index() {
     return 0
   fi
 
-  # 1. Kill PID recorded from previous background index launch
-  if [ -f "$INDEX_PIDFILE" ]; then
-    local pid
-    pid=$(cat "$INDEX_PIDFILE" 2>/dev/null || true)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  local protected f pid orphans opid
+  protected=$(_other_harness_pids | sort -u)
+
+  # 1. Kill PIDs this harness recorded for a previous background index launch,
+  #    plus the untagged legacy pidfile.
+  for f in "$INDEX_PIDFILE" "$INDEX_PIDFILE_LEGACY"; do
+    [ -f "$f" ] || continue
+    pid=$(cat "$f" 2>/dev/null || true)
+    if [ -n "$pid" ] && ! _pid_in_list "$pid" "$protected" && kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null || true
     fi
-    rm -f "$INDEX_PIDFILE"
-  fi
+    rm -f "$f"
+  done
 
-  # 2. Sweep any orphaned memsearch index processes for this MEMORY_DIR
-  local orphans
+  # 2. Sweep orphaned memsearch index processes for this MEMORY_DIR. Every
+  #    harness sharing MEMSEARCH_DIR indexes the same MEMORY_DIR, so the
+  #    pattern alone cannot tell them apart -- skip what another harness owns.
   orphans=$(pgrep -f "memsearch index $MEMORY_DIR" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
-    echo "$orphans" | while read -r opid; do
+    printf '%s\n' "$orphans" | while read -r opid; do
+      [ -n "$opid" ] || continue
+      if _pid_in_list "$opid" "$protected"; then continue; fi
       kill "$opid" 2>/dev/null || true
     done
   fi
 
-  # 3. Kill orphaned milvus_lite processes (they don't exit when memsearch index exits)
+  # 3. Kill orphaned milvus_lite processes (they don't exit when memsearch index
+  #    exits). This pattern is global, so the protected set matters most here.
   orphans=$(pgrep -f "milvus_lite/lib/milvus" 2>/dev/null || true)
   if [ -n "$orphans" ]; then
-    echo "$orphans" | while read -r opid; do
+    printf '%s\n' "$orphans" | while read -r opid; do
+      [ -n "$opid" ] || continue
+      if _pid_in_list "$opid" "$protected"; then continue; fi
       kill "$opid" 2>/dev/null || true
     done
   fi

--- a/tests/test_hook_index_pidfile.py
+++ b/tests/test_hook_index_pidfile.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+PLUGINS = ["claude-code", "codex"]
+DEFAULT_HARNESS = {"claude-code": "claude-code", "codex": "codex"}
+
+
+def _common_sh(plugin: str) -> Path:
+    return Path(f"plugins/{plugin}/hooks/common.sh")
+
+
+def _pgrep_shim(bin_dir: Path) -> Path:
+    """A pgrep that hides milvus_lite from the sweep.
+
+    Step 3 of kill_orphaned_index matches `milvus_lite/lib/milvus` with no path
+    scoping, so under the real pgrep it would kill the milvus_lite processes that
+    other tests in this suite are using. The `memsearch index <dir>` pattern is
+    scoped to a tmp_path, so that one passes through to the real pgrep.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    real = shutil.which("pgrep") or "/usr/bin/pgrep"
+    shim = bin_dir / "pgrep"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'for arg in "$@"; do\n'
+        '  case "$arg" in\n'
+        "    *milvus_lite/lib/milvus*) exit 1 ;;\n"
+        "  esac\n"
+        "done\n"
+        f'exec {real} "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return shim
+
+
+def _run_bash(plugin: str, body: str, *, env_extra: dict[str, str], memsearch_dir: Path) -> str:
+    """Source a plugin's common.sh and run `body` against it."""
+    script = textwrap.dedent(f"""
+        SCRIPT_DIR="$(cd "$(dirname "{_common_sh(plugin)}")" && pwd)"
+        source "{_common_sh(plugin)}" </dev/null
+        {body}
+    """)
+    shim_dir = memsearch_dir.parent / "shim-bin"
+    _pgrep_shim(shim_dir)
+    env = {
+        **os.environ,
+        "PATH": f"{shim_dir}{os.pathsep}{os.environ['PATH']}",
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "CLAUDE_PROJECT_DIR": str(memsearch_dir.parent),
+        **env_extra,
+    }
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env, check=True)
+    return result.stdout
+
+
+def _spawn_sleeper(memory_dir: Path, bin_dir: Path, *, with_child: bool = False) -> subprocess.Popen[bytes]:
+    """A process whose command line matches the `memsearch index <dir>` sweep pattern.
+
+    `exec -a` replaces the wrapper with the sleep itself, so the PID handles SIGTERM
+    promptly; a bash wrapper would defer the signal until its foreground child exited.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    fake = bin_dir / "memsearch"
+    if with_child:
+        # Stays alive as a parent so the descendant-protection case has a subtree.
+        body = 'exec -a "memsearch index $2 child" sleep 30 &\necho $! > "$2.child"\nwait\n'
+    else:
+        body = 'exec -a "memsearch index $2" sleep 30\n'
+    fake.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+    fake.chmod(0o755)
+    return subprocess.Popen([str(fake), "index", str(memory_dir)])
+
+
+def _alive(proc: subprocess.Popen[bytes]) -> bool:
+    """poll() reaps the child; os.kill(pid, 0) would report a zombie as alive."""
+    return proc.poll() is None
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+@pytest.mark.parametrize("plugin", PLUGINS)
+def test_pidfile_is_tagged_with_the_harness(tmp_path: Path, plugin: str) -> None:
+    memsearch_dir = tmp_path / ".memsearch"
+    out = _run_bash(plugin, 'echo "$INDEX_PIDFILE"', env_extra={}, memsearch_dir=memsearch_dir)
+    assert out.strip().endswith(f".index.{DEFAULT_HARNESS[plugin]}.pid")
+
+
+@pytest.mark.parametrize("plugin", PLUGINS)
+def test_memsearch_harness_env_overrides_the_default_tag(tmp_path: Path, plugin: str) -> None:
+    memsearch_dir = tmp_path / ".memsearch"
+    out = _run_bash(
+        plugin, 'echo "$INDEX_PIDFILE"', env_extra={"MEMSEARCH_HARNESS": "grok"}, memsearch_dir=memsearch_dir
+    )
+    assert out.strip().endswith(".index.grok.pid")
+
+
+@pytest.mark.parametrize("plugin", PLUGINS)
+def test_cleanup_spares_an_index_owned_by_another_harness(tmp_path: Path, plugin: str) -> None:
+    memsearch_dir = tmp_path / ".memsearch"
+    memory_dir = memsearch_dir / "memory"
+    memory_dir.mkdir(parents=True)
+
+    other = _spawn_sleeper(memory_dir, tmp_path / "bin-other")
+    mine = _spawn_sleeper(memory_dir, tmp_path / "bin-mine")
+    time.sleep(0.3)
+    (memsearch_dir / ".index.other-harness.pid").write_text(str(other.pid), encoding="utf-8")
+    (memsearch_dir / f".index.{DEFAULT_HARNESS[plugin]}.pid").write_text(str(mine.pid), encoding="utf-8")
+
+    try:
+        _run_bash(plugin, "kill_orphaned_index", env_extra={}, memsearch_dir=memsearch_dir)
+        time.sleep(0.4)
+
+        assert _alive(other), "another harness's in-flight index must survive"
+        assert not _alive(mine), "this harness's own stale index must be reaped"
+        assert (memsearch_dir / ".index.other-harness.pid").exists()
+        assert not (memsearch_dir / f".index.{DEFAULT_HARNESS[plugin]}.pid").exists()
+    finally:
+        for proc in (other, mine):
+            proc.kill()
+            proc.wait()
+
+
+@pytest.mark.parametrize("plugin", PLUGINS)
+def test_cleanup_spares_descendants_of_another_harness(tmp_path: Path, plugin: str) -> None:
+    """milvus_lite is a child of `memsearch index` and outlives it, so the subtree is protected."""
+    memsearch_dir = tmp_path / ".memsearch"
+    memory_dir = memsearch_dir / "memory"
+    memory_dir.mkdir(parents=True)
+
+    other = _spawn_sleeper(memory_dir, tmp_path / "bin-other", with_child=True)
+    time.sleep(0.5)
+    child_pid = int(Path(f"{memory_dir}.child").read_text(encoding="utf-8").strip())
+    (memsearch_dir / ".index.other-harness.pid").write_text(str(other.pid), encoding="utf-8")
+
+    try:
+        _run_bash(plugin, "kill_orphaned_index", env_extra={}, memsearch_dir=memsearch_dir)
+        time.sleep(0.4)
+
+        assert _alive(other), "another harness's index must survive"
+        assert _pid_alive(child_pid), "its child must survive too"
+    finally:
+        for pid in (child_pid, other.pid):
+            with contextlib.suppress(OSError):
+                os.kill(pid, 9)
+        other.wait()
+
+
+@pytest.mark.parametrize("plugin", PLUGINS)
+def test_cleanup_reaps_the_untagged_legacy_pidfile(tmp_path: Path, plugin: str) -> None:
+    memsearch_dir = tmp_path / ".memsearch"
+    memory_dir = memsearch_dir / "memory"
+    memory_dir.mkdir(parents=True)
+
+    legacy = _spawn_sleeper(memory_dir, tmp_path / "bin-legacy")
+    time.sleep(0.3)
+    (memsearch_dir / ".index.pid").write_text(str(legacy.pid), encoding="utf-8")
+
+    try:
+        _run_bash(plugin, "kill_orphaned_index", env_extra={}, memsearch_dir=memsearch_dir)
+        time.sleep(0.4)
+
+        assert not _alive(legacy)
+        assert not (memsearch_dir / ".index.pid").exists()
+    finally:
+        legacy.kill()
+        legacy.wait()


### PR DESCRIPTION
## Problem

Claude Code and Codex can share a single `MEMSEARCH_DIR`, and so can third-party clients that load these Claude-compatible plugin hooks. When two harnesses share one, either can reap an index the other still has in flight, because all three kill steps in `kill_orphaned_index` are harness-blind:

1. `INDEX_PIDFILE` is one shared path, `.index.pid` — whoever starts last overwrites it.
2. `pgrep -f "memsearch index $MEMORY_DIR"` matches every harness. They all index the same `MEMORY_DIR`, so the pattern cannot tell them apart.
3. `pgrep -f "milvus_lite/lib/milvus"` is unscoped and matches every `milvus_lite` process on the machine.

The visible symptom is a killed index mid-run, then stale search results until the next session start re-indexes.

Worth noting that **a per-harness pidfile alone does not fix this** — steps 2 and 3 would keep cross-killing on their own. All three steps have to become ownership-aware.

## Fix

Tag the pidfile with the harness — `.index.<harness>.pid`, defaulting to the plugin's own name and overridable via `MEMSEARCH_HARNESS` — then have both pattern sweeps skip PIDs owned by another harness's live index.

The protected set includes **descendants**: `milvus_lite` is spawned by `memsearch index` and outlives it, so sparing only the recorded root would still let step 3 kill the child.

Applied to `claude-code` and `codex`, which carry byte-identical cleanup logic. Fixing only one would leave the Claude Code + Codex pairing broken.

Two deliberate choices:

- The pre-tagging `.index.pid` is left unowned and reaped by whichever cleanup runs first, so an in-place upgrade does not strand it.
- `WATCH_PIDFILE` stays shared. One watcher per memory dir is the intended behavior, not a collision.

`MEMSEARCH_HARNESS` also gives harnesses outside this repo a supported way to identify themselves — I hit this running Grok Build, which loads the `claude-code` plugin hooks verbatim.

## Tests

`tests/test_hook_index_pidfile.py`, 10 cases parametrized over both plugins, following the existing pytest-drives-bash pattern in `test_claude_hooks.py`:

- pidfile is tagged with the harness
- `MEMSEARCH_HARNESS` overrides the default tag
- cleanup spares an index owned by another harness, and reaps its own
- cleanup spares **descendants** of another harness's index
- cleanup still reaps the untagged legacy pidfile

**8 of the 10 fail against unpatched code.** The 2 that pass are the legacy-pidfile cases, which the current code satisfies by definition — they are there to guard that path against regression.

Full suite: 360 passed, 7 skipped. `ruff check` and `ruff format --check` clean.

## One thing I did not fix

The tests need a `pgrep` shim, and the reason is worth surfacing on its own.

Step 3's `milvus_lite/lib/milvus` pattern has no path, project, or user scoping, so calling `kill_orphaned_index` in-process kills **every** `milvus_lite` on the machine — including instances belonging to other tests in this suite, which is what the shim works around. The same is true in real use for unrelated projects and non-memsearch milvus work.

That felt like a distinct problem with a wider blast radius than this PR, so I left it alone rather than widening the diff. Happy to open a separate issue, or fold a fix in here if you would prefer that.
