### PR TITLE
docs(proposals): design proposals for consolidation, quality filter, heat archival

### DIFF
--- a/proposals/001-idle-consolidation.md
+++ b/proposals/001-idle-consolidation.md
@@ -1,0 +1,74 @@
+# Proposal 001: Idle LLM memory consolidation (autoDream-style)
+
+> Status: draft · Scope: core library + optional DSH/Claude plugin trigger
+> Inspired by dsh-mneme autoDream / Sleep Mode (modusensus/dsh-mneme).
+
+## Problem
+
+`memsearch compact` is a manual, whole-store summarization step. Nothing ever
+merges duplicate notes, adjudicates contradictory ones, or archives stale
+memory. Over months the markdown store grows monotonically and recall quality
+degrades (RRF surfaces superseded chunks alongside current ones).
+
+## Proposal
+
+Add an **automatic, threshold-triggered consolidation pass** over the markdown
+store, LLM-driven but validated and idempotent:
+
+1. **Trigger** (configurable, never blocks writes):
+   - after N new chunks indexed (default 200) or M chars appended (default 20k)
+     since the last run, debounced by 10 min;
+   - plus a manual `memsearch consolidate` CLI command.
+2. **Candidate selection**: group recent chunks by heading/source; feed the LLM
+   a bounded snapshot (newest-first sliding window, like mneme's
+   `dreamMaxSnapshotSize`), with per-chunk `source:startLine:endLine` anchors.
+3. **Decision list** — the LLM returns a JSON array of decisions only:
+   `keep | merge | archive | conflict | update`, each with explicit chunk ids.
+4. **Fail-safe application** (no LLM output is trusted):
+   - unknown ids, cross-file merges, invalid actions are skipped; the valid
+     subset applies; run is marked `degraded`;
+   - `merge`: keep the most information-complete section, fold others into it,
+     archive losers with a `superseded-by` note;
+   - `archive`: move to `<memory>/archive/YYYY-MM.md` — never physical delete
+     (markdown stays the source of truth, git history preserved);
+   - `conflict`: keep the winner, annotate the loser with provenance;
+   - `update`: in-place correction, max 2 per run, 24h age protection.
+5. **Audit**: append a run record to `<memory>/.consolidation.log`
+   (input snapshot sha256 + decision list + per-id disposition), replayable
+   offline; re-running the same decisions is a no-op.
+6. **Reindex**: after applying, re-index only touched files.
+
+## Configuration (TOML)
+
+```toml
+[consolidation]
+enabled = false          # opt-in first release
+threshold_chunks = 200
+threshold_chars = 20000
+delay_ms = 600000
+max_tokens = 32768       # mirrors mneme's dreamMaxTokens guidance
+prompt = "prompts.consolidate"  # [prompts] section, shared template style
+```
+
+LLM route reuses `[llm]` (same providers as `compact`).
+
+## Integration points
+
+- `src/memsearch/consolidate.py` (new): decision parse/validate/apply, audit.
+- `src/memsearch/core.py`: hook into `index()` epilogue (fire-and-forget task).
+- `src/memsearch/cli.py`: `memsearch consolidate` command.
+- `plugins/_shared/prompts/consolidate.txt`: shared template.
+
+## Testing
+
+- Unit: decision validation matrix (invalid ids, cross-type merge, overflow),
+  idempotent replay of an audit record, degraded-run marking.
+- Golden-file tests on a fixture markdown store.
+- Manual E2E in each platform plugin (DSH first: complete turns, confirm
+  consolidation fired and collection re-indexed).
+
+## Open questions
+
+- Should the DSH plugin trigger consolidation on `session/disposed` as well?
+- Interaction with the per-project collection model (consolidate per
+  collection only — cross-project merge is out of scope).

--- a/proposals/002-write-quality-filter.md
+++ b/proposals/002-write-quality-filter.md
@@ -1,0 +1,63 @@
+# Proposal 002: Pre-write memory quality filter
+
+> Status: draft · Scope: core library (capture path shared by all plugins)
+> Inspired by dsh-mneme `memoryQualityFilter` (v0.4.6).
+
+## Problem
+
+Automatic capture writes everything the summarizer emits: meta-comments about
+the memory system itself ("[memsearch] Recall available"), ultra-short notes,
+near-duplicates of yesterday's note, self-referential type tags. These pollute
+the index and dilute hybrid-search recall even when they never get injected.
+
+## Proposal
+
+Score every candidate section **before it is appended** to
+`memory/YYYY-MM-DD.md`. The scorer is a **pure function** — no I/O, no shared
+state, no LLM — mirroring mneme's design:
+
+Penalties (0–100 start):
+- meta-memory vocabulary (talks about the memory plugin itself), −25;
+- self-referential agent-verbosity boilerplate ("The user asked… I replied…"), −10;
+- content shorter than `min_content_length` chars after normalization, −30;
+- high token repetition ratio (> 0.6), −20;
+- near-duplicate of a section written in the last 48h (hash-shingle Jaccard
+  > 0.8 against the current day file), −40.
+
+Actions:
+- `score >= 60` → write normally;
+- `30 <= score < 60` → write, but record `quality` in the section anchor
+  comment and down-weight at search time (multiply normalized RRF score by
+  `quality/100`);
+- `score < 30` → do not append; log a one-line skip reason to stderr/DSH log.
+
+Unlike mneme we have no persistent DB, so "archived low quality" becomes
+"not written" — the transcript anchor already keeps the raw turn reachable,
+so no information is lost (progressive disclosure still works via `expand`).
+
+## Configuration
+
+```toml
+[quality_filter]
+enabled = true
+min_content_length = 40
+degrade_threshold = 60
+reject_threshold = 30
+```
+
+## Integration points
+
+- `src/memsearch/quality.py` (new): `score_section(text, recent_sections)`.
+- Capture paths: `plugins/dsh/index.js` summarize-then-append step,
+  `plugins/claude-code/hooks/stop.sh` pipeline, and the opencode capture
+  daemon — the score call should live in one shared place where possible
+  (a small `memsearch quality` CLI subcommand the shell hooks can call, or
+  the shared summarize scripts).
+- `src/memsearch/store.py`: optional `quality` scalar field + down-weighting
+  in the hybrid search scorer.
+
+## Testing
+
+- Unit: each penalty rule; boundary scores; pure-function property tests.
+- Regression: fixture capture corpus, verify skipped/degraded distribution is
+  sane (< 10% rejected on real conversational turns).

