### PR TITLE
feat(plugins): make the daily memory filename collision-safe on synced directories

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -11,10 +11,10 @@ memsearch uses a layered TOML config system. Most users don't need to configure 
 Since v0.4.11, project-level `.memsearch.toml` is intentionally restricted
 before it is merged. It can only set low-risk local indexing keys:
 `milvus.collection`, `embedding.batch_size`, `chunking.max_chunk_size`,
-`chunking.overlap_lines`, `indexing.ignore_files`, `indexing.exclude`, and
-`watch.debounce_ms`. Put trusted settings such as provider routing, API
-endpoints, API keys, prompt files, and `plugins.*` automation in global config
-or pass them as explicit CLI flags.
+`chunking.overlap_lines`, `indexing.ignore_files`, `indexing.exclude`,
+`watch.debounce_ms`, and `memory.filename_suffix`. Put trusted settings such as
+provider routing, API endpoints, API keys, prompt files, and `plugins.*`
+automation in global config or pass them as explicit CLI flags.
 
 ## Quick Setup
 
@@ -122,6 +122,49 @@ memsearch config set milvus.token "your-api-key"
 memsearch config list          # show all settings
 memsearch config get milvus.uri  # show specific value
 ```
+
+## Shared Memory Directories (multi-machine)
+
+Plugins append each turn's summary to a daily journal named after the date:
+`.memsearch/memory/YYYY-MM-DD.md`. One machine, one writer, no problem.
+
+It becomes a problem when the project folder is synced between machines by a
+file-level sync provider (iCloud Drive, Dropbox, Syncthing, OneDrive). Both
+machines then append to the *same physical file* on the same day, and none of
+those providers merge concurrent plain-text appends. You get a
+`(conflicted copy)` duplicate, or last-writer-wins quietly drops one machine's
+turn summaries with no error at all.
+
+`memory.filename_suffix` gives each writer a daily file of its own:
+
+```bash
+# On every machine that shares the directory
+memsearch config set memory.filename_suffix hostname
+```
+
+Journals then look like `2026-01-02-studio.md` and `2026-01-02-laptop.md`, and
+the two machines never touch each other's file. Search is unaffected: plugins
+index the whole memory directory, so both machines still recall both histories.
+
+| Value | Result |
+|-------|--------|
+| _(empty, the default)_ | `2026-01-02.md` — unchanged behavior for everyone who does not opt in |
+| `hostname` | `2026-01-02-<short hostname>.md` |
+| any other string | `2026-01-02-<that string>.md` |
+
+Notes:
+
+- The resolved value is sanitized to a filesystem-safe token before use, so a
+  hostname carrying dots, spaces or non-ASCII characters is safe: anything
+  outside `A-Za-z0-9_-` becomes `-`, and the token is capped at 32 characters.
+- `MEMSEARCH_MEMORY_FILE_SUFFIX` overrides the config value for one process,
+  which is handy for a quick try before writing anything to disk.
+- Two machines that genuinely share a hostname need an explicit distinct value
+  rather than `hostname`.
+- This is one of the few keys a project-local `.memsearch.toml` may set, so a
+  synced checkout can carry the setting for every machine at once.
+- Implemented by the Claude Code and Codex plugins. The OpenClaw, OpenCode and
+  DeepSeek Harness plugins still write the bare `YYYY-MM-DD.md` name.
 
 ## Plugin Summarization Routing
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -760,6 +760,13 @@ All memories are stored as plain markdown in `.memsearch/memory/`.
 
 **File format:** One file per day, named `YYYY-MM-DD.md`:
 
+> When `.memsearch/memory/` is shared between machines by a file-level sync
+> provider (iCloud, Dropbox, Syncthing), set
+> `memsearch config set memory.filename_suffix hostname` on each machine so
+> every writer owns its own `YYYY-MM-DD-<host>.md` and concurrent appends
+> stop overwriting each other. See the
+> [configuration reference](https://memsearch.dev/home/configuration/).
+
 ```markdown
 ## Session 14:30
 

--- a/plugins/claude-code/hooks/common.sh
+++ b/plugins/claude-code/hooks/common.sh
@@ -305,6 +305,76 @@ ensure_memory_dir() {
   mkdir -p "$MEMORY_DIR"
 }
 
