### PR TITLE
feat: add Voyage AI reranker provider

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -86,6 +86,34 @@ memsearch config set embedding.provider openai
 memsearch index --force   # re-index with new provider
 ```
 
+## Reranking
+
+Reranking re-scores search results with a cross-encoder that reads the query and
+each chunk *together*, which is more accurate than embedding similarity alone. It
+is disabled by default; set a provider or a model to enable it.
+
+| Provider | Install | API Key | Notes |
+|----------|---------|---------|-------|
+| *(empty, default)* | `pip install memsearch[onnx]` | No | Local cross-encoder, free, ~150MB model download |
+| voyage | `pip install memsearch[voyage]` | `VOYAGE_API_KEY` | Hosted API, nothing to load per process |
+
+```bash
+# Hosted reranker (defaults to rerank-3)
+memsearch config set reranker.provider voyage
+
+# ...or pick the model explicitly
+memsearch config set reranker.provider voyage
+memsearch config set reranker.model rerank-3-lite
+
+# Local cross-encoder instead
+memsearch config set reranker.model Alibaba-NLP/gte-reranker-modernbert-base
+```
+
+Local backends load the model from HuggingFace on first use, and each process
+pays that load cost — noticeable for short-lived CLI invocations, where the
+hosted provider avoids it. No re-indexing is needed either way: reranking only
+affects query time.
+
 ## Milvus Backend
 
 | Backend | Config | Notes |

--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -114,6 +114,11 @@ pays that load cost — noticeable for short-lived CLI invocations, where the
 hosted provider avoids it. No re-indexing is needed either way: reranking only
 affects query time.
 
+Reranking never fails a search. If the configured backend is unavailable, or the
+Voyage API rejects the call (an unset `VOYAGE_API_KEY`, for instance), memsearch
+logs a warning and returns the unranked results, still capped at the requested
+`--top-k`.
+
 ## Milvus Backend
 
 | Backend | Config | Notes |

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -70,6 +70,7 @@ _PARAM_MAP = {
     "overlap_lines": "chunking.overlap_lines",
     "debounce_ms": "watch.debounce_ms",
     "reranker_model": "reranker.model",
+    "reranker_provider": "reranker.provider",
 }
 
 
@@ -109,6 +110,7 @@ def _cfg_to_memsearch_kwargs(
         "ignore_files": _merge_unique(cfg.indexing.ignore_files, extra_ignore_files),
         "exclude": _merge_unique(cfg.indexing.exclude, extra_exclude),
         "reranker_model": cfg.reranker.model,
+        "reranker_provider": cfg.reranker.provider,
     }
 
 
@@ -333,6 +335,11 @@ def index(
 )
 @_common_options
 @click.option("--reranker-model", default=None, help="Cross-encoder model for reranking (empty string disables).")
+@click.option(
+    "--reranker-provider",
+    default=None,
+    help='Reranker backend: "voyage" for the hosted API, or empty for a local cross-encoder.',
+)
 @click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
 def search(
     query: str,
@@ -347,6 +354,7 @@ def search(
     milvus_uri: str | None,
     milvus_token: str | None,
     reranker_model: str | None,
+    reranker_provider: str | None,
     json_output: bool,
 ) -> None:
     """Search indexed memory for QUERY."""
@@ -363,6 +371,7 @@ def search(
             milvus_uri=milvus_uri,
             milvus_token=milvus_token,
             reranker_model=reranker_model,
+            reranker_provider=reranker_provider,
         )
     )
     ms = None

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -95,7 +95,8 @@ class WatchConfig:
 
 @dataclass
 class RerankerConfig:
-    model: str = ""  # empty = disabled; set to model ID to enable
+    provider: str = ""  # "voyage" for the hosted API; empty = local cross-encoder
+    model: str = ""  # empty = disabled, unless provider is set
 
 
 @dataclass

--- a/src/memsearch/core.py
+++ b/src/memsearch/core.py
@@ -73,6 +73,7 @@ class MemSearch:
         ignore_files: list[str] | None = None,
         exclude: list[str] | None = None,
         reranker_model: str = "",
+        reranker_provider: str = "",
     ) -> None:
         self._paths = [str(p) for p in (paths or [])]
         self._max_chunk_size = max_chunk_size
@@ -94,6 +95,10 @@ class MemSearch:
             description=description,
         )
         self._reranker_model = reranker_model
+        self._reranker_provider = reranker_provider
+        # A provider alone is enough to enable reranking; the backend supplies
+        # its own default model when none is configured.
+        self._rerank_enabled = bool(reranker_model or reranker_provider)
 
     # ------------------------------------------------------------------
     # Indexing
@@ -248,12 +253,18 @@ class MemSearch:
             filter_expr = f'source like "{escaped}%"'
 
         embeddings = await self._embedder.embed([query])
-        fetch_k = top_k * 3 if self._reranker_model else top_k
+        fetch_k = top_k * 3 if self._rerank_enabled else top_k
         results = self._store.search(embeddings[0], query_text=query, top_k=fetch_k, filter_expr=filter_expr)
-        if self._reranker_model and results:
+        if self._rerank_enabled and results:
             from .reranker import rerank
 
-            results = rerank(query, results, model_name=self._reranker_model, top_k=top_k)
+            results = rerank(
+                query,
+                results,
+                model_name=self._reranker_model,
+                top_k=top_k,
+                provider=self._reranker_provider,
+            )
         return results
 
     # ------------------------------------------------------------------

--- a/src/memsearch/reranker.py
+++ b/src/memsearch/reranker.py
@@ -4,11 +4,20 @@ Re-scores hybrid search results using a cross-encoder that reads query and
 document together, producing more accurate relevance scores than embedding
 similarity alone.
 
-Two backends are supported, auto-detected at runtime:
-  1. ONNX Runtime (preferred) — lightweight, CPU-only, included in ``memsearch[onnx]``
-  2. sentence-transformers CrossEncoder — PyTorch-based, included in ``memsearch[local]``
+Three backends are supported, chosen by the ``reranker.provider`` setting the
+same way ``embedding.provider`` selects an embedding backend:
+  1. ``"voyage"`` — Voyage AI hosted rerank API; needs ``memsearch[voyage]``
+     and ``VOYAGE_API_KEY``
+  2. ``""`` (default) — a local cross-encoder, auto-detecting the best runtime:
+     ONNX Runtime (``memsearch[onnx]``), else sentence-transformers
+     (``memsearch[local]``)
 
-If neither is installed, reranking is silently skipped.
+Local backends load a cross-encoder from HuggingFace, so the first call downloads
+weights and every process pays the load cost; the hosted backend has no local
+model to load, which keeps per-process search latency low for short-lived CLI
+invocations.
+
+If no backend is available, reranking is silently skipped.
 """
 
 from __future__ import annotations
@@ -229,6 +238,41 @@ def _rerank_torch(query: str, results: list[dict[str, Any]], model_name: str, to
 
 
 # ======================================================================
+# Voyage AI backend (hosted API)
+# ======================================================================
+
+DEFAULT_VOYAGE_RERANKER = "rerank-3"
+
+_voyage_client: Any = None
+_voyage_client_lock = threading.Lock()
+
+
+def _load_voyage_client() -> Any:
+    """Return a cached Voyage client (reads ``VOYAGE_API_KEY``)."""
+    global _voyage_client
+    with _voyage_client_lock:
+        if _voyage_client is None:
+            import voyageai
+
+            _voyage_client = voyageai.Client()
+            logger.info("Initialised Voyage AI reranker client")
+        return _voyage_client
+
+
+def _rerank_voyage(query: str, results: list[dict[str, Any]], model_name: str, top_k: int) -> list[dict[str, Any]]:
+    """Rerank using the Voyage AI rerank endpoint.
+
+    The API returns its results already ordered by relevance, each carrying the
+    index of the document it scored, so the original result dicts are looked up
+    by that index rather than re-sorted locally.
+    """
+    client = _load_voyage_client()
+    documents = [r["content"] for r in results]
+    response = client.rerank(query, documents, model=model_name, top_k=top_k or None)
+    return [{**results[item.index], "score": float(item.relevance_score)} for item in response.results]
+
+
+# ======================================================================
 # Public API
 # ======================================================================
 
@@ -239,12 +283,9 @@ def rerank(
     *,
     model_name: str = DEFAULT_RERANKER,
     top_k: int = 0,
+    provider: str = "",
 ) -> list[dict[str, Any]]:
     """Re-score search results with a cross-encoder.
-
-    Automatically selects the best available backend:
-      1. ONNX Runtime (``memsearch[onnx]``) — preferred, lightweight
-      2. sentence-transformers (``memsearch[local]``) — PyTorch fallback
 
     Parameters
     ----------
@@ -254,18 +295,40 @@ def rerank(
         Search results from MilvusStore.search(). Each dict must have
         a ``content`` key with the chunk text.
     model_name:
-        HuggingFace model ID for the cross-encoder.
+        The rerank model. For ``provider="voyage"`` a Voyage rerank id such as
+        ``rerank-3``; otherwise a HuggingFace ``org/name`` cross-encoder id.
     top_k:
         Return only the top-k results after reranking.
         0 means return all results (re-sorted).
+    provider:
+        ``"voyage"`` for the hosted Voyage rerank API, or ``""`` (default) for a
+        local cross-encoder, auto-detecting ONNX then sentence-transformers.
 
     Returns
     -------
     list[dict]
-        Results re-sorted by cross-encoder score.
+        Results re-sorted by relevance score. Returned unchanged when no
+        backend is available.
     """
     if not results:
         return []
+
+    if provider == "voyage":
+        try:
+            return _rerank_voyage(query, results, model_name or DEFAULT_VOYAGE_RERANKER, top_k)
+        except ImportError:
+            logger.warning(
+                'Reranker provider "voyage" requires the voyageai client '
+                '(pip install "memsearch[voyage]"); skipping reranking',
+            )
+            return results
+
+    if provider:
+        logger.warning(
+            'Unknown reranker provider %r; expected "voyage" or "" for a local cross-encoder. Skipping reranking',
+            provider,
+        )
+        return results
 
     backend = _detect_backend()
     if backend == "onnx":

--- a/src/memsearch/reranker.py
+++ b/src/memsearch/reranker.py
@@ -259,6 +259,19 @@ def _load_voyage_client() -> Any:
         return _voyage_client
 
 
+def _voyage_error_types() -> tuple[type[BaseException], ...]:
+    """Voyage's error hierarchy, or an empty tuple when voyageai is absent.
+
+    ``except ()`` never matches, so ``rerank()`` can name this unconditionally;
+    a missing client is already covered by its ImportError branch.
+    """
+    try:
+        from voyageai.error import VoyageError
+    except ImportError:
+        return ()
+    return (VoyageError,)
+
+
 def _rerank_voyage(query: str, results: list[dict[str, Any]], model_name: str, top_k: int) -> list[dict[str, Any]]:
     """Rerank using the Voyage AI rerank endpoint.
 
@@ -307,8 +320,8 @@ def rerank(
     Returns
     -------
     list[dict]
-        Results re-sorted by relevance score. Returned unchanged when no
-        backend is available.
+        Results re-sorted by relevance score, at most ``top_k`` of them. When no
+        backend is available the original order is kept, still capped at ``top_k``.
     """
     if not results:
         return []
@@ -321,14 +334,24 @@ def rerank(
                 'Reranker provider "voyage" requires the voyageai client '
                 '(pip install "memsearch[voyage]"); skipping reranking',
             )
-            return results
+            return results[:top_k] if top_k > 0 else results
+        except _voyage_error_types() as e:
+            # A missing VOYAGE_API_KEY surfaces here as AuthenticationError, and
+            # transient API trouble as one of its siblings. Degrade to unranked
+            # results the way a missing client does, rather than failing the search.
+            logger.warning(
+                "Voyage rerank failed (%s: %s); skipping reranking",
+                type(e).__name__,
+                e,
+            )
+            return results[:top_k] if top_k > 0 else results
 
     if provider:
         logger.warning(
             'Unknown reranker provider %r; expected "voyage" or "" for a local cross-encoder. Skipping reranking',
             provider,
         )
-        return results
+        return results[:top_k] if top_k > 0 else results
 
     backend = _detect_backend()
     if backend == "onnx":
@@ -341,4 +364,4 @@ def rerank(
         "sentence-transformers is installed; skipping reranking",
         model_name,
     )
-    return results
+    return results[:top_k] if top_k > 0 else results

--- a/tests/test_cli_config_helpers.py
+++ b/tests/test_cli_config_helpers.py
@@ -28,6 +28,7 @@ def test_build_cli_overrides_maps_only_non_none_values() -> None:
         overlap_lines=3,
         debounce_ms=250,
         reranker_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        reranker_provider="voyage",
     )
 
     assert overrides == {
@@ -57,6 +58,7 @@ def test_build_cli_overrides_maps_only_non_none_values() -> None:
         },
         "reranker": {
             "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+            "provider": "voyage",
         },
     }
 
@@ -97,6 +99,7 @@ def test_cfg_to_memsearch_kwargs_translates_resolved_config() -> None:
         "ignore_files": [".gitignore", ".cursorignore"],
         "exclude": ["generated/**", "drafts/**"],
         "reranker_model": "",
+        "reranker_provider": "",
     }
 
 

--- a/tests/test_reranker_voyage.py
+++ b/tests/test_reranker_voyage.py
@@ -1,0 +1,121 @@
+"""Unit tests for the Voyage AI reranker backend."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from memsearch import reranker
+
+
+def _install_fake_voyageai(monkeypatch, *, record: dict, order: list[int]):
+    """Install a fake ``voyageai`` module whose rerank() returns *order*."""
+    voyageai_module = types.ModuleType("voyageai")
+
+    class FakeClient:
+        def rerank(self, query, documents, *, model, top_k=None):
+            record["query"] = query
+            record["documents"] = documents
+            record["model"] = model
+            record["top_k"] = top_k
+            selected = order if top_k is None else order[:top_k]
+            return types.SimpleNamespace(
+                results=[
+                    types.SimpleNamespace(index=idx, relevance_score=1.0 - position / 10)
+                    for position, idx in enumerate(selected)
+                ]
+            )
+
+    voyageai_module.Client = FakeClient
+    monkeypatch.setitem(sys.modules, "voyageai", voyageai_module)
+    monkeypatch.setattr(reranker, "_voyage_client", None)
+
+
+def _results(n: int = 3) -> list[dict]:
+    return [{"content": f"chunk {i}", "source": f"/tmp/{i}.md"} for i in range(n)]
+
+
+def test_voyage_provider_reranks_via_the_api(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[2, 0, 1])
+
+    out = reranker.rerank("why did it fail", _results(), model_name="rerank-3", provider="voyage")
+
+    assert record["model"] == "rerank-3"
+    assert record["query"] == "why did it fail"
+    assert record["documents"] == ["chunk 0", "chunk 1", "chunk 2"]
+    # API order is authoritative; the original result dicts are preserved.
+    assert [r["content"] for r in out] == ["chunk 2", "chunk 0", "chunk 1"]
+    assert [r["source"] for r in out] == ["/tmp/2.md", "/tmp/0.md", "/tmp/1.md"]
+    assert out[0]["score"] > out[1]["score"] > out[2]["score"]
+
+
+def test_voyage_provider_falls_back_to_default_model(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[0, 1, 2])
+
+    reranker.rerank("q", _results(), model_name="", provider="voyage")
+
+    assert record["model"] == reranker.DEFAULT_VOYAGE_RERANKER
+
+
+def test_voyage_provider_passes_top_k_through(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[2, 0, 1])
+
+    out = reranker.rerank("q", _results(), model_name="rerank-3", top_k=2, provider="voyage")
+
+    assert record["top_k"] == 2
+    assert [r["content"] for r in out] == ["chunk 2", "chunk 0"]
+
+
+def test_voyage_provider_top_k_zero_requests_all(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[1, 0, 2])
+
+    out = reranker.rerank("q", _results(), model_name="rerank-3", top_k=0, provider="voyage")
+
+    assert record["top_k"] is None
+    assert len(out) == 3
+
+
+def test_voyage_provider_skips_when_voyageai_is_not_installed(monkeypatch):
+    # A None entry in sys.modules makes `import voyageai` raise ImportError.
+    monkeypatch.setitem(sys.modules, "voyageai", None)
+    monkeypatch.setattr(reranker, "_voyage_client", None)
+    original = _results()
+
+    out = reranker.rerank("q", original, model_name="rerank-3", provider="voyage")
+
+    assert out == original
+
+
+def test_unknown_provider_skips_reranking(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[2, 1, 0])
+    original = _results()
+
+    out = reranker.rerank("q", original, model_name="rerank-3", provider="nope")
+
+    assert out == original
+    assert record == {}, "an unknown provider must not reach any backend"
+
+
+def test_local_provider_does_not_reach_voyage(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[2, 1, 0])
+    monkeypatch.setattr(reranker, "_detect_backend", lambda: "none")
+    original = _results()
+
+    out = reranker.rerank("q", original, model_name=reranker.DEFAULT_RERANKER)
+
+    assert record == {}, "the default local provider must not call the Voyage API"
+    assert out == original
+
+
+def test_empty_results_short_circuit(monkeypatch):
+    record: dict = {}
+    _install_fake_voyageai(monkeypatch, record=record, order=[])
+
+    assert reranker.rerank("q", [], model_name="rerank-3", provider="voyage") == []
+    assert record == {}

--- a/tests/test_reranker_voyage.py
+++ b/tests/test_reranker_voyage.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
+
+import pytest
 
 from memsearch import reranker
 
@@ -119,3 +122,150 @@ def test_empty_results_short_circuit(monkeypatch):
 
     assert reranker.rerank("q", [], model_name="rerank-3", provider="voyage") == []
     assert record == {}
+
+
+# ======================================================================
+# Degradation paths must still honour top_k
+#
+# MemSearch.search() over-fetches top_k * 3 candidates whenever reranking is
+# enabled, expecting rerank() to narrow them back down. A path that skips
+# reranking and hands the candidate list straight back would therefore return
+# up to three times the requested result count.
+# ======================================================================
+
+
+def _install_failing_voyageai(monkeypatch, exc_name: str = "AuthenticationError"):
+    """Install a fake ``voyageai`` whose rerank() raises a Voyage error.
+
+    Mirrors the real SDK: the client constructs happily without a key and the
+    failure surfaces at rerank() time as ``voyageai.error.AuthenticationError``,
+    a subclass of ``voyageai.error.VoyageError``.
+    """
+    voyageai_module = types.ModuleType("voyageai")
+    error_module = types.ModuleType("voyageai.error")
+
+    class VoyageError(Exception):
+        pass
+
+    class AuthenticationError(VoyageError):
+        pass
+
+    error_module.VoyageError = VoyageError
+    error_module.AuthenticationError = AuthenticationError
+
+    raised = RuntimeError("boom") if exc_name == "RuntimeError" else AuthenticationError("no api key")
+
+    class FailingClient:
+        def rerank(self, query, documents, *, model, top_k=None):
+            raise raised
+
+    voyageai_module.Client = FailingClient
+    voyageai_module.error = error_module
+    monkeypatch.setitem(sys.modules, "voyageai", voyageai_module)
+    monkeypatch.setitem(sys.modules, "voyageai.error", error_module)
+    monkeypatch.setattr(reranker, "_voyage_client", None)
+
+
+def test_missing_voyageai_still_honours_top_k(monkeypatch):
+    monkeypatch.setitem(sys.modules, "voyageai", None)
+    monkeypatch.setattr(reranker, "_voyage_client", None)
+
+    out = reranker.rerank("q", _results(9), model_name="rerank-3", top_k=3, provider="voyage")
+
+    assert [r["content"] for r in out] == ["chunk 0", "chunk 1", "chunk 2"]
+
+
+def test_unknown_provider_still_honours_top_k():
+    out = reranker.rerank("q", _results(9), model_name="rerank-3", top_k=3, provider="nope")
+
+    assert [r["content"] for r in out] == ["chunk 0", "chunk 1", "chunk 2"]
+
+
+def test_missing_local_backend_still_honours_top_k(monkeypatch):
+    monkeypatch.setattr(reranker, "_detect_backend", lambda: "none")
+
+    out = reranker.rerank("q", _results(9), model_name=reranker.DEFAULT_RERANKER, top_k=3)
+
+    assert [r["content"] for r in out] == ["chunk 0", "chunk 1", "chunk 2"]
+
+
+def test_degraded_top_k_zero_still_returns_every_candidate(monkeypatch):
+    monkeypatch.setattr(reranker, "_detect_backend", lambda: "none")
+    original = _results(9)
+
+    assert reranker.rerank("q", original, model_name=reranker.DEFAULT_RERANKER, top_k=0) == original
+
+
+# ======================================================================
+# A Voyage API error degrades like a missing package, rather than crashing
+# ======================================================================
+
+
+def test_voyage_api_error_degrades_to_unranked_results(monkeypatch, caplog):
+    _install_failing_voyageai(monkeypatch)
+    original = _results()
+
+    with caplog.at_level(logging.WARNING, logger="memsearch.reranker"):
+        out = reranker.rerank("q", original, model_name="rerank-3", provider="voyage")
+
+    assert out == original
+    assert "AuthenticationError" in caplog.text
+
+
+def test_voyage_api_error_still_honours_top_k(monkeypatch):
+    _install_failing_voyageai(monkeypatch)
+
+    out = reranker.rerank("q", _results(9), model_name="rerank-3", top_k=3, provider="voyage")
+
+    assert [r["content"] for r in out] == ["chunk 0", "chunk 1", "chunk 2"]
+
+
+def test_non_voyage_exception_still_propagates(monkeypatch):
+    _install_failing_voyageai(monkeypatch, exc_name="RuntimeError")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        reranker.rerank("q", _results(), model_name="rerank-3", provider="voyage")
+
+
+# ======================================================================
+# The search() over-fetch interplay the unit tests above stand in for
+# ======================================================================
+
+
+class _FakeEmbedder:
+    dimension = 4
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] * self.dimension for _ in texts]
+
+
+class _FakeStore:
+    """Returns exactly as many chunks as it was asked for."""
+
+    def __init__(self) -> None:
+        self.requested_top_k: int | None = None
+
+    def search(self, embedding, *, query_text, top_k, filter_expr):
+        self.requested_top_k = top_k
+        return _results(top_k)
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_over_deliver_when_reranking_degrades(monkeypatch):
+    from memsearch.core import MemSearch
+
+    # A None entry in sys.modules makes `import voyageai` raise ImportError.
+    monkeypatch.setitem(sys.modules, "voyageai", None)
+    monkeypatch.setattr(reranker, "_voyage_client", None)
+
+    ms = MemSearch.__new__(MemSearch)
+    ms._embedder = _FakeEmbedder()
+    ms._store = _FakeStore()
+    ms._reranker_model = ""
+    ms._reranker_provider = "voyage"
+    ms._rerank_enabled = True
+
+    out = await ms.search("q", top_k=10)
+
+    assert ms._store.requested_top_k == 30, "search() over-fetches candidates for the reranker"
+    assert len(out) == 10, "the caller asked for 10 results and must not get the raw candidate list"


### PR DESCRIPTION
## Problem

Reranking currently requires a local cross-encoder. That has two costs for the
short-lived processes that dominate real usage (the plugin hooks and the
`memory-recall` skill each shell out to `memsearch search`):

1. **Per-process model load.** ~150MB of weights are loaded from disk on every
   invocation, since nothing survives between CLI runs.
2. **A hard network dependency.** `_load_onnx_model` calls `list_repo_files(repo_id)`
   on every call, even when the model is fully cached, so reranking with
   `HF_HUB_OFFLINE=1` raises rather than degrading.

Measured on an indexed corpus, enabling the local reranker took search from
~3.5s to ~14s per invocation.

## Change

Adds a hosted Voyage AI rerank backend, selected by a new `reranker.provider`
setting that mirrors how `embedding.provider` selects an embedding backend:

```toml
[reranker]
provider = "voyage"
model = "rerank-3"      # optional; this is the default
```

Also available as `memsearch search --reranker-provider voyage`.

Added latency measured through the CLI on the same corpus and query: **~0.35s
for the hosted provider vs ~10.5s for the local cross-encoder** (the constant
interpreter/`uv run` overhead was held the same across both).

## Notes on the design

- **`provider` mirrors `embedding.provider`** rather than encoding the backend in
  the model string. I first prototyped a prefix form (`voyageai/rerank-3`) and a
  bare-name heuristic, but a `provider` field matches the existing config shape,
  needs no shape-sniffing, and does not shadow the real `voyageai` HuggingFace
  namespace.
- **Backwards compatible.** An empty `provider` keeps the current auto-detected
  local behaviour. `MemSearch` now enables reranking on
  `reranker_model or reranker_provider`, so `provider` alone works and the
  backend supplies its default model.
- **No new dependency.** Reuses the existing `voyage` extra (`memsearch[voyage]`),
  already present for the Voyage embedding provider.
- **Degradation matches the local backends.** A missing `voyageai` package logs a
  warning and returns results unranked, the same as an absent local backend. API
  errors (bad key, network) propagate, as an ONNX/HF failure does today. Happy to
  make those degrade instead if you would prefer that.
- The pre-existing `list_repo_files` per-call network hit is left alone to keep
  this PR focused; happy to open a separate one for it.

## Testing

- New `tests/test_reranker_voyage.py` (8 tests, fake `voyageai` module): API
  dispatch and result mapping, default-model fallback, `top_k` pass-through,
  `top_k=0` meaning all, missing-package degradation, unknown-provider
  degradation, local models never reaching the API, and empty-input
  short-circuit.
- Extended `tests/test_cli_config_helpers.py` for the new config key in both the
  override map and the resolved kwargs.
- Full suite: **386 passed, 7 skipped**. `ruff check` and `ruff format --check`
  both clean.
- Verified end to end against the live Voyage API and a real Milvus collection,
  with the expected chunk returned at rank 1.
