### PR TITLE
chore(release): bump plugin versions for single-source skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-dsh",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, memory-recall skill, and a skill-candidate review panel.",
   "type": "module",
   "main": "index.js",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -68,13 +68,9 @@ def test_skill_copies_match_shared() -> None:
             assert name == shared_name, f"{skill}/{platform}: name mismatch"
             expected_middle = [shared_middle[0], *FRONTMATTER_EXTRA[platform]]
             assert middle == expected_middle, (
-                f"{skill}/{platform}: frontmatter mismatch\n"
-                f"  got:      {middle}\n"
-                f"  expected: {expected_middle}"
+                f"{skill}/{platform}: frontmatter mismatch\n  got:      {middle}\n  expected: {expected_middle}"
             )
-            assert body == shared_body, (
-                f"{skill}/{platform}: body drifted from shared source"
-            )
+            assert body == shared_body, f"{skill}/{platform}: body drifted from shared source"
 
 
 def test_skill_references_match_shared() -> None:
@@ -84,19 +80,11 @@ def test_skill_references_match_shared() -> None:
         assert shared_refs.is_dir(), f"missing shared references {shared_refs}"
 
         shared_files = {
-            p.relative_to(shared_refs): p.read_bytes()
-            for p in sorted(shared_refs.rglob("*"))
-            if p.is_file()
+            p.relative_to(shared_refs): p.read_bytes() for p in sorted(shared_refs.rglob("*")) if p.is_file()
         }
 
         for platform in (*FS_PLATFORMS, "dsh"):
             refs = ROOT / "plugins" / platform / "skills" / skill / "references"
             assert refs.is_dir(), f"missing references {refs}"
-            copied_files = {
-                p.relative_to(refs): p.read_bytes()
-                for p in sorted(refs.rglob("*"))
-                if p.is_file()
-            }
-            assert copied_files == shared_files, (
-                f"{skill}/{platform}: references/ drifted from shared source"
-            )
+            copied_files = {p.relative_to(refs): p.read_bytes() for p in sorted(refs.rglob("*")) if p.is_file()}
+            assert copied_files == shared_files, f"{skill}/{platform}: references/ drifted from shared source"


### PR DESCRIPTION
## Summary

Bump the four plugin components affected by the single-source skills refactor (#710), so the new `memory-config` / `memory-to-skill` skill content reaches each distribution channel.

## Version bumps

| Component | From | To | Channel |
|-----------|------|-----|---------|
| Claude Code | 0.4.18 | 0.4.19 | Marketplace |
| DSH | 0.1.3 | 0.1.4 | npm `@zilliz/memsearch-dsh` |
| OpenCode | 0.3.14 | 0.3.15 | npm `@zilliz/memsearch-opencode` |
| OpenClaw | 0.3.17 | 0.3.18 | ClawHub |

`memsearch` (PyPI) and Codex are unchanged: the refactor touched no core-library code, and Codex has no version file.

## Validation

- DSH: `node --check` + `npm pack --dry-run` (0.1.4, 23 files incl. `skills/`)
- OpenCode: `npm test` (16 pass) + `npm pack --dry-run` (0.3.15)
- OpenClaw: `npm test` (5 pass) + `npm pack --dry-run` (0.3.18)
- Python: `tests/test_skills_sync.py` + transcript/parse tests (11 pass)