+# _memsearch_config_get <dotted.key>
+# Print one resolved config value, or nothing when memsearch is unavailable.
+_memsearch_config_get() {
+  [ -n "$MEMSEARCH_CMD" ] || return 0
+  $MEMSEARCH_CMD config get "$1" 2>/dev/null || true
+}
+
+# --- Daily memory journal filename ---
+# Keep the block between the BEGIN/END markers byte-identical across plugins: a
+# plugin install only bundles its own directory, so it cannot source a shared
+# file at runtime. tests/test_claude_hooks.py enforces the copy-match invariant.
+# BEGIN shared: daily-memory-file
+
+# _sanitize_filename_suffix <raw>
+# Reduce an arbitrary string (typically a hostname) to a filesystem-safe token:
+# every byte outside [A-Za-z0-9_-] becomes "-", runs collapse, leading and
+# trailing "-" are dropped, and the result is capped at 32 characters. Prints
+# nothing when no safe character survives. Rewriting "." and "/" is what keeps
+# a hostile value from escaping the memory directory or hiding the journal.
+_sanitize_filename_suffix() {
+  printf '%s' "$1" |
+    LC_ALL=C tr -c 'A-Za-z0-9_-' '-' |
+    LC_ALL=C cut -c1-32 |
+    LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+# daily_memory_file <YYYY-MM-DD>
+# Absolute path of the daily memory journal for the given date.
+#
+# Default (no env var, no config) is the historical "$MEMORY_DIR/<date>.md".
+# When MEMSEARCH_MEMORY_FILE_SUFFIX (env, wins) or memory.filename_suffix
+# (config) is set, this writer's own token is appended: "<date>-<suffix>.md".
+# The literal value "hostname" expands to this machine's short hostname.
+#
+# Multi-writer memory directories need this: when .memsearch/memory/ is shared
+# through a file-level sync provider (iCloud, Dropbox, Syncthing), two machines
+# append to the same daily file, and those providers do not merge concurrent
+# plain-text appends -- one machine's turns are silently dropped, or a
+# "(conflicted copy)" duplicate appears. One file per writer removes the race.
+# Indexing is unaffected: memsearch indexes the directory, not one file name.
+daily_memory_file() {
+  local day="$1"
+  local raw="${MEMSEARCH_MEMORY_FILE_SUFFIX-}"
+  local suffix=""
+
+  if [ -z "$raw" ]; then
+    raw=$(_memsearch_config_get memory.filename_suffix) || true
+  fi
+  if [ "$raw" = "hostname" ]; then
+    raw=$(hostname -s 2>/dev/null || hostname 2>/dev/null || printf '%s' "${HOSTNAME:-}") || true
+  fi
+  if [ -n "$raw" ]; then
+    suffix=$(_sanitize_filename_suffix "$raw") || true
+    # A value built only from rewritten bytes -- a non-ASCII hostname, say --
+    # must not collapse back to the shared name, because that is exactly the
+    # silent collision this knob exists to prevent. Fall back to a stable
+    # checksum of the raw value so the writer still owns a file of its own.
+    if [ -z "$suffix" ]; then
+      suffix=$(printf '%s' "$raw" | LC_ALL=C cksum 2>/dev/null | cut -d' ' -f1) || true
+    fi
+  fi
+
+  if [ -n "$suffix" ]; then
+    printf '%s/%s-%s.md' "$MEMORY_DIR" "$day" "$suffix"
+  else
+    printf '%s/%s.md' "$MEMORY_DIR" "$day"
+  fi
+}
+# END shared: daily-memory-file
+
 # Collection description (set by session-start.sh, empty by default)
 COLLECTION_DESC=""
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -274,7 +274,10 @@ fi
 context=""
 
 # Find the 2 most recent daily log files (sorted by filename descending).
-DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md'
+# Matches both the bare daily journal (2026-01-02.md) and the per-writer
+# variants a synced, multi-machine memory directory produces when
+# memory.filename_suffix is set (2026-01-02-laptop.md).
+DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*.md'
 recent_files=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name "$DAILY_JOURNAL_PATTERN" -print 2>/dev/null | sort -r | head -2 || true)
 
 if [ -n "$recent_files" ]; then

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -71,7 +71,7 @@ fi
 # Determine today's date and current time
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
-MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
+MEMORY_FILE=$(daily_memory_file "$TODAY")
 
 # Extract session ID and last user turn UUID for progressive disclosure anchors
 SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl)

