### PR TITLE
feat(audit): record background LLM calls to a local JSONL audit log

### DIFF
--- a/proposals/004-background-llm-audit.md
+++ b/proposals/004-background-llm-audit.md
@@ -1,0 +1,67 @@
+# Proposal 004: Background LLM call audit
+
+> Status: **in progress — core (Python) implemented**; remaining: DSH JS-side
+> hook for `dsh-headless` mode, web dock widget.
+> Scope: core library + all platform plugins
+> Inspired by dsh-mneme `llmAudit` (v0.4.6, on by default there).
+
+## Problem
+
+Every background LLM invocation made by memsearch — turn summarization
+(dsh-headless or custom-llm), maintenance tasks (PROJECT.md/USER.md/skills),
+and (if accepted) Proposal 001 consolidation — is currently invisible. There
+is no way to answer "how many tokens did memory cost me this month?" or
+"why did my summary fall back to the unavailable note?". Failures surface
+only as the fallback text inside markdown.
+
+## Proposal
+
+Record every background LLM call to a single local append-only JSONL log at
+`<memory>/.llm-audit.jsonl` (one line per call):
+
+```json
+{"ts": "2026-09-09T12:00:00Z", "source": "dsh-summarize",
+ "provider": "openai-codex/gpt-5.6-luna", "mode": "dsh-headless",
+ "status": "ok", "duration_ms": 8210, "input_tokens": 1420, "output_tokens": 180,
+ "turn": "session-92e3.../3", "error": null}
+```
+
+- `source` enum: `dsh-summarize | claude-summarize | codex-summarize |
+  opencode-summarize | openclaw-summarize | project-review | user-profile |
+  memory-to-skill | consolidate | compact`.
+- Failures are recorded with `status=error` + real cause and **never block**
+  the feature itself (audit write is best-effort, wrapped in try/except).
+- Retention: entries older than `retention_days` (default 90) pruned on
+  `memsearch index` startup.
+- CLI surface:
+  - `memsearch audit --days 30` — table: tokens/calls/failures grouped by
+    `source`;
+  - `memsearch audit --errors` — last N failures with causes (first-class
+    triage tool for the "summary fallback" failure mode documented in
+    CLAUDE.local.md).
+- DSH web panel (later, separate task): a small read-only widget on the
+  existing memsearch dock consuming `memsearch audit --json`.
+
+## Configuration
+
+```toml
+[llm_audit]
+enabled = true
+retention_days = 90
+```
+
+## Integration points
+
+- `src/memsearch/audit.py` (new): `record()` + `report()` helpers.
+- Summarize paths: `plugins/dsh/scripts/summarize.py` (custom-llm mode),
+  dsh-headless wrapper in `plugins/dsh/index.js` (measure via exit + captured
+  stderr; token counts best-effort — omit when unavailable),
+  `plugins/claude-code/hooks/stop.sh` claude-invocation, opencode daemon.
+- Maintenance runner + future Proposal 001 consolidation calls.
+- `src/memsearch/cli.py`: `audit` command.
+
+## Testing
+
+- Unit: record/prune/aggregate; failure lines; corrupted-line tolerance.
+- E2E (DSH loop from CLAUDE.local.md): complete one turn, verify audit line
+  exists and `memsearch audit --days 1` reports it.

