### PR TITLE
fix(opencode): omit turn text when summaries fail

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -164,10 +164,12 @@ memsearch config set plugins.opencode.summarize.provider openai
 ```
 
 Leave `plugins.opencode.summarize.provider` empty or set it to `native` to keep the current `small_model` / plugin default behavior. This setting does not fall back to `llm.model`.
+Native summaries run with isolated XDG config and data directories, and the plugin does not copy the user's OpenCode auth store into them. If that environment cannot authenticate, capture retains only an unavailable note and the transcript anchor.
+Native `opencode run` output must contain bullet lines. The managed-provider command keeps its existing contract and accepts any non-empty plain-text summary.
 
 ## How It Works
 
-1. **Capture**: After each conversation turn, the plugin extracts the user+assistant exchange, summarizes it via LLM, and appends to a daily markdown file.
+1. **Capture**: After each conversation turn, the plugin extracts the user+assistant exchange, sends it to the configured summarizer, and appends the result to a daily markdown file. If summarization fails, times out, exits unsuccessfully, or returns no usable output, the plugin writes a short unavailable note instead of the turn text. The transcript remains accessible through the entry's progressive-disclosure anchor.
 
 2. **Index**: The markdown files are indexed by memsearch into a Milvus collection (Milvus Lite by default, runs in-process).
 
@@ -181,6 +183,6 @@ Leave `plugins.opencode.summarize.provider` empty or set it to `native` to keep 
 |---------|-------------|----------|----------|
 | Session storage | JSONL | SQLite | JSONL |
 | Hook system | Shell scripts | TypeScript hooks | JS API |
-| Summarizer | claude -p --model haiku | opencode prompt | openclaw agent |
+| Summarizer | claude -p --model haiku | opencode run | openclaw agent |
 | Context injection | SessionStart hook | system.transform | before_agent_start |
 | Skill context | context: fork | N/A (no fork) | N/A |

--- a/plugins/opencode/scripts/capture-daemon.py
+++ b/plugins/opencode/scripts/capture-daemon.py
@@ -40,6 +40,10 @@ from opencode_turns import (
 
 _ANCHOR_RE = re.compile(r"<!-- session:([^ ]+) turn:([^ ]+) db:")
 _TAIL_TURN_QUIET_PERIOD_MS = int(os.environ.get("MEMSEARCH_OPENCODE_TAIL_QUIET_MS", "300000"))
+_SUMMARY_UNAVAILABLE = (
+    "- Memory summary unavailable: summarizer failed or returned no usable output; "
+    "transcript content was omitted. Use the transcript anchor for progressive disclosure."
+)
 
 
 class TailTurnObservation:
@@ -402,15 +406,15 @@ def summarize_with_llm(
     project_dir: str | os.PathLike[str] | None = None,
 ) -> str | None:
     """Summarize using configured provider routing."""
-    if not get_plugin_summarize_enabled(memsearch_cmd):
-        return None
+    try:
+        if not get_plugin_summarize_enabled(memsearch_cmd):
+            return None
 
-    system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
-    full_prompt = f"{system_prompt}\n\nTranscript:\n{turn_text}"
+        system_prompt = _load_summarize_prompt("OpenCode", memsearch_cmd)
+        full_prompt = f"{system_prompt}\n\nTranscript:\n{turn_text}"
 
-    summarize_provider = get_plugin_summarize_provider(memsearch_cmd)
-    if summarize_provider and summarize_provider != "native" and memsearch_cmd:
-        try:
+        summarize_provider = get_plugin_summarize_provider(memsearch_cmd)
+        if summarize_provider and summarize_provider != "native" and memsearch_cmd:
             result = subprocess.run(
                 [*split_memsearch_cmd(memsearch_cmd), "summarize", "--plugin", "opencode", "--agent-name", "OpenCode"],
                 input=turn_text,
@@ -421,6 +425,8 @@ def summarize_with_llm(
                 timeout=30,
                 env={**os.environ, "MEMSEARCH_NO_WATCH": "1"},
             )
+            if result.returncode != 0:
+                return None
             output = result.stdout.strip()
             lines = output.split("\n")
             bullets = [line for line in lines if line.strip().startswith("- ")]
@@ -428,20 +434,17 @@ def summarize_with_llm(
                 return "\n".join(bullets)
             if output:
                 return output
-        except Exception:
-            pass
-        return None
 
-    # Native path: summarize using opencode run in isolated env (no plugins -> no recursion).
-    isolated_dir = ensure_isolated_config(project_dir)
+            return None
 
-    summarize_model = get_plugin_summarize_model(memsearch_cmd) or small_model
-    cmd = ["opencode", "run"]
-    if summarize_model:
-        cmd += ["-m", summarize_model]
-    cmd.append(full_prompt)
+        # Native path: summarize using opencode run in isolated env (no plugins -> no recursion).
+        isolated_dir = ensure_isolated_config(project_dir)
+        summarize_model = get_plugin_summarize_model(memsearch_cmd) or small_model
+        cmd = ["opencode", "run"]
+        if summarize_model:
+            cmd += ["-m", summarize_model]
+        cmd.append(full_prompt)
 
-    try:
         result = subprocess.run(
             cmd,
             env={
@@ -458,6 +461,8 @@ def summarize_with_llm(
             text=True,
             timeout=30,
         )
+        if result.returncode != 0:
+            return None
         output = result.stdout.strip()
         lines = output.split("\n")
         bullets = [line for line in lines if line.strip().startswith("- ")]
@@ -767,7 +772,7 @@ def capture_session_turns(
             summary = summarize_with_llm(turn_text, small_model, memsearch_cmd, project_dir)
             write_capture(
                 memory_dir,
-                summary if summary else turn_text,
+                summary if summary else _SUMMARY_UNAVAILABLE,
                 session_id,
                 turn.turn_id,
                 db_path,

--- a/tests/test_opencode_turns.py
+++ b/tests/test_opencode_turns.py
@@ -765,6 +765,221 @@ def test_capture_session_turns_keeps_monotonic_turn_index_across_batches(
     conn.close()
 
 
+def _prepare_summary_capture(
+    tmp_path: Path,
+    session_id: str,
+    marker: str,
+    assistant_text: str = "Answer",
+) -> tuple[sqlite3.Connection, sqlite3.Connection, Path, Path, Path]:
+    db_path = tmp_path / "opencode.db"
+    conn = _make_opencode_db(db_path)
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    memory_dir = project_dir / ".memsearch" / "memory"
+
+    _insert_message(conn, "u1", session_id, 100, "user", text=marker)
+    _insert_message(
+        conn,
+        "a1",
+        session_id,
+        110,
+        "assistant",
+        parent_id="u1",
+        finish="stop",
+        text=assistant_text,
+    )
+    _insert_message(conn, "u2", session_id, 200, "user", text="Close the first turn")
+    conn.commit()
+    return conn, open_turn_db(str(project_dir)), db_path, project_dir, memory_dir
+
+
+def _run_summary_capture(
+    conn: sqlite3.Connection,
+    turn_db: sqlite3.Connection,
+    db_path: Path,
+    memory_dir: Path,
+    session_id: str,
+) -> str:
+    capture_daemon.capture_session_turns(
+        conn,
+        turn_db,
+        str(memory_dir),
+        session_id,
+        "",
+        "memsearch",
+        str(db_path),
+    )
+    return next(memory_dir.glob("*.md")).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("mode", ["missing", "failure", "nonzero", "empty", "unusable", "timeout"])
+def test_capture_session_turns_omits_transcript_when_native_summary_fails(
+    tmp_path: Path,
+    monkeypatch,
+    mode: str,
+) -> None:
+    session_id = "ses_summary_failure"
+    marker = "S651_SYNTHETIC_PRIVATE_TURN_MARKER"
+    conn, turn_db, db_path, _, memory_dir = _prepare_summary_capture(tmp_path, session_id, marker)
+    isolated_root = tmp_path / "isolated"
+
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda *args: True)
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_provider", lambda *args: "")
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_model", lambda *args: "")
+    monkeypatch.setattr(capture_daemon, "_load_summarize_prompt", lambda *args: "Summarize safely.")
+    monkeypatch.setattr(capture_daemon, "ensure_isolated_config", lambda *args: str(isolated_root))
+
+    def fail_native(cmd, **kwargs):
+        if mode == "missing":
+            raise FileNotFoundError("opencode")
+        if mode == "failure":
+            raise RuntimeError("synthetic native failure")
+        if mode == "timeout":
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+        if mode == "nonzero":
+            return subprocess.CompletedProcess(cmd, 23, stdout=f"- {marker}\n", stderr="synthetic failure")
+        if mode == "unusable":
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{marker}\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(capture_daemon.subprocess, "run", fail_native)
+
+    content = _run_summary_capture(conn, turn_db, db_path, memory_dir, session_id)
+    assert marker not in content
+    assert "Memory summary unavailable" in content
+    assert "transcript content was omitted" in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+    assert load_turn_state(turn_db, session_id).last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_omits_transcript_when_prompt_loading_raises(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_id = "ses_prompt_exception"
+    marker = "S651_SYNTHETIC_PROMPT_EXCEPTION_MARKER"
+    conn, turn_db, db_path, _, memory_dir = _prepare_summary_capture(
+        tmp_path,
+        session_id,
+        marker,
+        "Synthetic answer",
+    )
+
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda *args: True)
+
+    def raise_prompt_decode_error(*args):
+        raise UnicodeError("synthetic unreadable prompt")
+
+    monkeypatch.setattr(capture_daemon, "_load_summarize_prompt", raise_prompt_decode_error)
+
+    content = _run_summary_capture(conn, turn_db, db_path, memory_dir, session_id)
+    assert marker not in content
+    assert "Synthetic answer" not in content
+    assert capture_daemon._SUMMARY_UNAVAILABLE in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+    assert load_turn_state(turn_db, session_id).last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+@pytest.mark.parametrize("mode", ["exception", "nonzero", "empty", "timeout"])
+def test_capture_session_turns_omits_transcript_when_managed_summary_fails(
+    tmp_path: Path,
+    monkeypatch,
+    mode: str,
+) -> None:
+    session_id = "ses_managed_summary_failure"
+    marker = "S651_SYNTHETIC_MANAGED_PRIVATE_MARKER"
+    conn, turn_db, db_path, _, memory_dir = _prepare_summary_capture(tmp_path, session_id, marker)
+
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda *args: True)
+    monkeypatch.setattr(capture_daemon, "_load_summarize_prompt", lambda *args: "Summarize safely.")
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_provider", lambda *args: "openai")
+
+    def fail_managed(cmd, **kwargs):
+        if mode == "exception":
+            raise RuntimeError("synthetic managed failure")
+        if mode == "timeout":
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+        if mode == "nonzero":
+            return subprocess.CompletedProcess(cmd, 23, stdout=f"- {marker}\n", stderr="synthetic failure")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(capture_daemon.subprocess, "run", fail_managed)
+
+    content = _run_summary_capture(conn, turn_db, db_path, memory_dir, session_id)
+    assert marker not in content
+    assert capture_daemon._SUMMARY_UNAVAILABLE in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+    assert load_turn_state(turn_db, session_id).last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_accepts_managed_provider_plain_text(tmp_path: Path, monkeypatch) -> None:
+    session_id = "ses_managed_plain_text"
+    marker = "S651_SYNTHETIC_MANAGED_PLAIN_TEXT_MARKER"
+    plain_summary = "Managed provider plain-text summary."
+    conn, turn_db, db_path, _, memory_dir = _prepare_summary_capture(tmp_path, session_id, marker)
+
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda *args: True)
+    monkeypatch.setattr(capture_daemon, "_load_summarize_prompt", lambda *args: "Summarize safely.")
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_provider", lambda *args: "openai")
+    monkeypatch.setattr(
+        capture_daemon.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=f"{plain_summary}\n", stderr=""),
+    )
+
+    content = _run_summary_capture(conn, turn_db, db_path, memory_dir, session_id)
+    assert plain_summary in content
+    assert marker not in content
+    assert "Memory summary unavailable" not in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+    assert load_turn_state(turn_db, session_id).last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
+def test_capture_session_turns_keeps_normal_native_summary_behavior(tmp_path: Path, monkeypatch) -> None:
+    session_id = "ses_summary_success"
+    marker = "S651_SYNTHETIC_NORMAL_USER_MARKER"
+    conn, turn_db, db_path, _, memory_dir = _prepare_summary_capture(tmp_path, session_id, marker)
+    isolated_root = tmp_path / "isolated"
+
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_enabled", lambda *args: True)
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_provider", lambda *args: "")
+    monkeypatch.setattr(capture_daemon, "get_plugin_summarize_model", lambda *args: "")
+    monkeypatch.setattr(capture_daemon, "_load_summarize_prompt", lambda *args: "Summarize safely.")
+    monkeypatch.setattr(capture_daemon, "ensure_isolated_config", lambda *args: str(isolated_root))
+
+    captured_env = {}
+
+    def summarize_native(cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        return subprocess.CompletedProcess(cmd, 0, stdout="- Safe synthetic summary.\n", stderr="")
+
+    monkeypatch.setattr(capture_daemon.subprocess, "run", summarize_native)
+
+    content = _run_summary_capture(conn, turn_db, db_path, memory_dir, session_id)
+    assert "- Safe synthetic summary." in content
+    assert marker not in content
+    assert "Memory summary unavailable" not in content
+    assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" in content
+    assert captured_env["XDG_DATA_HOME"] == str(isolated_root / "data")
+    assert captured_env["MEMSEARCH_NO_WATCH"] == "1"
+    assert load_turn_state(turn_db, session_id).last_completed_turn_id == "u1"
+
+    turn_db.close()
+    conn.close()
+
+
 def test_capture_session_turns_is_idempotent_after_partial_state_save_failure(
     tmp_path: Path,
     monkeypatch,
@@ -1082,7 +1297,8 @@ def test_capture_session_turns_uses_legacy_last_msg_time_before_sidecar_exists(
     assert f"<!-- session:{session_id} db:{db_path} -->" in content
     assert f"<!-- session:{session_id} turn:u1 db:{db_path} -->" not in content
     assert f"<!-- session:{session_id} turn:u2 db:{db_path} -->" in content
-    assert "Question two" in content
+    assert "Question two" not in content
+    assert "Memory summary unavailable" in content
 
     state = load_turn_state(turn_db, session_id)
     assert state.last_completed_turn_id == "u2"


### PR DESCRIPTION
## Summary

- write a bounded unavailable note instead of the original turn when summary setup or execution cannot produce usable output
- make prompt loading and both summarizer routes exception-safe, and reject unsuccessful summarizer processes
- preserve native bullet-only output and managed-provider non-empty plain-text output contracts
- keep native OpenCode summarization in isolated XDG config and data directories
- document the fail-closed behavior and the native `opencode run` command

## Rationale

OpenCode capture currently falls back to the rendered user and assistant turn when native summarization is unavailable, times out, exits unsuccessfully, or returns no usable output. That fallback can persist content the summarizer was intended to reduce. Prompt loading errors can also stop capture before its anchor and checkpoint are written.

This change makes the full summary setup and execution path fail closed. It keeps the existing progressive-disclosure anchor and advances the capture checkpoint, but stores only a short diagnostic. It intentionally does not copy or link the user's OpenCode auth store. Current OpenCode summarizer sessions remain in the existing isolated data directory and database, outside the parent capture daemon's session set.

## Testing

- focused OpenCode capture tests for native missing/setup/runtime exception, prompt read/decode exception, nonzero, empty, non-bullet, timeout, and success cases
- managed-provider capture tests for exception, nonzero, empty, timeout, and accepted non-empty plain-text output
- full Python test suite
- lock, Ruff lint, Ruff format, Python compile, shell syntax, and diff checks
- OpenCode Node tests and package dry-run
- isolated OpenCode 1.17.3 source-plugin E2E covering write, native capture, direct search, and fresh-session `memory_search` recall with localhost synthetic providers

Addresses #651.