--- a/plugins/codex/hooks/common.sh
+++ b/plugins/codex/hooks/common.sh
@@ -318,6 +318,75 @@ ensure_memory_dir() {
   mkdir -p "$MEMORY_DIR"
 }
 
+# _memsearch_config_get <dotted.key>
+# Print one resolved config value, or nothing when memsearch is unavailable.
+_memsearch_config_get() {
+  _memsearch config get "$1" 2>/dev/null || true
+}
+
+# --- Daily memory journal filename ---
+# Keep the block between the BEGIN/END markers byte-identical across plugins: a
+# plugin install only bundles its own directory, so it cannot source a shared
+# file at runtime. tests/test_claude_hooks.py enforces the copy-match invariant.
+# BEGIN shared: daily-memory-file
+
+# _sanitize_filename_suffix <raw>
+# Reduce an arbitrary string (typically a hostname) to a filesystem-safe token:
+# every byte outside [A-Za-z0-9_-] becomes "-", runs collapse, leading and
+# trailing "-" are dropped, and the result is capped at 32 characters. Prints
+# nothing when no safe character survives. Rewriting "." and "/" is what keeps
+# a hostile value from escaping the memory directory or hiding the journal.
+_sanitize_filename_suffix() {
+  printf '%s' "$1" |
+    LC_ALL=C tr -c 'A-Za-z0-9_-' '-' |
+    LC_ALL=C cut -c1-32 |
+    LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+# daily_memory_file <YYYY-MM-DD>
+# Absolute path of the daily memory journal for the given date.
+#
+# Default (no env var, no config) is the historical "$MEMORY_DIR/<date>.md".
+# When MEMSEARCH_MEMORY_FILE_SUFFIX (env, wins) or memory.filename_suffix
+# (config) is set, this writer's own token is appended: "<date>-<suffix>.md".
+# The literal value "hostname" expands to this machine's short hostname.
+#
+# Multi-writer memory directories need this: when .memsearch/memory/ is shared
+# through a file-level sync provider (iCloud, Dropbox, Syncthing), two machines
+# append to the same daily file, and those providers do not merge concurrent
+# plain-text appends -- one machine's turns are silently dropped, or a
+# "(conflicted copy)" duplicate appears. One file per writer removes the race.
+# Indexing is unaffected: memsearch indexes the directory, not one file name.
+daily_memory_file() {
+  local day="$1"
+  local raw="${MEMSEARCH_MEMORY_FILE_SUFFIX-}"
+  local suffix=""
+
+  if [ -z "$raw" ]; then
+    raw=$(_memsearch_config_get memory.filename_suffix) || true
+  fi
+  if [ "$raw" = "hostname" ]; then
+    raw=$(hostname -s 2>/dev/null || hostname 2>/dev/null || printf '%s' "${HOSTNAME:-}") || true
+  fi
+  if [ -n "$raw" ]; then
+    suffix=$(_sanitize_filename_suffix "$raw") || true
+    # A value built only from rewritten bytes -- a non-ASCII hostname, say --
+    # must not collapse back to the shared name, because that is exactly the
+    # silent collision this knob exists to prevent. Fall back to a stable
+    # checksum of the raw value so the writer still owns a file of its own.
+    if [ -z "$suffix" ]; then
+      suffix=$(printf '%s' "$raw" | LC_ALL=C cksum 2>/dev/null | cut -d' ' -f1) || true
+    fi
+  fi
+
+  if [ -n "$suffix" ]; then
+    printf '%s/%s-%s.md' "$MEMORY_DIR" "$day" "$suffix"
+  else
+    printf '%s/%s.md' "$MEMORY_DIR" "$day"
+  fi
+}
+# END shared: daily-memory-file
+
 # Collection description (set by session-start.sh, empty by default)
 COLLECTION_DESC=""
 

--- a/plugins/codex/hooks/session-start.sh
+++ b/plugins/codex/hooks/session-start.sh
@@ -113,7 +113,10 @@ PROJECT_BASENAME=$(basename "$PROJECT_DIR")
 COLLECTION_DESC="${PROJECT_BASENAME} | ${PROVIDER}/${MODEL:-default}"
 
 # Capture preexisting memory files before writing the new session heading.
-DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md'
+# Matches both the bare daily journal (2026-01-02.md) and the per-writer
+# variants a synced, multi-machine memory directory produces when
+# memory.filename_suffix is set (2026-01-02-laptop.md).
+DAILY_JOURNAL_PATTERN='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*.md'
 EXISTING_MEMORY_FILES=$(find "$MEMORY_DIR" -maxdepth 1 -type f -name "$DAILY_JOURNAL_PATTERN" 2>/dev/null | sort || true)
 EXISTING_MEMORY_COUNT=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | sed '/^$/d' | wc -l | tr -d ' ')
 