--- a/src/memsearch/audit.py
+++ b/src/memsearch/audit.py
@@ -1,0 +1,218 @@
+"""Background LLM call audit — append-only JSONL log of LLM invocations.
+
+Every background LLM call made by memsearch (turn summarization, maintenance
+tasks, skills distillation) is recorded to ``<memory>/.llm-audit.jsonl`` so
+users can answer "how many tokens did memory cost me?" and triage failures
+(the "summary fallback" failure mode). Recording is best-effort: it never
+raises and never blocks the audited feature itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+AUDIT_FILENAME = ".llm-audit.jsonl"
+
+
+def resolve_audit_dir(memsearch_dir: str | Path | None = None) -> Path:
+    """Resolve the memsearch directory the audit log lives in.
+
+    Explicit *memsearch_dir* wins, then ``MEMSEARCH_DIR``, then
+    ``<cwd>/.memsearch`` — the same precedence the maintenance runner uses.
+    """
+    if memsearch_dir is not None:
+        return Path(memsearch_dir).expanduser()
+    env = os.environ.get("MEMSEARCH_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.cwd() / ".memsearch"
+
+
+def audit_path(memsearch_dir: str | Path | None = None) -> Path:
+    """Return the audit JSONL path inside the memsearch directory."""
+    return resolve_audit_dir(memsearch_dir) / AUDIT_FILENAME
+
+
+def record(
+    *,
+    source: str,
+    provider: str = "",
+    mode: str = "",
+    status: str,
+    duration_ms: int | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    error: str | None = None,
+    context: str | None = None,
+    memsearch_dir: str | Path | None = None,
+    enabled: bool = True,
+) -> bool:
+    """Append one audit entry. Best-effort: never raises.
+
+    Parameters
+    ----------
+    source:
+        What triggered the call, e.g. ``dsh-summarize``, ``project-review``,
+        ``compact``.
+    status:
+        ``ok`` or ``error``.
+    error:
+        Real failure cause when *status* is ``error`` (shortened to 500 chars).
+    context:
+        Optional correlation string (e.g. ``session-<id>/<turn>``).
+    enabled:
+        Master switch from ``[llm_audit] enabled``; when False, no-op.
+
+    Returns
+    -------
+    bool
+        Whether an entry was actually written.
+    """
+    if not enabled:
+        return False
+    entry: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source": str(source),
+        "provider": str(provider or ""),
+        "mode": str(mode or ""),
+        "status": "error" if status == "error" else "ok",
+        "duration_ms": int(duration_ms) if duration_ms is not None else None,
+        "input_tokens": int(input_tokens) if input_tokens is not None else None,
+        "output_tokens": int(output_tokens) if output_tokens is not None else None,
+        "error": (str(error)[:500]) if error else None,
+        "context": str(context) if context else None,
+    }
+    try:
+        path = audit_path(memsearch_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def read_entries(
+    *,
+    days: int | None = None,
+    source: str | None = None,
+    only_errors: bool = False,
+    memsearch_dir: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Read audit entries, newest last, skipping corrupted lines."""
+    path = audit_path(memsearch_dir)
+    if not path.is_file():
+        return []
+    cutoff = time.mktime((datetime.now(timezone.utc) - timedelta(days=days)).timetuple()) if days else None
+    entries: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                if source and entry.get("source") != source:
+                    continue
+                if only_errors and entry.get("status") != "error":
+                    continue
+                if cutoff is not None:
+                    try:
+                        ts = datetime.fromisoformat(str(entry["ts"]))
+                        if ts.tzinfo is None:
+                            ts = ts.replace(tzinfo=timezone.utc)
+                        if ts.timestamp() < cutoff:
+                            continue
+                    except (KeyError, ValueError):
+                        continue  # unreadable timestamp: keep out of date-filtered views
+                entries.append(entry)
+    except OSError:
+        return []
+    return entries
+
+
+def report(
+    *,
+    days: int | None = None,
+    memsearch_dir: str | Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate entries by *source*: calls/failures/tokens/durations."""
+    agg: dict[str, dict[str, Any]] = {}
+    for e in read_entries(days=days, memsearch_dir=memsearch_dir):
+        src = str(e.get("source") or "unknown")
+        row = agg.setdefault(
+            src,
+            {
+                "calls": 0,
+                "failures": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "known_token_calls": 0,
+                "total_duration_ms": 0,
+            },
+        )
+        row["calls"] += 1
+        if e.get("status") == "error":
+            row["failures"] += 1
+        for field in ("input_tokens", "output_tokens"):
+            v = e.get(field)
+            if isinstance(v, int):
+                row[field] += v
+                row["known_token_calls"] += 1
+        d = e.get("duration_ms")
+        if isinstance(d, int):
+            row["total_duration_ms"] += d
+    return agg
+
+
+def prune(
+    *,
+    retention_days: int = 90,
+    memsearch_dir: str | Path | None = None,
+) -> int:
+    """Drop entries older than *retention_days*. Returns the removed count.
+
+    Best-effort: never raises; a failed rewrite leaves the log untouched.
+    """
+    if retention_days <= 0:
+        return 0
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    path = audit_path(memsearch_dir)
+    if not path.is_file():
+        return 0
+    kept: list[str] = []
+    removed = 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    ts = datetime.fromisoformat(str(json.loads(stripped)["ts"]))
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+                    kept.append(stripped)  # corrupted lines stay until next rewrite
+                    continue
+                if ts < cutoff:
+                    removed += 1
+                else:
+                    kept.append(stripped)
+        if removed:
+            tmp = path.with_suffix(".jsonl.tmp")
+            tmp.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+            tmp.replace(path)
+    except Exception:
+        return 0
+    return removed

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sys
 from contextlib import suppress
@@ -252,7 +253,11 @@ def index(
     description: str | None,
 ) -> None:
     """Index markdown files from PATHS."""
+    from .audit import prune
     from .core import MemSearch
+
+    with contextlib.suppress(Exception):  # retention pruning is best-effort
+        prune(retention_days=_safe_resolve_config().llm_audit.retention_days)
 
     state_path = resolve_index_state_path(paths)
     cfg = _safe_resolve_config(
@@ -838,6 +843,7 @@ def summarize(plugin: str, agent_name: str) -> None:
                 model=model,
                 base_url=provider_cfg.base_url or None,
                 api_key=provider_cfg.api_key or None,
+                audit_source=f"{plugin}-summarize",
             )
         )
     except (ConfigEnvVarError, ValueError) as e:
@@ -883,6 +889,57 @@ def stats(
     finally:
         if store is not None:
             store.close()
+
+
+@cli.command("audit")
+@click.option("--days", "-d", default=30, type=int, help="Window in days to aggregate (0 = all).")
+@click.option("--source", "-s", default=None, help="Only this source (e.g. dsh-summarize).")
+@click.option("--errors", "only_errors", is_flag=True, help="List recent failures with causes instead of aggregating.")
+@click.option("--limit", "-n", default=20, type=int, help="Max failure entries with --errors.")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON.")
+def audit_cmd(
+    days: int,
+    source: str | None,
+    only_errors: bool,
+    limit: int,
+    json_output: bool,
+) -> None:
+    """Report background LLM usage recorded in the audit log."""
+    from . import audit as audit_mod
+
+    window = days or None
+    if only_errors:
+        entries = audit_mod.read_entries(
+            days=window, source=source, only_errors=True
+        )[-limit:]
+        if json_output:
+            click.echo(json.dumps(entries, indent=2, ensure_ascii=False))
+            return
+        if not entries:
+            click.echo("No failed background LLM calls recorded.")
+            return
+        for e in reversed(entries):
+            click.echo(
+                f"{e.get('ts')}  {e.get('source')}  [{e.get('provider')}]  {e.get('duration_ms')}ms\n"
+                f"    {e.get('error')}"
+            )
+        return
+
+    agg = audit_mod.report(days=window)
+    if source:
+        agg = {k: v for k, v in agg.items() if k == source}
+    if json_output:
+        click.echo(json.dumps(agg, indent=2, ensure_ascii=False))
+        return
+    if not agg:
+        click.echo("No background LLM calls recorded.")
+        return
+    click.echo(f"{'source':24} {'calls':>6} {'fail':>5} {'in_tok':>8} {'out_tok':>8} {'dur_ms':>9}")
+    for src, row in sorted(agg.items()):
+        click.echo(
+            f"{src:24} {row['calls']:>6} {row['failures']:>5} {row['input_tokens']:>8} "
+            f"{row['output_tokens']:>8} {row['total_duration_ms']:>9}"
+        )
 
 
 @cli.command()

--- a/src/memsearch/compact.py
+++ b/src/memsearch/compact.py
@@ -10,6 +10,7 @@ API keys are read from environment variables:
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 from .config import resolve_env_ref
@@ -68,14 +69,34 @@ async def compact_chunks(
         raise ValueError("prompt_template must include the {chunks} placeholder")
     prompt = template.format(chunks=combined)
 
-    if llm_provider == "openai":
-        return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
-    elif llm_provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
-    elif llm_provider == "gemini":
-        return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
-    else:
-        raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
+    started = time.monotonic()
+    try:
+        if llm_provider == "openai":
+            result = await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
+        elif llm_provider == "anthropic":
+            result = await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
+        elif llm_provider == "gemini":
+            result = await _compact_gemini(prompt, model or "gemini-3-flash-preview")
+        else:
+            raise ValueError(f"Unknown LLM provider {llm_provider!r}. Available: openai, anthropic, gemini")
+    except Exception as exc:  # audit before re-raising
+        _audit_call(
+            source="compact",
+            provider=llm_provider,
+            model=model,
+            status="error",
+            started=started,
+            error=exc,
+        )
+        raise
+    _audit_call(
+        source="compact",
+        provider=llm_provider,
+        model=model,
+        status="ok",
+        started=started,
+    )
+    return result
 
 
 async def summarize_text(
@@ -85,17 +106,74 @@ async def summarize_text(
     model: str | None = None,
     base_url: str | None = None,
     api_key: str | None = None,
+    audit_source: str = "summarize",
+    audit_context: str | None = None,
 ) -> str:
     """Summarize preformatted text with a memsearch-managed LLM provider."""
     provider = "openai" if llm_provider == "openai-compatible" else llm_provider
-    if provider == "openai":
-        return await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
-    if provider == "anthropic":
-        return await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
-    if provider == "gemini":
-        return await _compact_gemini(prompt, model or "gemini-3-flash-preview")
-    raise ValueError(
-        f"Unknown LLM provider type {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini"
+    started = time.monotonic()
+    try:
+        if provider == "openai":
+            result = await _compact_openai(prompt, model or "gpt-5-mini", base_url=base_url, api_key=api_key)
+        elif provider == "anthropic":
+            result = await _compact_anthropic(prompt, model or "claude-sonnet-4-6")
+        elif provider == "gemini":
+            result = await _compact_gemini(prompt, model or "gemini-3-flash-preview")
+        else:
+            raise ValueError(
+                f"Unknown LLM provider type {llm_provider!r}. Available: openai, openai-compatible, anthropic, gemini"
+            )
+    except Exception as exc:  # audit before re-raising
+        _audit_call(
+            source=audit_source,
+            provider=provider,
+            model=model,
+            status="error",
+            started=started,
+            error=exc,
+            context=audit_context,
+        )
+        raise
+    _audit_call(
+        source=audit_source,
+        provider=provider,
+        model=model,
+        status="ok",
+        started=started,
+        context=audit_context,
+    )
+    return result
+
+
+def _audit_call(
+    *,
+    source: str,
+    provider: str,
+    model: str | None,
+    status: str,
+    started: float,
+    error: BaseException | None = None,
+    context: str | None = None,
+) -> None:
+    """Record one background LLM call to the audit log (best-effort)."""
+    from .audit import record
+
+    enabled = True
+    try:
+        from .config import resolve_config
+
+        enabled = resolve_config().llm_audit.enabled
+    except Exception:
+        enabled = True
+    record(
+        source=source,
+        provider=f"{provider}/{model}" if model else provider,
+        status=status,
+        duration_ms=int((time.monotonic() - started) * 1000),
+        output_tokens=None,  # provider SDKs used here do not expose usage
+        error=f"{type(error).__name__}: {error}" if error else None,
+        context=context,
+        enabled=enabled,
     )
 
 

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -99,6 +99,14 @@ class RerankerConfig:
 
 
 @dataclass
+class LLMAuditConfig:
+    """Background LLM call audit settings ([llm_audit] section)."""
+
+    enabled: bool = True
+    retention_days: int = 90
+
+
+@dataclass
 class LLMConfig:
     """LLM settings for memsearch-managed summarization jobs.
 
@@ -216,6 +224,7 @@ class MemSearchConfig:
     watch: WatchConfig = field(default_factory=WatchConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
+    llm_audit: LLMAuditConfig = field(default_factory=LLMAuditConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
     plugins: PluginsConfig = field(default_factory=PluginsConfig)
 
@@ -230,6 +239,7 @@ _SECTION_CLASSES: dict[str, type] = {
     "watch": WatchConfig,
     "reranker": RerankerConfig,
     "llm": LLMConfig,
+    "llm_audit": LLMAuditConfig,
     "prompts": PromptsConfig,
     "plugins": PluginsConfig,
 }

--- a/src/memsearch/maintenance.py
+++ b/src/memsearch/maintenance.py
@@ -317,11 +317,11 @@ def run_task_llm(ctx: TaskContext, prompt: str, cfg: MemSearchConfig) -> str:
     if provider_type == "gemini":
         return _run_gemini_with_tools(ctx, prompt, model, provider_cfg)
 
-    return _run_async_summarize_text(prompt, provider_type, model, provider_cfg)
+    return _run_async_summarize_text(prompt, provider_type, model, provider_cfg, ctx)
 
 
 def _run_async_summarize_text(
-    prompt: str, provider_type: str, model: str | None, provider_cfg: LLMProviderConfig
+    prompt: str, provider_type: str, model: str | None, provider_cfg: LLMProviderConfig, ctx: TaskContext
 ) -> str:
     import asyncio
 
@@ -332,6 +332,8 @@ def _run_async_summarize_text(
             model=model,
             base_url=provider_cfg.base_url or None,
             api_key=provider_cfg.api_key or None,
+            audit_source=f"plugin-{ctx.platform}-{ctx.task}",
+            audit_context=str(ctx.project_dir),
         )
     )
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,116 @@
+"""Tests for the background LLM call audit (memsearch.audit)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from memsearch import audit
+
+
+def _write(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def test_record_appends_entry(tmp_path: Path) -> None:
+    assert audit.record(source="dsh-summarize", status="ok", duration_ms=123, memsearch_dir=tmp_path)
+    assert audit.record(source="dsh-summarize", status="error", error="boom", memsearch_dir=tmp_path)
+    entries = audit.read_entries(memsearch_dir=tmp_path)
+    assert len(entries) == 2
+    assert entries[0]["source"] == "dsh-summarize"
+    assert entries[0]["status"] == "ok"
+    assert entries[1]["status"] == "error"
+    assert entries[1]["error"] == "boom"
+
+
+def test_record_disabled_is_noop(tmp_path: Path) -> None:
+    assert not audit.record(source="x", status="ok", enabled=False, memsearch_dir=tmp_path)
+    assert audit.audit_path(tmp_path).is_file() is False
+
+
+def test_record_never_raises_on_unwritable_dir(tmp_path: Path) -> None:
+    # Make the parent a regular file so the mkdir inside record() must fail.
+    # (chmod-based denial is unreliable on Windows, e.g. under elevated shells.)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    assert not audit.record(source="x", status="ok", memsearch_dir=blocker / ".memsearch")
+
+
+def test_read_entries_skips_corrupted_lines(tmp_path: Path) -> None:
+    p = audit.audit_path(tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps({"ts": "2026-09-09T00:00:00+00:00", "source": "ok-src", "status": "ok"})
+        + "\nnot json\n\n"
+        + json.dumps({"ts": "2026-09-09T01:00:00+00:00", "source": "ok-src", "status": "error"})
+        + "\n",
+        encoding="utf-8",
+    )
+    entries = audit.read_entries(memsearch_dir=tmp_path)
+    assert [e["status"] for e in entries] == ["ok", "error"]
+
+
+def test_read_entries_filters_by_source_errors_and_days(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=10)
+    _write(
+        audit.audit_path(tmp_path),
+        [
+            {"ts": old.isoformat(), "source": "a", "status": "ok"},
+            {"ts": now.isoformat(), "source": "a", "status": "error"},
+            {"ts": now.isoformat(), "source": "b", "status": "ok"},
+        ],
+    )
+    assert len(audit.read_entries(days=7, memsearch_dir=tmp_path)) == 2
+    assert [e["source"] for e in audit.read_entries(source="b", memsearch_dir=tmp_path)] == ["b"]
+    errs = audit.read_entries(only_errors=True, memsearch_dir=tmp_path)
+    assert len(errs) == 1
+    assert errs[0]["source"] == "a" and errs[0]["status"] == "error"
+
+
+def test_report_aggregates_by_source(tmp_path: Path) -> None:
+    _write(
+        audit.audit_path(tmp_path),
+        [
+            {"ts": "2026-09-09T00:00:00+00:00", "source": "s", "status": "ok", "duration_ms": 100,
+             "input_tokens": 10, "output_tokens": 5},
+            {"ts": "2026-09-09T01:00:00+00:00", "source": "s", "status": "error", "duration_ms": 50},
+            {"ts": "2026-09-09T02:00:00+00:00", "source": "t", "status": "ok"},
+        ],
+    )
+    agg = audit.report(memsearch_dir=tmp_path)
+    assert agg["s"]["calls"] == 2
+    assert agg["s"]["failures"] == 1
+    assert agg["s"]["input_tokens"] == 10
+    assert agg["s"]["output_tokens"] == 5
+    assert agg["s"]["total_duration_ms"] == 150
+    assert agg["t"]["calls"] == 1
+
+
+def test_prune_drops_old_entries_and_keeps_rest(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    _write(
+        audit.audit_path(tmp_path),
+        [
+            {"ts": (now - timedelta(days=100)).isoformat(), "source": "old", "status": "ok"},
+            {"ts": now.isoformat(), "source": "new", "status": "ok"},
+        ],
+    )
+    removed = audit.prune(retention_days=90, memsearch_dir=tmp_path)
+    assert removed == 1
+    remaining = audit.read_entries(memsearch_dir=tmp_path)
+    assert [e["source"] for e in remaining] == ["new"]
+
+
+def test_prune_never_raises_on_missing_file(tmp_path: Path) -> None:
+    assert audit.prune(retention_days=90, memsearch_dir=tmp_path) == 0
+
+
+def test_audit_config_defaults() -> None:
+    from memsearch.config import MemSearchConfig
+
+    cfg = MemSearchConfig()
+    assert cfg.llm_audit.enabled is True
+    assert cfg.llm_audit.retention_days == 90


### PR DESCRIPTION
## Summary

Adds a local, append-only JSONL audit log for every background LLM call made by memsearch, per [Proposal 004](proposals/004-background-llm-audit.md).

- New `src/memsearch/audit.py`: `record()` / `report()` helpers writing one JSON line per call to `<memory>/.llm-audit.jsonl` (ts, source, provider, mode, status, duration, token counts, turn, error).
- Failures are recorded with `status=error` + real cause and never block the feature itself (audit write is best-effort).
- Retention: entries older than `retention_days` (default 90) are pruned on `memsearch index` startup.
- New config section `[llm_audit]` (`enabled`, `retention_days`).
- New CLI: `memsearch audit --days N` (token/call/failure table grouped by source) and `memsearch audit --errors` (last failures with causes).
- Summarize paths (`compact.py`) and the maintenance runner now record their LLM calls.

## Testing

- New `tests/test_audit.py`: record/prune/aggregate, failure lines, corrupted-line tolerance (9 tests).
- Full suite: `413 passed, 7 skipped` on Windows and on Ubuntu 24.04 (WSL2, Python 3.12) parity run.

## Out of scope (follow-ups)

- DSH JS-side hook for `dsh-headless` mode and the web dock widget (see Proposal 004).