--- a/proposals/003-heat-and-cold-archive.md
+++ b/proposals/003-heat-and-cold-archive.md
@@ -1,0 +1,72 @@
+# Proposal 003: Heat decay and cold-memory archival
+
+> Status: draft · Scope: core library (index + search ranking)
+> Inspired by dsh-mneme heat model (v0.7.0 / restored v0.7.20) and Sleep
+> Mode phase 2 (archival demotion).
+
+## Problem
+
+All indexed chunks rank equally regardless of age or usage. A decision from
+six months ago that was never recalled competes with yesterday's active
+context. Milvus has no notion of "this memory is cold", so stale chunks keep
+surfacing in top-k.
+
+## Proposal
+
+1. **Heat per chunk** (power-law decay, mneme's formula):
+   `H = 1 / (1 + λ·Δt)^α`, `Δt` = days since last touch, defaults
+   `λ = 0.05`, `α = 2`. "Touch" = returned in a search result (recall) or
+   re-written by capture. Per-type half-lives: `decision` decays slowest,
+   `history` fastest (config table below).
+2. **Storage**: a `heat` FLOAT + `last_accessed` field on each chunk in
+   Milvus (schema migration; Lite and Server both support adding fields on
+   re-create — markdown stays the source of truth, so a full reindex is an
+   acceptable migration path).
+3. **Ranking**: multiply normalized RRF score by `0.5 + 0.5·H` — cold chunks
+   sink smoothly, never fully banned (explicit high-BM25 matches still win).
+4. **Cold archival** (maintenance task, off by default):
+   - not recalled in 30 days → chunk excluded from search but its section
+     stays in markdown untouched (soft, index-level only);
+   - 90 days → move section to `<memory>/archive/YYYY-MM.md` (with
+     `memsearch expand` still resolving via archive path);
+   - archival runs inside the Proposal 001 maintenance pass; dual protection
+     (age AND heat < 0.05) to avoid demoting recently-written-but-unrecalled
+     reference notes.
+
+## Configuration
+
+```toml
+[heat]
+enabled = false        # opt-in; OFF default preserves current ranking
+lambda = 0.05
+alpha = 2.0
+[heat.half_life_days]
+decision = 180
+preference = 120
+project = 90
+history = 30
+[cold_archive]
+enabled = false
+demote_days = 30
+archive_days = 90
+min_heat = 0.05
+```
+
+## Integration points
+
+- `src/memsearch/heat.py` (new): decay math + touch tracking.
+- `src/memsearch/store.py`: schema fields, touch-on-recall after hybrid
+  search, ranking multiplier.
+- `src/memsearch/scanner.py`: include `<memory>/archive/` with a `archived`
+  flag so `expand` keeps working.
+
+## Testing
+
+- Unit: decay curve values, half-life table, dual-protection gating.
+- Search integration: cold vs fresh chunk ordering; explicit keyword override.
+- Migration: reindex round-trip preserves heat defaults.
+
+## Open questions
+
+- Should `watch` mode update heat, or only explicit `search` calls (DSH
+  injects searches every turn — that alone may keep everything warm)?


### PR DESCRIPTION
## Summary

Adds three design proposals under `proposals/`, docs-only, inspired by mechanisms in dsh-mneme:

- **001 — Idle LLM memory consolidation (autoDream-style):** threshold-triggered, LLM-driven but fail-safe/idempotent merge/archive/adjudication pass over the markdown store, with a replayable audit log and manual `memsearch consolidate` CLI. Opt-in, never deletes markdown (archive only).
- **002 — Pre-write memory quality filter:** pure-function scorer (no LLM, no I/O) applied before appending to `memory/YYYY-MM-DD.md`; penalties for meta-memory vocabulary, boilerplate, ultra-short and near-duplicate content; write / down-weight / skip actions.
- **003 — Heat decay and cold-memory archival:** power-law heat per chunk (`H = 1/(1+λΔt)^α`), touch-on-recall, RRF ranking multiplier, and a two-stage cold archive (index-level demotion at 30d, markdown archival at 90d with dual protection).

All three are drafts for discussion — no code changes in this PR. Related implementation PR: #728 (Proposal 004, background LLM audit log).

## Testing

Docs-only change; no tests affected.