@@ -121,7 +124,7 @@ EXISTING_MEMORY_COUNT=$(printf '%s\n' "$EXISTING_MEMORY_FILES" | sed '/^$/d' | w
 ensure_memory_dir
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
-MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
+MEMORY_FILE=$(daily_memory_file "$TODAY")
 if [ ! -f "$MEMORY_FILE" ] || ! grep -qF "## Session $NOW" "$MEMORY_FILE"; then
   echo -e "\n## Session $NOW\n" >> "$MEMORY_FILE"
 fi

--- a/plugins/codex/hooks/stop.sh
+++ b/plugins/codex/hooks/stop.sh
@@ -249,7 +249,7 @@ ensure_memory_dir
 # Determine today's date and current time
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
-MEMORY_FILE="$MEMORY_DIR/$TODAY.md"
+MEMORY_FILE=$(daily_memory_file "$TODAY")
 
 # Extract session ID for progressive disclosure anchors
 SESSION_ID=$(_json_val "$INPUT" "session_id" "")

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -42,6 +42,10 @@ _PROJECT_CONFIG_ALLOWED_PATHS = {
     ("indexing", "ignore_files"),
     ("indexing", "exclude"),
     ("watch", "debounce_ms"),
+    # Naming a file inside the project's own .memsearch/memory/ directory is
+    # local and low-risk, and a synced project checkout is exactly where the
+    # multi-machine setup this knob exists for keeps its settings.
+    ("memory", "filename_suffix"),
 }
 
 
@@ -91,6 +95,27 @@ class IndexingConfig:
 @dataclass
 class WatchConfig:
     debounce_ms: int = 1500
+
+
+@dataclass
+class MemoryConfig:
+    """Naming of the daily memory journal written by the platform plugins.
+
+    ``filename_suffix`` is empty by default, which keeps the historical
+    ``<memory_dir>/YYYY-MM-DD.md`` name and the single-writer behavior. Set it
+    when several machines append to one ``.memsearch/memory/`` directory shared
+    through a file-level sync provider (iCloud, Dropbox, Syncthing): those
+    providers do not merge concurrent plain-text appends, so both machines
+    writing the same daily file loses turns or produces conflicted copies.
+
+    The literal value ``"hostname"`` expands to the machine's short hostname;
+    any other value is used verbatim. Plugins sanitize the resolved value to a
+    filesystem-safe token before using it, so a hostname carrying dots, spaces
+    or non-ASCII characters is still safe. Indexing needs no change: plugins
+    index the whole memory directory, not one file name.
+    """
+
+    filename_suffix: str = ""
 
 
 @dataclass
@@ -214,6 +239,7 @@ class MemSearchConfig:
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     indexing: IndexingConfig = field(default_factory=IndexingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
+    memory: MemoryConfig = field(default_factory=MemoryConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
@@ -228,6 +254,7 @@ _SECTION_CLASSES: dict[str, type] = {
     "chunking": ChunkingConfig,
     "indexing": IndexingConfig,
     "watch": WatchConfig,
+    "memory": MemoryConfig,
     "reranker": RerankerConfig,
     "llm": LLMConfig,
     "prompts": PromptsConfig,

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import json
 import os
 import shutil
@@ -582,7 +583,9 @@ def test_session_start_recent_memory_selects_daily_journals() -> None:
         source = script.read_text(encoding="utf-8")
 
         assert "DAILY_JOURNAL_PATTERN" in source
-        assert "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md" in source
+        # The trailing "*" keeps per-writer journals (2026-01-02-laptop.md,
+        # written when memory.filename_suffix is set) inside cold-start recall.
+        assert "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*.md" in source
 
 
 def test_session_start_warns_when_index_state_is_unhealthy(tmp_path: Path) -> None:
@@ -1912,3 +1915,265 @@ def test_version_gt_orders_supported_versions(common_sh: str) -> None:
     got = result.stdout.split()
     want = ["gt" if expected else "not" for _, _, expected in cases]
     assert got == want, [(c, g, w) for c, g, w in zip(cases, got, want, strict=True) if g != w]
+
+
+# --- Daily memory journal filename (issue #720) ------------------------------
+#
+# A .memsearch/memory/ directory shared through a file-level sync provider has
+# more than one writer, and those providers do not merge concurrent plain-text
+# appends: two machines appending to the same "$TODAY.md" silently lose turn
+# summaries. memory.filename_suffix / MEMSEARCH_MEMORY_FILE_SUFFIX give each
+# writer its own daily file. The default stays the bare date.
+
+MARKER_BEGIN = "# BEGIN shared: daily-memory-file"
+MARKER_END = "# END shared: daily-memory-file"
+
+
+def _shared_daily_memory_block(common_sh: str) -> str:
+    text = Path(common_sh).read_text(encoding="utf-8")
+    start = text.index(MARKER_BEGIN)
+    end = text.index(MARKER_END) + len(MARKER_END)
+    return text[start:end]
+
+
+def _daily_memory_file(common_sh: str, suffixes: list[str], memory_dir: str = "/memdir") -> list[str]:
+    """Run ``daily_memory_file`` once per suffix and return the produced paths.
+
+    Every call sets MEMSEARCH_MEMORY_FILE_SUFFIX, so the config lookup is never
+    reached and no memsearch install is involved.
+    """
+    script = (
+        'source "$1" < /dev/null; shift; MEMORY_DIR="$1"; shift; '
+        'while [ "$#" -gt 0 ]; do '
+        'MEMSEARCH_MEMORY_FILE_SUFFIX="$1" daily_memory_file 2026-01-02; echo; shift; done'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", common_sh, memory_dir, *suffixes],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "MEMSEARCH_DISABLE": ""},
+        check=True,
+    )
+    return result.stdout.splitlines()
+
+
+def test_daily_memory_block_is_byte_identical_across_plugins() -> None:
+    """A plugin install bundles only its own directory, so it cannot source a
+    shared file at runtime. Mirrors tests/test_skills_sync.py."""
+    blocks = {common_sh: _shared_daily_memory_block(common_sh) for common_sh in COMMON_SHS}
+    first = next(iter(blocks.values()))
+    for common_sh, block in blocks.items():
+        assert block == first, f"{common_sh} drifted from the shared daily-memory-file block"
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SHS, ids=PLUGIN_IDS)
+def test_daily_memory_file_defaults_to_the_bare_date(common_sh: str, tmp_path: Path) -> None:
+    """Regression guard, never red by design: it pins the pre-#720 filename.
+
+    With no env var and no config the journal keeps its exact historical name,
+    so single-machine users see no change at all.
+    """
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    # An install that answers "" for every config key: the unset default.
+    _write_executable(fake_bin / "memsearch", "#!/usr/bin/env bash\nexit 0\n")
+
+    script = 'source "$1" < /dev/null; MEMORY_DIR=/memdir; daily_memory_file 2026-01-02'
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", common_sh],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "HOME": str(tmp_path),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "MEMSEARCH_DISABLE": "",
+            "MEMSEARCH_MEMORY_FILE_SUFFIX": "",
+        },
+        check=True,
+    )
+
+    assert result.stdout == "/memdir/2026-01-02.md"
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SHS, ids=PLUGIN_IDS)
+def test_daily_memory_file_sanitizes_the_suffix(common_sh: str) -> None:
+    """A hostname may carry dots, spaces, slashes or non-ASCII bytes."""
+    cases = [
+        # (raw suffix, expected filename)
+        ("laptop", "2026-01-02-laptop.md"),
+        ("Ada's MacBook.local", "2026-01-02-Ada-s-MacBook-local.md"),
+        # Path separators and dot segments must never leave the memory dir.
+        ("../../etc/passwd", "2026-01-02-etc-passwd.md"),
+        (".hidden", "2026-01-02-hidden.md"),
+        # Long values are capped so the filename stays reasonable.
+        ("abcdefghijklmnopqrstuvwxyz0123456789extra", "2026-01-02-abcdefghijklmnopqrstuvwxyz012345.md"),
+    ]
+
+    got = _daily_memory_file(common_sh, [raw for raw, _ in cases])
+
+    assert got == [f"/memdir/{expected}" for _, expected in cases]
+
+
+@pytest.mark.parametrize("common_sh", COMMON_SHS, ids=PLUGIN_IDS)
+def test_daily_memory_file_never_collapses_a_set_suffix_to_the_shared_name(common_sh: str) -> None:
+    """A suffix built only from rewritten bytes still has to own its own file.
+
+    Falling back to the bare date here would silently restore the collision the
+    knob was set to avoid, so an otherwise unusable value becomes a stable
+    checksum of the raw string instead.
+    """
+    cyrillic, punctuation = _daily_memory_file(common_sh, ["мак", "..."])
+
+    for path in (cyrillic, punctuation):
+        assert path != "/memdir/2026-01-02.md"
+        assert path.startswith("/memdir/2026-01-02-")
+        assert path.endswith(".md")
+    assert cyrillic != punctuation
+
+
+def _run_claude_stop_hook(tmp_path: Path, *, suffix_config: str = "", env_suffix: str = "") -> Path:
+    """Drive the Claude Code Stop hook once and return the memory directory."""
+    script = Path("plugins/claude-code/hooks/stop.sh")
+    plugin_root = Path("plugins/claude-code").resolve()
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    transcript = tmp_path / "session-720.jsonl"
+    home.mkdir()
+    fake_bin.mkdir()
+    _write_claude_transcript(transcript, turn_uuid="turn-720")
+
+    _write_executable(
+        fake_bin / "memsearch",
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "config" ] && [ "$2" = "get" ]; then\n'
+        '  case "$3" in\n'
+        "    embedding.provider) echo onnx ;;\n"
+        "    plugins.claude-code.summarize.enabled) echo true ;;\n"
+        f"    memory.filename_suffix) echo '{suffix_config}' ;;\n"
+        '    *) echo "" ;;\n'
+        "  esac\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    _write_executable(
+        fake_bin / "claude",
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "--help" ]; then\n'
+        '  echo "Usage: claude"\n'
+        "  exit 0\n"
+        "fi\n"
+        'echo "- User hit the synced-memory filename collision."\n',
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_MEMORY_FILE_SUFFIX": env_suffix,
+    }
+    subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return memsearch_dir / "memory"
+
+
+def test_claude_stop_hook_keeps_the_bare_daily_journal_by_default(tmp_path: Path) -> None:
+    """Regression guard, never red by design: unconfigured installs must not move."""
+    memory = _run_claude_stop_hook(tmp_path)
+
+    today = datetime.date.today().isoformat()
+    assert [path.name for path in sorted(memory.glob("*.md"))] == [f"{today}.md"]
+
+
+def test_claude_stop_hook_writes_a_per_writer_journal_from_config(tmp_path: Path) -> None:
+    memory = _run_claude_stop_hook(tmp_path, suffix_config="Build Box.local")
+
+    today = datetime.date.today().isoformat()
+    journal = memory / f"{today}-Build-Box-local.md"
+    assert [path.name for path in sorted(memory.glob("*.md"))] == [journal.name]
+    assert "synced-memory filename collision" in journal.read_text(encoding="utf-8")
+
+
+def test_claude_stop_hook_env_suffix_overrides_config(tmp_path: Path) -> None:
+    memory = _run_claude_stop_hook(tmp_path, suffix_config="from-config", env_suffix="from-env")
+
+    today = datetime.date.today().isoformat()
+    assert [path.name for path in sorted(memory.glob("*.md"))] == [f"{today}-from-env.md"]
+
+
+def test_codex_session_start_writes_a_per_writer_journal(tmp_path: Path) -> None:
+    """The Codex SessionStart heading has to land in the same per-writer file
+    the Stop hook appends to, or the two hooks split one day in two."""
+    script = Path("plugins/codex/hooks/session-start.sh")
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    memsearch_dir = tmp_path / ".memsearch"
+    home.mkdir()
+    fake_bin.mkdir()
+    (home / ".memsearch").mkdir()
+    (home / ".memsearch" / "config.toml").write_text("", encoding="utf-8")
+
+    _write_executable(
+        fake_bin / "memsearch",
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "config" ] && [ "$2" = "get" ]; then\n'
+        '  case "$3" in\n'
+        "    embedding.provider) echo onnx ;;\n"
+        "    memory.filename_suffix) echo workstation ;;\n"
+        '    *) echo "" ;;\n'
+        "  esac\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "MEMSEARCH_PROJECT_DIR": str(tmp_path),
+        "MEMSEARCH_DIR": str(memsearch_dir),
+        "MEMSEARCH_NO_WATCH": "1",
+        "MEMSEARCH_MEMORY_FILE_SUFFIX": "",
+    }
+    subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps({"cwd": str(tmp_path)}),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    today = datetime.date.today().isoformat()
+    memory = memsearch_dir / "memory"
+    assert [path.name for path in sorted(memory.glob("*.md"))] == [f"{today}-workstation.md"]
+
+
+def test_claude_session_start_recall_includes_per_writer_journals(tmp_path: Path) -> None:
+    """Cold-start recall must still see the journals the other machine wrote."""
+    journal = "\n".join(
+        [
+            "# 2026-08-19",
+            "",
+            "## Session 09:00",
+            "### 09:00",
+            "- OTHER_MACHINE_MARKER",
+            "",
+        ]
+    )
+
+    context = _run_claude_session_start_with_memory(tmp_path, {"2026-08-19-otherbox.md": journal})
+
+    assert "OTHER_MACHINE_MARKER" in context

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -660,3 +660,40 @@ def test_dict_to_config_accepts_empty_section_dicts() -> None:
     assert cfg.embedding.provider == "openai"
     assert cfg.milvus.collection == "memsearch_chunks"
     assert cfg.watch.debounce_ms == 1500
