### PR TITLE
fix: enable best-effort Milvus Lite on Windows

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,13 +10,13 @@ See [Architecture — Indexing Cost Model](architecture.md#indexing-cost-model) 
 
 ## Does memsearch work on Windows?
 
-Yes, but **Milvus Lite** (the default local `.db` backend) does not provide Windows binaries.
+Milvus Server and Zilliz Cloud remain the recommended Windows backends. Milvus Lite 3.x now provides a Windows-capable foundation, so memsearch no longer blocks the default local backend on Windows. This local path is best-effort: it has not received one-to-one native Windows validation by the memsearch maintainers and is not part of the formal support matrix.
 
-If you are on Windows, use one of these options instead:
+If the local backend fails, use one of these alternatives:
 
 - **Milvus Server** via Docker
 - **Zilliz Cloud**
-- **WSL2** if you specifically want the Milvus Lite local-file workflow
+- **WSL2** for a Linux-based Milvus Lite local workflow
 
 See [Getting Started — Milvus Backends](getting-started.md#milvus-backends) for the backend comparison and recommended setup.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -368,8 +368,10 @@ Data is stored in a single local `.db` file. No server to install, no ports to o
 
 **Best for:** personal use, single-agent setups, prototyping, development.
 
-!!! warning "Windows not supported"
-    Milvus Lite does not provide Windows binaries ([milvus-lite#176](https://github.com/milvus-io/milvus-lite/issues/176)). On Windows, use **Milvus Server** (Docker) or **Zilliz Cloud** instead. Alternatively, run memsearch inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
+!!! warning "Native Windows is best-effort"
+    Milvus Lite 3.x provides a Windows-capable foundation, and memsearch selects versions containing the required Windows fixes. This path has not received one-to-one native Windows validation by the memsearch maintainers and is not part of the formal support matrix. Use **Milvus Server**, **Zilliz Cloud**, or [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) if the local backend fails.
+
+Collection descriptions are best-effort metadata. Some Milvus Lite 3.x versions accept a description during collection creation but return an empty value later. Memsearch does not use description round-trip for indexing or search correctness.
 
 === "Python"
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,13 +51,13 @@ If you do not want to manage API keys, switch to a local provider such as ONNX, 
 
 ## Windows + Milvus Lite
 
-Milvus Lite (the default local `.db` backend) does not provide Windows binaries.
+Milvus Lite 3.x provides a Windows-capable foundation, and memsearch installs `milvus-lite>=3.1.1` with `pymilvus>=2.6.11` on Windows. The local path is best-effort because the memsearch maintainers have not completed one-to-one native Windows validation; it is not part of the formal support matrix.
 
-On Windows, use one of these options instead:
+If the local backend fails, use one of these alternatives:
 
 - Milvus Server via Docker
 - Zilliz Cloud
-- WSL2 if you specifically want the local Milvus Lite workflow
+- WSL2 for a Linux-based Milvus Lite workflow
 
 See [Getting Started — Milvus Backends](getting-started.md#milvus-backends).
 
@@ -71,12 +71,23 @@ Collection '...' is in state 'released'; call load() before search/get/query
 
 Upgrade memsearch first. Current memsearch versions explicitly load existing Milvus collections before query/search operations.
 
-If this started after upgrading Milvus Lite, check whether the local `.db` file was created by an older Milvus Lite release. Milvus Lite 3.x uses a new pure-Python storage engine and cannot read `.db` files from the previous storage format. Move the old `.db` file aside, then rebuild the index from source markdown:
+If this started after upgrading Milvus Lite, check whether the local `.db` file was created by an older Milvus Lite release. Milvus Lite 3.x uses a different storage layout and cannot automatically migrate a 2.x `.db` file. Preserve the old database and your source markdown, move the database aside manually, then rebuild the derived index from markdown:
 
-```bash
-mv ~/.memsearch/milvus.db ~/.memsearch/milvus.db.bak
-memsearch index . --force
-```
+=== "macOS / Linux"
+
+    ```bash
+    mv ~/.memsearch/milvus.db ~/.memsearch/milvus.db.bak
+    memsearch index . --force
+    ```
+
+=== "Windows PowerShell"
+
+    ```powershell
+    Move-Item "$HOME\.memsearch\milvus.db" "$HOME\.memsearch\milvus.db.bak"
+    memsearch index . --force
+    ```
+
+Do not delete the old database until the rebuilt index has been verified. Memsearch does not perform an in-place 2.x-to-3.x migration. Collection descriptions are also best-effort metadata in Lite 3.x: an empty value from `describe_collection()` does not indicate an indexing or search failure.
 
 Alternatively, keep using the older Milvus Lite environment that created the `.db` file, or switch to Milvus Server via Docker / Zilliz Cloud.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "pymilvus>=2.5.0,!=2.6.10",
+    "pymilvus>=2.5.0,!=2.6.10; sys_platform != 'win32'",
+    "pymilvus>=2.6.11; sys_platform == 'win32'",
     "milvus-lite>=2.5.0; sys_platform != 'win32'",
+    "milvus-lite>=3.1.1; sys_platform == 'win32'",
     "click>=8.1",
     "watchdog>=4.0",
     "pathspec>=0.12",

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -230,7 +230,11 @@ def cli() -> None:
 @click.option(
     "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
 )
-@click.option("--description", default=None, help="Collection description (written on creation only).")
+@click.option(
+    "--description",
+    default=None,
+    help="Best-effort collection metadata written on creation; some backends may not return it.",
+)
 def index(
     paths: tuple[str, ...],
     provider: str | None,
@@ -577,7 +581,11 @@ def _extract_section(
 @click.option(
     "--max-chunk-size", default=None, type=click.IntRange(min=1), help="Max chunk size in characters (must be >= 1)."
 )
-@click.option("--description", default=None, help="Collection description (written on creation only).")
+@click.option(
+    "--description",
+    default=None,
+    help="Best-effort collection metadata written on creation; some backends may not return it.",
+)
 def watch(
     paths: tuple[str, ...],
     provider: str | None,

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -44,6 +44,9 @@ class MemSearch:
     collection:
         Milvus collection name.  Use different names to isolate
         agents sharing the same Milvus server.
+    description:
+        Best-effort collection metadata written during creation. Some backends
+        may not return it; indexing and search do not depend on it.
     ignore_files:
         Ignore filenames to discover within each directory index root, such
         as ``[".gitignore"]``. Empty by default for backward compatibility.

--- a/src/memsearch/store.py
+++ b/src/memsearch/store.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
-import sys
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -72,15 +71,6 @@ class MilvusStore:
         from pymilvus import MilvusClient
 
         is_local = not uri.startswith(("http", "tcp"))
-        if is_local and sys.platform == "win32":
-            raise RuntimeError(
-                "milvus-lite does not support Windows (no wheels on PyPI).\n"
-                "Use a remote Milvus server instead:\n"
-                "  docker run -d -p 19530:19530 milvusdb/milvus:latest standalone\n"
-                "  MemSearch(milvus_uri='http://localhost:19530')\n"
-                "Or run memsearch inside WSL2: "
-                "https://learn.microsoft.com/en-us/windows/wsl/install"
-            )
         resolved = str(Path(uri).expanduser()) if is_local else uri
         if is_local:
             Path(resolved).parent.mkdir(parents=True, exist_ok=True)
@@ -111,6 +101,8 @@ class MilvusStore:
 
         from pymilvus import DataType, Function, FunctionType
 
+        # Description is optional backend metadata. Indexing and search never
+        # depend on it because some Milvus Lite versions do not return it.
         schema = self._client.create_schema(
             enable_dynamic_field=True,
             description=self._description,

--- a/tests/test_dependency_markers.py
+++ b/tests/test_dependency_markers.py
@@ -1,0 +1,23 @@
+"""Regression tests for platform-specific Milvus dependency floors."""
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
+
+def test_milvus_dependency_floors_are_split_by_platform():
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+    milvus_dependencies = {
+        requirement for requirement in dependencies if requirement.startswith(("milvus-lite", "pymilvus"))
+    }
+
+    assert milvus_dependencies == {
+        "milvus-lite>=2.5.0; sys_platform != 'win32'",
+        "milvus-lite>=3.1.1; sys_platform == 'win32'",
+        "pymilvus>=2.5.0,!=2.6.10; sys_platform != 'win32'",
+        "pymilvus>=2.6.11; sys_platform == 'win32'",
+    }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -190,21 +190,67 @@ def test_drop(store: MilvusStore):
 
 
 def test_collection_description(tmp_path: Path):
-    """Collection should store the description when provided."""
+    """Description is best-effort metadata and is not required for search."""
     db = str(tmp_path / "desc_test.db")
     desc = "myproject | openai/text-embedding-3-small"
     s = MilvusStore(uri=db, dimension=4, description=desc)
     info = s._client.describe_collection(s._collection)
-    assert info.get("description") == desc
+    assert info.get("description", "") in ("", desc)
+    s.upsert(
+        [
+            {
+                "embedding": [1.0, 0.0, 0.0, 0.0],
+                "content": "Search remains functional without description round-trip",
+                "source": "description.md",
+                "heading": "Metadata",
+                "chunk_hash": "description_hash",
+                "heading_level": 1,
+                "start_line": 1,
+                "end_line": 1,
+            }
+        ]
+    )
+    results = s.search([1.0, 0.0, 0.0, 0.0], query_text="description", top_k=1)
+    assert [result["chunk_hash"] for result in results] == ["description_hash"]
     s.close()
 
 
 def test_collection_description_empty_by_default(tmp_path: Path):
-    """Collection should have empty description when not provided."""
+    """An empty description must not prevent collection creation."""
     db = str(tmp_path / "desc_default_test.db")
     s = MilvusStore(uri=db, dimension=4)
     info = s._client.describe_collection(s._collection)
     assert info.get("description") == ""
+    s.close()
+
+
+def test_windows_local_uri_reaches_milvus_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The Windows dependency floor replaces the obsolete runtime platform guard."""
+    connected: dict[str, str] = {}
+
+    class FakeMilvusClient:
+        def __init__(self, *, uri: str):
+            connected["uri"] = uri
+
+        def has_collection(self, collection_name: str) -> bool:
+            return True
+
+        def load_collection(self, collection_name: str) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    class FakePyMilvus:
+        MilvusClient = FakeMilvusClient
+
+    db = tmp_path / "windows-local.db"
+    with monkeypatch.context() as patch:
+        patch.setitem(sys.modules, "pymilvus", FakePyMilvus())
+        patch.setattr(sys, "platform", "win32")
+        s = MilvusStore(uri=str(db), dimension=None)
+
+    assert connected["uri"] == str(db)
     s.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,8 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -752,6 +753,23 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/1e/f073d88436f1d4d4f7dcd638c5512197ad78fcdc1eb77db1d9929cf158ea/faiss_cpu-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:e0fe7278f3784b7d205ae715a115801cafb75f6e55db6b0fbe83c4ff379f003f", size = 16246848, upload-time = "2026-08-03T17:49:53.512Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b1/47967207659650ad74c1b06c42671e6beb4f7d798fe6eb2d53ba5e77ad90/faiss_cpu-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:90169515a95ea58a9a95d419e518907927a8ef54c46788396365ec5902c9c8df", size = 16247194, upload-time = "2026-08-03T17:49:56.38Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/021398ec5608314124b554bb025878a86f129bcf3576c293826352d9a783/faiss_cpu-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:5b940897b317febaa761088513a3db164fad3ac71a5e1ed7be9a052c9bf1a447", size = 16251530, upload-time = "2026-08-03T17:50:00.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/74/4a70395a6e07036628a1bd0b3f709101a6aecfa6a746db13b6e7921cf291/faiss_cpu-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:22dddb013e764aad66dac6cd15b49c7598d60339e0591b73b5e081629419c21b", size = 16251914, upload-time = "2026-08-03T17:50:03.293Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/13/0a021b9df16963f839a3f325657656b70f23b5a6dbeb422eaa187d0121b3/faiss_cpu-1.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:37170d5e9ead4b6bfd9c314afc39e17e92064068a0c5a4063dd3f39568c2667e", size = 16535739, upload-time = "2026-08-03T17:50:06.714Z" },
+]
+
+[[package]]
 name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1467,10 +1485,12 @@ version = "0.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
+    { name = "milvus-lite", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "milvus-lite", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pymilvus" },
+    { name = "pymilvus", version = "2.6.8", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "pymilvus", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
     { name = "setuptools" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomli-w" },
@@ -1545,13 +1565,15 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'onnx'", specifier = ">=0.20" },
     { name = "memsearch", extras = ["google", "voyage", "jina", "mistral", "ollama", "local", "anthropic", "onnx"], marker = "extra == 'all'" },
     { name = "milvus-lite", marker = "sys_platform != 'win32'", specifier = ">=2.5.0" },
+    { name = "milvus-lite", marker = "sys_platform == 'win32'", specifier = ">=3.1.1" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
     { name = "onnxruntime", marker = "python_full_version == '3.10.*' and extra == 'onnx'", specifier = ">=1.17,<1.24" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.17" },
     { name = "openai", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=0.12" },
-    { name = "pymilvus", specifier = ">=2.5.0,!=2.6.10" },
+    { name = "pymilvus", marker = "sys_platform != 'win32'", specifier = ">=2.5.0,!=2.6.10" },
+    { name = "pymilvus", marker = "sys_platform == 'win32'", specifier = ">=2.6.11" },
     { name = "sentence-transformers", marker = "extra == 'local'", specifier = ">=3.0" },
     { name = "setuptools", specifier = ">=78.1.1,<81" },
     { name = "tokenizers", marker = "extra == 'onnx'", specifier = ">=0.15" },
@@ -1589,6 +1611,17 @@ wheels = [
 name = "milvus-lite"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "tqdm" },
 ]
@@ -1597,6 +1630,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
     { url = "https://files.pythonhosted.org/packages/2e/cf/3d1fee5c16c7661cf53977067a34820f7269ed8ba99fe9cf35efc1700866/milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9", size = 45337093, upload-time = "2025-06-30T04:24:06.706Z" },
     { url = "https://files.pythonhosted.org/packages/d3/82/41d9b80f09b82e066894d9b508af07b7b0fa325ce0322980674de49106a0/milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c", size = 55263911, upload-time = "2025-06-30T04:24:19.434Z" },
+]
+
+[[package]]
+name = "milvus-lite"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "faiss-cpu" },
+    { name = "grpcio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/48/3826b9b18621aa38548ed59749a3a2df0578a1262f8aeeed5cdeb7a9fb94/milvus_lite-3.2.1.tar.gz", hash = "sha256:4d988fe0a6bbdfc708046014ad69f4b140c43567ecafd8b6df300ad7d37210f3", size = 722376, upload-time = "2026-08-25T03:14:40.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/ac/7534ce7526191f776e0d8f28c32ea69f0ae9516b1510a5653eeb5038e1b9/milvus_lite-3.2.1-py3-none-any.whl", hash = "sha256:0742fb4c54858bcc6fc3c2142ec651e2b0f4ae30f19e21d4fbc6db65b9e16c7b", size = 269551, upload-time = "2026-08-25T03:14:37.101Z" },
 ]
 
 [[package]]
@@ -1855,7 +1912,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1899,7 +1957,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -2204,7 +2263,8 @@ name = "onnxruntime"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "coloredlogs" },
@@ -2440,7 +2500,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
@@ -2844,6 +2905,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/67/b554a8e09f3f3decccf405eb8fbe86696321cbcb5b62d18b4a5057a4c113/pyarrow-25.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:60e89d8f13861a1f7f8d950fa54aebb8023b30734d0ac51ffa80beabe2df4bba", size = 27848683, upload-time = "2026-08-10T12:37:12.058Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/5236033550633c9b7377b2a53660b2bbb06cb06dc09c4356332d67643ca1/pyarrow-25.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:62cd0d785b8aa6675ee355f9fc02252a340f4441257c42674937826fd7594325", size = 27857263, upload-time = "2026-08-10T12:37:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+    { url = "https://files.pythonhosted.org/packages/31/24/97e8bd98f1e3b07e2ba08bcdff690674fbe16d69a7d2712cc3884665e615/pyarrow-25.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:31e49a7888fcdf3a835da33ae777f6bb9a866334e5a789282fc26dcf426f7f15", size = 27870159, upload-time = "2026-08-10T12:39:26.161Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/75/f3d789dc06011a765d14d86bda799cf72ac1d715b6a6edecaa0d73d95062/pyarrow-25.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:f729cfdbd36fd99d543b67a914d2de044c84ebe45be8b34902b299b608c15c8f", size = 28620729, upload-time = "2026-08-10T12:40:51.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c0/37d4a7e8e2f7a6076283673d5298018ca26478b934c6ee369e10505ab32c/pyarrow-25.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4288f27577352d608ca08553b0865e4a9b3aa14820c5d95b53337218d609835b", size = 28753071, upload-time = "2026-08-10T12:40:46.623Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3032,6 +3107,17 @@ wheels = [
 name = "pymilvus"
 version = "2.6.8"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "cachetools" },
     { name = "grpcio" },
@@ -3045,6 +3131,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/68/9b8bac2267af60035d65fb5a4247c5ac8da175d66ec794d84d9cd3486524/pymilvus-2.6.8.tar.gz", hash = "sha256:15232f5f66805bf2f50b30bbad59637b62f5258d9343f7615353ce1221fab6b5", size = 1421303, upload-time = "2026-01-29T07:32:16.519Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/27/3af2199afaabd48791584fa5da5929f08d1a3c8c37a2ef12c15fc9309111/pymilvus-2.6.8-py3-none-any.whl", hash = "sha256:c4c413ffdef2599064301fd831de6f9839a753abe27c68c6148707629711d069", size = 300995, upload-time = "2026-01-29T07:32:14.199Z" },
+]
+
+[[package]]
+name = "pymilvus"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "cachetools" },
+    { name = "grpcio" },
+    { name = "orjson" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/78/6bd0dba340706bc63346af96f0ebe36ff17f75404f5de935fda94d476c98/pymilvus-3.0.1.tar.gz", hash = "sha256:c02389059088b18d6e598cd175541e445c772fab4926c5e527c4913be34887f1", size = 347593, upload-time = "2026-07-29T14:55:43.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/9d/7011887b29f452905745e8bd321f404068d5bfe78fe84e42c0b7cd81a065/pymilvus-3.0.1-py3-none-any.whl", hash = "sha256:c5a8d5c1fa1de7b416e3529d383d8cc2e7da2170433ffa4a2d9087e14f70171a", size = 386820, upload-time = "2026-07-29T14:55:44.279Z" },
 ]
 
 [[package]]
@@ -3437,7 +3549,8 @@ name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "joblib" },
@@ -3548,7 +3661,8 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },


### PR DESCRIPTION
## Summary

- add Windows-only dependency floors of `milvus-lite>=3.1.1` and `pymilvus>=2.6.11` while leaving Linux and macOS floors unchanged
- remove the obsolete runtime guard that rejected every local Milvus Lite URI on Windows
- document and test collection descriptions as best-effort metadata that indexing and search do not depend on
- document the manual rebuild path for Milvus Lite 2.x databases instead of attempting an automatic migration

This enables a limited, best-effort local path on Windows. It does not add Windows to the formal support matrix, add Windows CI, or change the recommended Milvus Server and Zilliz Cloud alternatives.

## Compatibility

The non-Windows dependency declarations and lock selections remain unchanged. On Windows, the PyMilvus floor applies to local Lite and to clients connecting to remote Milvus Server or Zilliz Cloud; the Milvus Lite floor applies to the local backend.

Milvus Lite 2.x and 3.x use different local storage layouts. Existing 2.x databases are not migrated in place. Users should preserve their Markdown source and old database, move the old database aside, rebuild the derived index from Markdown, and verify the rebuilt index before removing the backup.

Collection descriptions remain accepted during creation, but some Lite 3.x versions may return an empty description later. This metadata is best-effort and is not used to determine indexing or search correctness.

## Testing

- regression tests before the implementation: 2 expected failures
- targeted tests: 34 passed
- clean-environment Linux full suite: 358 passed, 7 skipped (comparable base: 356 passed, 7 skipped)
- exact-floor Linux storage and high-level paths with `pymilvus==2.6.11` and `milvus-lite==3.1.1`: passed
- actual-lock Linux storage and high-level paths with `pymilvus==3.0.1` and `milvus-lite==3.2.1`: passed
- locked wheel-only resolution for Windows, Linux, and macOS on Python 3.10-3.13: 12/12 passed
- exact-floor Windows wheel-only resolution on Python 3.10-3.13: 4/4 passed
- `uv lock --check`, changed-file Ruff, changed-file format, and diff checks: passed

The Windows resolver checks confirm package availability but are not native Windows runtime tests. No native Windows E2E or Windows CI was added for this best-effort change.

Closes #703