+
+
+def test_memory_filename_suffix_defaults_to_empty():
+    """Regression guard, never red by design.
+
+    An empty suffix is what keeps the plugins writing the historical
+    ``memory/YYYY-MM-DD.md`` name for every single-machine user.
+    """
+    assert MemSearchConfig().memory.filename_suffix == ""
+    assert get_config_value("memory.filename_suffix", MemSearchConfig()) == ""
+
+
+def test_memory_filename_suffix_roundtrips_through_global_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    global_cfg = tmp_path / "global.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", global_cfg)
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", tmp_path / ".memsearch.toml")
+
+    set_config_value("memory.filename_suffix", "hostname")
+
+    assert load_config_file(global_cfg)["memory"]["filename_suffix"] == "hostname"
+    assert resolve_config().memory.filename_suffix == "hostname"
+
+
+def test_memory_filename_suffix_is_allowed_in_project_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The knob names a file inside the project's own memory directory.
+
+    A checkout synced between two machines is where the multi-machine setup
+    this exists for keeps its settings, so the project layer may set it.
+    """
+    project_cfg = tmp_path / ".memsearch.toml"
+    monkeypatch.setattr("memsearch.config.GLOBAL_CONFIG_PATH", tmp_path / "global.toml")
+    monkeypatch.setattr("memsearch.config.PROJECT_CONFIG_PATH", project_cfg)
+
+    set_config_value("memory.filename_suffix", "hostname", project=True)
+
+    assert load_config_file(project_cfg)["memory"]["filename_suffix"] == "hostname"
+    assert resolve_config().memory.filename_suffix == "hostname"


### PR DESCRIPTION
Closes #720.

When `.memsearch/memory/` is shared between machines by a file-level sync provider (iCloud Drive, Dropbox, Syncthing), both machines append to the same `YYYY-MM-DD.md` on the same day. Those providers do not merge concurrent plain-text appends, so the result is a `(conflicted copy)` duplicate or a silent last-writer-wins drop of one machine's turn summaries — no error, no signal.

This adds an opt-in per-writer suffix to the daily journal filename.

**Default behaviour does not change.** With no config and no env var the filename stays exactly `$TODAY.md`. Two tests pin that: `test_daily_memory_file_defaults_to_the_bare_date` (both plugins) and `test_claude_stop_hook_keeps_the_bare_daily_journal_by_default`.

**Configuration uses the channel the hooks already use** — `memsearch config get <key>` — rather than a new mechanism:

```bash
memsearch config set memory.filename_suffix hostname   # on each machine
```

`""` (default) keeps `2026-01-02.md`; `"hostname"` expands to `hostname -s`; any other value is used literally, which covers the case in the issue where two machines happen to share a hostname. `MEMSEARCH_MEMORY_FILE_SUFFIX` overrides the config value for one process. `memory.filename_suffix` is also permitted in project-local `.memsearch.toml`, since it only names a file inside the project's own memory directory and a synced checkout is where a multi-machine setup naturally keeps it.

**Indexing is untouched**, as the issue notes: `memsearch index "$MEMORY_DIR"` ingests every `*.md` regardless of name.

Two supporting changes were required for the feature to work end to end:

- `DAILY_JOURNAL_PATTERN` in both `session-start.sh` files is widened to `…[0-9]*.md`. Without it, enabling the suffix would have silently emptied cold-start recall, since the old glob does not match `2026-01-02-laptop.md`. This has its own red-then-green test.
- The resolved suffix is sanitized to a filesystem-safe token — anything outside `A-Za-z0-9_-` becomes `-`, runs collapse, leading/trailing `-` are stripped, capped at 32 characters. That is what makes `../../etc/passwd` and `.hidden` structurally harmless rather than merely filtered. If a value sanitizes down to nothing (a fully non-ASCII hostname), it falls back to a `cksum` of the raw string rather than to the bare date — falling back to the bare date would silently restore the very collision the user just opted out of.

**Scope.** Implemented in the two shell plugins, `claude-code` and `codex`, which are where the `MEMORY_FILE="$MEMORY_DIR/$TODAY.md"` line quoted in the issue actually lives. `openclaw` (`index.ts:728`), `opencode` (`scripts/capture-daemon.py:590`) and `dsh` (`index.js:799`) have equivalent writers in TypeScript/Python/JavaScript and still write the bare name; the config key lives in core so they can adopt it without a second design decision. Kept out of this PR to stay to one focused change in one language — happy to follow up if you would rather have them together. Related: `plugins/dsh/index.js:62` has `DAILY_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/`, the JS twin of the pattern widened here; untouched, so a user who enables the suffix *and* runs the dsh plugin against the same directory will not see suffixed files in dsh's "recent journals" listing (its indexing is unaffected).

**Why the logic is duplicated.** `plugins/_shared/` is a source directory whose contents are *copied* into each plugin by the sync scripts, because a plugin install bundles only its own directory and cannot source `_shared` at runtime. There is no `_shared/hooks/` and no shell-sync script, and adding one would be a larger structural change than this fix. So the block lives once, between `# BEGIN/END shared: daily-memory-file` markers in each plugin's `common.sh`, and `test_daily_memory_block_is_byte_identical_across_plugins` enforces byte-equality — the same copy-match invariant `tests/test_skills_sync.py` and `tests/test_maintenance_runner.py` already enforce. The one line that genuinely differs per plugin (claude-code uses `$MEMSEARCH_CMD` as a string, codex uses a `_memsearch` array wrapper) is isolated into a small adapter outside the markers.

**Docs:** `docs/home/configuration.md` gains a "Shared Memory Directories (multi-machine)" section and the project-config allow-list entry; cross-referenced from `plugins/claude-code/README.md`.

**Tests.** 15 new tests across `tests/test_claude_hooks.py` and `tests/test_config.py`, following the existing pytest-drives-the-shell-hooks idiom. Every behavioural test was confirmed **failing on unmodified source** before it passed — stashing only `plugins/` and `src/` and keeping the tests gives `15 failed, 105 passed`; restoring gives `120 passed`. Full suite: `419 passed, 7 skipped` (baseline on `main` before this change: `404 passed, 7 skipped`, no pre-existing failures). `ruff check` and `ruff format --check` both clean; `bash -n` clean on all six changed hook scripts.

Two honest gaps. `shellcheck` was not run — it is not installed here, and the repo does not use it either (`lint.yml` and `.pre-commit-config.yaml` are ruff-only), so the shell changes are unchecked by any linter here or upstream; `bash -n` was substituted. And three of the tests drive a fake `memsearch` stub, so they pin the hook's *parsing* of `config get` output rather than proving `memory.filename_suffix` is a real key; that was checked separately against the real CLI end to end, but that check is a manual run, not part of the committed suite, so a rename of the config key would not be caught by `tests/`.

Local runs were on Python 3.14 (CI matrix is 3.10–3.13). The sanitizer was additionally checked to produce identical output on GNU coreutils / bash 5 (`ubuntu:24.04`) and BSD / bash 3.2 (macOS).

Authored by Mycroft, the synthetic co-founder at Anton Dzyatkovsky's lab (autonomous mode; named responsible person: Anton Dziatkovskii). The test runs above were independently re-executed before submission.
