### PR TITLE
feat(dsh): configurable summarize profile and snapshotEvents compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,33 @@ jobs:
 
       - name: Pack package
         run: npm pack --dry-run
+
+  dsh:
+    name: DSH plugin (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: plugins/dsh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Check package entrypoints
+        run: |
+          node --check index.js
+          node --check client.js
+
+      - name: Test package
+        run: npm test
+
+      - name: Pack package
+        run: npm pack --dry-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Read `CLAUDE.md` before changing this repository. If `CLAUDE.local.md` exists, read it for machine-specific checkout paths, DSH profiles, and verification commands; never commit that local file.
+
+For DSH plugin work, use `plugins/dsh/README.md` and `docs/platforms/dsh/how-it-works.md` as the behavior owners. Keep changes cross-platform, update tests and documentation together, and verify native runtime behavior after unit tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ When modifying hooks/skills, keep in mind:
 - The `memory-recall` skill uses `context: fork` — the subagent has its own context window and does not see main conversation history
 - `transcript.py` lives in the plugin directory (not in core library) since it is entirely Claude Code JSONL-specific
 
+### DeepSeek Harness Plugin (`plugins/dsh/`)
+
+The DSH plugin is a plain ESM bundle with no build step. It captures `turn/end` from `session/event`, reads the immutable log through `session.snapshotEvents()`, writes the shared anchored markdown format, indexes each write, injects search results at `agent/pre-step`, and registers native memory skills. The browser half adds the read-only memory and skill-candidate dock to Web profiles.
+
+Run `node --test tests/*.test.js` from `plugins/dsh/` after each plugin change. A linked source install requires a DSH profile restart before production verification. Complete one Web turn, confirm the new markdown anchor and summary, then search the resolved collection. Child DSH processes must receive EOF on stdin and set `MEMSEARCH_DSH_SUMMARIZE=1` so the plugin stays inert inside summarization.
+
+See `plugins/dsh/README.md` for configuration and `docs/platforms/dsh/how-it-works.md` for lifecycle behavior.
+
 ## Key Design Decisions
 
 - **Markdown is the source of truth.** Milvus is a derived index, rebuildable anytime from `.md` files.

--- a/docs/platforms/dsh/how-it-works.md
+++ b/docs/platforms/dsh/how-it-works.md
@@ -55,7 +55,7 @@ The same markdown journal can contain entries produced by Claude Code, Codex, DS
 `summarizeMode` selects the capture backend:
 
 - **`auto`** (default) uses a configured `[plugins.dsh.summarize]` provider when present; otherwise it uses `dsh-headless`.
-- **`dsh-headless`** starts a one-shot headless DSH agent using the model selected by the DSH deployment. The child process disables the MemSearch plugin to prevent recursive capture.
+- **`dsh-headless`** starts a one-shot DSH agent from `summarizeProfile` (`headless` by default). A dedicated profile can select a cheaper summary model without changing the interactive agent. The child process disables the MemSearch plugin to prevent recursive capture.
 - **`custom-llm`** calls a provider from the shared MemSearch configuration directly, which is useful for assigning a small dedicated summarization model.
 
 There is no silent fallback to a different backend. If the selected summarizer is unavailable, the journal records a short unavailable note with the original transcript anchor instead of writing an unsummarized conversation dump.

--- a/docs/platforms/dsh/installation.md
+++ b/docs/platforms/dsh/installation.md
@@ -67,6 +67,7 @@ The plugin works without configuration. Its DSH profile settings control lifecyc
 | `injectEnabled` | `true` | Search and inject returned memory candidates before the first model step |
 | `summarizeEnabled` | `true` | Summarize turns before writing them |
 | `summarizeMode` | `auto` | Use a configured API provider when present; otherwise use a one-shot DSH headless agent |
+| `summarizeProfile` | `headless` | Select the DSH application profile used by the headless backend |
 
 To override these settings, patch the `memsearch` row in the profile's `cordis.patch.yml`:
 
@@ -76,6 +77,7 @@ To override these settings, patch the `memsearch` row in the profile's `cordis.p
     captureEnabled: true
     injectEnabled: true
     summarizeMode: auto
+    summarizeProfile: headless
 ```
 
 Embedding, Milvus, and provider settings continue to live in the shared MemSearch configuration. For example, to route DSH capture summarization through a configured provider:

--- a/plugins/_shared/skills/memory-config/references/dsh.md
+++ b/plugins/_shared/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/_shared/skills/memory-config/references/dsh.md
+++ b/plugins/_shared/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.

--- a/plugins/claude-code/skills/memory-config/references/dsh.md
+++ b/plugins/claude-code/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/claude-code/skills/memory-config/references/dsh.md
+++ b/plugins/claude-code/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.

--- a/plugins/codex/skills/memory-config/references/dsh.md
+++ b/plugins/codex/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/codex/skills/memory-config/references/dsh.md
+++ b/plugins/codex/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -23,6 +23,33 @@ review   ── web UI dock panel ──> GET/POST /memsearch-dsh/* ──> list
 - A DSH profile (web / headless / tui) you want to attach memory to.
 - Node >= 22.19 (DSH's requirement).
 
+### Native Windows
+
+The plugin runs natively in Windows PowerShell: it does not require Git Bash or
+WSL at runtime. It resolves `memsearch.exe`, `uv.exe`, `python.exe`, and
+`dsh.ps1` without a shell, so installation paths containing spaces are
+supported.
+
+For local Ollama embeddings, configure the native CLI as usual:
+
+```powershell
+uv tool install "memsearch[ollama]"
+memsearch config set embedding.provider ollama
+memsearch config set embedding.model nomic-embed-text-v2-moe:latest
+memsearch config set embedding.base_url http://localhost:11434
+```
+
+The currently published `memsearch` 0.4.19 package still rejects Milvus Lite on
+Windows. Until the next release includes the upstream Windows support, install
+from `main` for a local Milvus Lite store, or set `[milvus] uri` to a remote
+Milvus server:
+
+```powershell
+uv tool install --force "memsearch[ollama] @ git+https://github.com/zilliztech/memsearch"
+```
+
+Native Windows configuration lives in `%USERPROFILE%\.memsearch\config.toml`.
+
 ## Install
 
 ### From npm (recommended)
@@ -80,11 +107,12 @@ Everything else — provider/model, Milvus, collection, memory dir — comes fro
 (no per-plugin config fields):
 
 - **Summarize provider/model** → `[plugins.dsh.summarize] provider` / `model`
-  in `~/.memsearch/config.toml` (or `[llm.providers.*]`; see the
-  `custom-llm` section below).
+  in `~/.memsearch/config.toml` (`%USERPROFILE%\.memsearch\config.toml` on
+  Windows), or `[llm.providers.*]`; see the `custom-llm` section below.
 - **Milvus** → `[milvus] uri` in memsearch config.
-- **Collection** → derived from the project path (`derive-collection.sh`),
-  or `--collection` passed to the memsearch CLI.
+- **Collection** → derived from the project path in JavaScript (matching the
+  legacy `derive-collection.sh` algorithm), or `--collection` passed to the
+  memsearch CLI.
 - **Memory dir** → `MEMSEARCH_DIR` env (explicit → global scope), else
   `<project>/.memsearch`.
 

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -101,6 +101,7 @@ block (patch the `memsearch` row you inserted). All keys are optional.
 | `injectEnabled` | bool | `true` | Inject returned memory candidates before each turn's first step. |
 | `summarizeEnabled` | bool | `true` | Summarize turns before writing (on failure a short unavailable note is written, never a raw dump). |
 | `summarizeMode` | string | `auto` | Summarizer backend. `auto` (default) mirrors the other platform plugins: if `[plugins.dsh.summarize] provider` is set in memsearch config, it uses `custom-llm`; otherwise `dsh-headless` (zero-config DSH agent). Explicit `dsh-headless` / `custom-llm` pin the backend. |
+| `summarizeProfile` | string | `headless` | DSH application profile started by the `dsh-headless` backend. Use a dedicated profile to isolate a cheaper summary model from the interactive agent. |
 
 Everything else — provider/model, Milvus, collection, memory dir — comes from
 **memsearch config / environment**, exactly like the other platform plugins
@@ -142,7 +143,8 @@ Example override layer (add this to the profile's own `cordis.patch.yml`):
 ```yaml
 - id: memsearch
   config:
-    summarizeMode: dsh-headless   # pin the headless backend (default is auto)
+    summarizeMode: dsh-headless       # pin the headless backend (default is auto)
+    summarizeProfile: memsearch-summary # isolate a dedicated summary model
 ```
 
 ### Summarization modes
@@ -161,7 +163,7 @@ a direct LLM call; configure nothing and you get a headless agent.
   This means the plugin behaves like the other four: **configure a provider
   → direct LLM; configure nothing → headless**.
 - **`dsh-headless`** — boots a one-shot DSH headless agent
-  (`dsh --profile headless "<summarize task>"`) to write the notes, mirroring
+  (`dsh --profile <summarizeProfile> "<summarize task>"`) to write the notes, mirroring
   how the other plugins reuse their own agent's headless mode. Zero-config for
   anyone already using DSH: the sub-agent's model is the deployment's
   `agent-default-model` — the user layer of `~/.dsh/settings.yaml` (the same

--- a/plugins/dsh/cordis.patch.yml
+++ b/plugins/dsh/cordis.patch.yml
@@ -23,6 +23,8 @@
         #   injectEnabled (bool, default true)    — inject returned memory candidates
         #   summarizeEnabled (bool, default true) — summarize turns before writing
         #   summarizeMode (string, default 'auto')
+        #   summarizeProfile (string, default 'headless') — DSH profile used by
+        #                          the dsh-headless backend
         #       -> 'auto'         if [plugins.dsh.summarize] provider is set in
         #                          memsearch config → custom-llm, else
         #                          dsh-headless (zero-config)

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -30,6 +30,7 @@
  */
 
 import { execFile, execFileSync, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   appendFileSync,
   existsSync,
@@ -41,7 +42,8 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { createRequire } from 'node:module'
-import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { homedir } from 'node:os'
+import { basename, delimiter, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url))
@@ -66,9 +68,125 @@ const MAINTENANCE_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6h; runner's due-state gat
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Shell-escape a string for safe use inside single quotes. */
-function shellEscape(s) {
-  return String(s).replace(/'/g, "'\\''")
+/** User home used for cross-platform executable and skill-path fallbacks. */
+function runtimeHome() {
+  return process.env.HOME || process.env.USERPROFILE || homedir()
+}
+
+/** Resolve one executable without invoking a shell. */
+function resolveExecutable(command, options = {}) {
+  const platform = options.platform || process.platform
+  const pathValue = options.path === undefined ? process.env.PATH || '' : options.path
+  const pathExt = options.pathExt === undefined ? process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD' : options.pathExt
+  const extensions = platform === 'win32' && !extname(command)
+    ? pathExt.split(';')
+      .filter(Boolean)
+      // Node's direct process APIs cannot launch cmd/bat files. PowerShell
+      // shims are handled explicitly by detectDshCmd().
+      .filter((value) => !/^\.(?:bat|cmd)$/i.test(value))
+      .map((value) => value.toLowerCase())
+    : ['']
+  const roots = isAbsolute(command) || command.includes('/') || command.includes('\\')
+    ? ['']
+    : pathValue.split(delimiter).filter(Boolean)
+  for (const root of roots) {
+    const base = root ? join(root.replace(/^"|"$/g, ''), command) : command
+    for (const extension of extensions) {
+      const candidates = extension ? [base + extension, base + extension.toUpperCase()] : [base]
+      for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate
+      }
+    }
+  }
+  return null
+}
+
+/** Normalize a command string, argv array, or command spec. */
+function commandSpec(command) {
+  if (Array.isArray(command)) return { file: command[0], args: command.slice(1) }
+  if (command && typeof command === 'object') return { file: command.file, args: command.args || [] }
+  return { file: String(command), args: [] }
+}
+
+/** Execute a command spec synchronously without shell parsing. */
+function execCommandSync(command, args, options) {
+  const spec = commandSpec(command)
+  return execFileSync(spec.file, [...spec.args, ...args], options)
+}
+
+/** Execute a command spec asynchronously without shell parsing. */
+function execCommand(command, args, options, callback) {
+  const spec = commandSpec(command)
+  return execFile(spec.file, [...spec.args, ...args], options, callback)
+}
+
+/** Return whether a Python Launcher version selector can start an interpreter. */
+function pythonLauncherAvailable(launcher, version) {
+  try {
+    execFileSync(launcher, [version, '-c', 'import sys'], { stdio: 'ignore', timeout: 3000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Resolve Python for plugin helper scripts. */
+function detectPythonCmd() {
+  const explicit = process.env.MEMSEARCH_PYTHON
+  if (explicit) {
+    if (explicit.trim().startsWith('[')) {
+      try {
+        const argv = JSON.parse(explicit)
+        if (Array.isArray(argv) && argv.length > 0 && argv.every((value) => typeof value === 'string')) return argv
+      } catch {
+        // Fall through to executable discovery below.
+      }
+    } else {
+      return [explicit]
+    }
+  }
+  const python3 = resolveExecutable('python3')
+  if (python3 && !(process.platform === 'win32' && /WindowsApps[\\/]python3\.exe$/i.test(python3))) {
+    return [python3]
+  }
+  if (process.platform === 'win32') {
+    const launcher = resolveExecutable('py')
+    if (launcher) {
+      for (const version of ['-3.12', '-3']) {
+        if (pythonLauncherAvailable(launcher, version)) return [launcher, version]
+      }
+    }
+  }
+  const python = resolveExecutable('python')
+  return python ? [python] : null
+}
+
+/** Render a command spec for runtime skill instructions. */
+function commandForSkill(command) {
+  const spec = commandSpec(command)
+  const quote = (value) => `"${String(value).replace(/"/g, '\\"')}"`
+  return [spec.file, ...spec.args].map((value) => /\s/.test(value) ? quote(value) : value).join(' ')
+}
+
+/** Open a directory with the platform file manager and report launch errors. */
+function openDirectory(dir) {
+  const opener = process.platform === 'win32'
+    ? 'explorer.exe'
+    : process.platform === 'darwin'
+      ? 'open'
+      : 'xdg-open'
+  // A headless server may have no desktop opener at all; that is not an error
+  // (the response still carries the path for the client to show).
+  const executable = resolveExecutable(opener)
+  if (!executable) return Promise.resolve(false)
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, [dir], { detached: true, stdio: 'ignore' })
+    child.once('error', reject)
+    child.once('spawn', () => {
+      child.unref()
+      resolve(true)
+    })
+  })
 }
 
 let dshLlmModule = null
@@ -139,47 +257,33 @@ async function createMemoryMessage(ctx, text) {
   })
 }
 
-/**
- * Detect the memsearch CLI command: installed binary on PATH first, then the
- * uvx fallback, then a bare `memsearch` best effort.
- *
- * `command -v` is resolved through bash so the check sees the same PATH the
- * later `bash -c` invocations use; calling `which` as a direct executable
- * bypasses shell built-ins and can miss the installed tool.
- */
+/** Detect the memsearch CLI as an executable plus fixed leading arguments. */
 function detectMemsearchCmd() {
-  const home = process.env.HOME || ''
-  const onPath = (cmd) => {
-    try {
-      execFileSync('bash', ['-c', `command -v ${cmd} >/dev/null 2>&1`], { stdio: 'pipe' })
-      return true
-    } catch {
-      return false
-    }
-  }
-  if (onPath('memsearch')) return 'memsearch'
-  const uvxPath = join(home, '.local', 'bin', 'uvx')
-  const uvxBin = existsSync(uvxPath) ? uvxPath : (onPath('uvx') ? 'uvx' : '')
-  if (uvxBin) {
-    return `${uvxBin} --from 'memsearch[onnx]' memsearch`
-  }
-  return 'memsearch'
+  const onPath = resolveExecutable('memsearch')
+  if (onPath) return [onPath]
+  const localUvx = join(runtimeHome(), '.local', 'bin', process.platform === 'win32' ? 'uvx.exe' : 'uvx')
+  const uvx = existsSync(localUvx) ? localUvx : resolveExecutable('uvx')
+  if (uvx) return [uvx, '--from', 'memsearch[onnx]', 'memsearch']
+  return ['memsearch']
 }
 
-/** Derive the per-project Milvus collection name via the shared script. */
+/** Derive the per-project Milvus collection name without a platform shell. */
 function deriveCollection(projectDir, override) {
   if (override) return override
-  const script = join(PLUGIN_DIR, 'scripts', 'derive-collection.sh')
+  let absolute = resolve(projectDir)
   try {
-    const result = execFileSync('bash', [script, projectDir], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-    return result.trim() || undefined
+    absolute = realpathSync(absolute)
   } catch {
-    return undefined
+    // Nonexistent paths keep their resolved absolute spelling, matching realpath -m.
   }
+  const sanitized = basename(absolute)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 40)
+  const hash = createHash('sha256').update(absolute).digest('hex').slice(0, 8)
+  return `ms_${sanitized}_${hash}`
 }
 
 /**
@@ -199,9 +303,7 @@ function deriveCollection(projectDir, override) {
  */
 function readMemsearchConfigValue(memsearchCmd, key) {
   try {
-    // memsearchCmd may be a full command line (e.g. `uvx --from 'memsearch[onnx]' memsearch`),
-    // so route through bash rather than execFileSync's single executable.
-    const result = execFileSync('bash', ['-c', `${memsearchCmd} config get '${key}'`], {
+    const result = execCommandSync(memsearchCmd, ['config', 'get', key], {
       encoding: 'utf-8',
       timeout: 5000,
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -306,12 +408,9 @@ function hhmmStr() {
 // Search / index (memsearch CLI)
 // ---------------------------------------------------------------------------
 
-/**
- * `--milvus-uri '<uri>'` CLI flag when a dedicated Milvus is configured for the
- * profile; empty otherwise (memsearch falls back to its own config).
- */
-function milvusUriFlag(milvusUri) {
-  return milvusUri ? `--milvus-uri '${shellEscape(milvusUri)}' ` : ''
+/** CLI arguments for a dedicated Milvus URI, or none for MemSearch config. */
+function milvusUriArgs(milvusUri) {
+  return milvusUri ? ['--milvus-uri', milvusUri] : []
 }
 
 /**
@@ -321,14 +420,16 @@ function milvusUriFlag(milvusUri) {
  */
 function runSearch(memsearchCmd, query, collection, projectDir, milvusUri) {
   return new Promise((resolve) => {
-    const command =
-      `${memsearchCmd} search '${shellEscape(query)}' ` +
-      `--top-k ${SEARCH_TOP_K} --json-output ` +
-      `${milvusUriFlag(milvusUri)}` +
-      `--collection '${shellEscape(collection)}'`
-    execFile(
-      'bash',
-      ['-c', command],
+    const args = [
+      'search', query,
+      '--top-k', String(SEARCH_TOP_K),
+      '--json-output',
+      ...milvusUriArgs(milvusUri),
+      '--collection', collection,
+    ]
+    execCommand(
+      memsearchCmd,
+      args,
       { cwd: projectDir, timeout: SEARCH_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
       (error, stdout) => {
         if (error) return resolve(null)
@@ -346,14 +447,11 @@ function runSearch(memsearchCmd, query, collection, projectDir, milvusUri) {
 /** Fire-and-forget `memsearch index` refresh for a project. */
 function indexMemory(ctx, memsearchCmd, memoryDir, collection, projectDir, milvusUri) {
   if (!existsSync(memoryDir)) return
-  const command =
-    `${memsearchCmd} index '${shellEscape(memoryDir)}' ` +
-    `${milvusUriFlag(milvusUri)}` +
-    `--collection '${shellEscape(collection)}'`
+  const args = ['index', memoryDir, ...milvusUriArgs(milvusUri), '--collection', collection]
   // Detached + unref so the index survives the DSH process: a headless or
   // one-shot session can exit right after the turn that wrote the memory, and
   // an ordinary child would be torn down with the parent before indexing.
-  const child = execFile('bash', ['-c', command], {
+  const child = execCommand(memsearchCmd, args, {
     cwd: projectDir,
     timeout: 120000,
     maxBuffer: 4 * 1024 * 1024,
@@ -366,24 +464,17 @@ function indexMemory(ctx, memsearchCmd, memoryDir, collection, projectDir, milvu
   child.unref()
 }
 
-/**
- * Run the shared maintenance runner (PROJECT.md / USER.md upkeep and
- * memory-to-skill distillation) for a project, fire-and-forget.
- *
- * Mirrors the other platform plugins: the runner is a due-state machine —
- * each task runs at most once per `min_interval_hours` and only when
- * `[plugins.dsh.<task>].enabled` is true in memsearch config. A missing
- * memsearch CLI or python3 is a no-op (the runner also checks internally).
- */
+/** Run optional PROJECT.md, USER.md, and memory-to-skill upkeep. */
 function runMaintenance(ctx, projectDir, memsearchDir) {
   const runner = join(PLUGIN_DIR, 'scripts', 'maintenance-runner.py')
-  if (!existsSync(runner)) return
-  const command =
-    `MEMSEARCH_NO_WATCH=1 python3 '${shellEscape(runner)}' ` +
-    `--platform dsh ` +
-    `--project-dir '${shellEscape(projectDir)}' ` +
-    `--memsearch-dir '${shellEscape(memsearchDir)}'`
-  const child = execFile('bash', ['-c', command], {
+  const python = detectPythonCmd()
+  if (!existsSync(runner) || !python) return
+  const child = execCommand(python, [
+    runner,
+    '--platform', 'dsh',
+    '--project-dir', projectDir,
+    '--memsearch-dir', memsearchDir,
+  ], {
     cwd: projectDir,
     timeout: 180000,
     maxBuffer: 4 * 1024 * 1024,
@@ -464,11 +555,11 @@ function resolveSkillInstallTarget(memsearchCmd, projectDir) {
       const paths = JSON.parse(read.value)
       if (Array.isArray(paths) && paths.length > 0) {
         const first = String(paths[0])
-        return join(first.startsWith('/') ? first : projectDir, first)
+        return isAbsolute(first) ? first : resolve(projectDir, first)
       }
     } catch { /* fall through to the DSH default */ }
   }
-  return join(process.env.HOME || '', '.agents', 'skills')
+  return join(runtimeHome(), '.agents', 'skills')
 }
 
 /** Hard cap for read-file payloads (protects the browser from huge files). */
@@ -580,10 +671,7 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       // skill-filesystem watcher picks up the new SKILL.md automatically.
       const projectDir = projectDirForSession(sessionId)
       const target = resolveSkillInstallTarget(memsearchCmd, projectDir)
-      const command =
-        `${memsearchCmd} skills install '${shellEscape(name)}' ` +
-        `--path '${shellEscape(target)}'`
-      const child = execFile('bash', ['-c', command], {
+      const child = execCommand(memsearchCmd, ['skills', 'install', name, '--path', target], {
         cwd: projectDir,
         timeout: 60000,
         maxBuffer: 4 * 1024 * 1024,
@@ -611,18 +699,13 @@ function registerSkillReviewRoutes(ctx, webServer, memsearchCmd) {
       if (!existsSync(dir)) {
         return sendJson(res, 404, { ok: false, error: `no such directory: ${dir}`, path: dir })
       }
-      // Open the directory in the local file manager (xdg-open on Linux). The
-      // response is success regardless of whether a desktop is present; the
-      // path is returned so the client can show it if nothing opens.
-      const child = execFile('xdg-open', [dir], {
-        detached: true,
-        stdio: 'ignore',
-        timeout: 10000,
-      }, (error) => {
-        if (error) ctx.logger.warn(`[memsearch] open dir failed: ${error.message}`)
-      })
-      child.unref()
-      return sendJson(res, 200, { ok: true, path: dir })
+      try {
+        const opened = await openDirectory(dir)
+        return sendJson(res, 200, { ok: true, opened, path: dir })
+      } catch (error) {
+        ctx.logger.warn(`[memsearch] open dir failed: ${error.message}`)
+        return sendJson(res, 500, { ok: false, error: error.message, path: dir })
+      }
     },
   })
 
@@ -818,6 +901,8 @@ function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
  */
 function summarizeCustomLlm(opts, render, projectDir) {
   return new Promise((resolve, reject) => {
+    const python = detectPythonCmd()
+    if (!python) return reject(new Error('Python 3 not found; set MEMSEARCH_PYTHON to its executable path'))
     const args = [
       join(PLUGIN_DIR, 'scripts', 'summarize.py'),
       '--agent-name', opts.agentName,
@@ -825,24 +910,30 @@ function summarizeCustomLlm(opts, render, projectDir) {
     ]
     if (opts.summarizeProvider) args.push('--provider', opts.summarizeProvider)
     if (opts.summarizeModel) args.push('--model', opts.summarizeModel)
-    const child = spawn('python3', args, { cwd: projectDir })
+    const spec = commandSpec(python)
+    const child = spawn(spec.file, [...spec.args, ...args], { cwd: projectDir })
     let stdout = ''
     let stderr = ''
+    let settled = false
+    let timer
+    const finish = (callback) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      callback()
+    }
     child.stdout.on('data', (data) => { stdout += data })
     child.stderr.on('data', (data) => { stderr += data })
-    child.on('error', reject)
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(stdout.trim() || null)
-      } else {
-        reject(new Error(stderr.trim() || `summarize.py exited with status ${code}`))
-      }
-    })
+    child.on('error', (error) => finish(() => reject(error)))
+    child.on('close', (code) => finish(() => {
+      if (code === 0) resolve(stdout.trim() || null)
+      else reject(new Error(stderr.trim() || `summarize.py exited with status ${code}`))
+    }))
     child.stdin.write(render)
     child.stdin.end()
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       try { child.kill('SIGKILL') } catch { /* already exited */ }
-      reject(new Error('summarization timed out'))
+      finish(() => reject(new Error('summarization timed out')))
     }, SUMMARIZE_TIMEOUT_MS)
     timer.unref?.()
   })
@@ -859,20 +950,39 @@ function summarizeCustomLlm(opts, render, projectDir) {
  * cannot treat as a single executable.
  */
 function detectDshCmd() {
-  const onPath = (cmd) => {
+  const json = process.env.MEMSEARCH_DSH_COMMAND_JSON
+  if (json) {
     try {
-      execFileSync('bash', ['-c', `command -v ${cmd} >/dev/null 2>&1`], { stdio: 'pipe' })
-      return true
+      const argv = JSON.parse(json)
+      if (Array.isArray(argv) && argv.length > 0 && argv.every((value) => typeof value === 'string')) return argv
     } catch {
-      return false
+      // Fall through to the legacy override and executable discovery.
     }
   }
-  if (onPath('dsh')) return ['dsh']
   const fromEnv = process.env.DSH_CLI
-  if (fromEnv) return fromEnv.split(/\s+/).filter(Boolean)
-  const home = process.env.HOME || ''
-  const pnpmBin = join(home, '.local', 'share', 'pnpm')
-  if (existsSync(join(pnpmBin, 'dsh'))) return [join(pnpmBin, 'dsh')]
+  if (fromEnv) {
+    const argv = []
+    for (const match of fromEnv.matchAll(/"([^"]*)"|'([^']*)'|(\S+)/g)) {
+      argv.push(match[1] ?? match[2] ?? match[3])
+    }
+    if (argv.length > 0) return argv
+  }
+  if (process.platform === 'win32') {
+    const script = resolveExecutable('dsh.ps1')
+    const shell = resolveExecutable('pwsh') || resolveExecutable('powershell')
+    if (script && shell) return [shell, '-NoProfile', '-File', script]
+  }
+  const executable = resolveExecutable('dsh')
+  if (executable && !/\.(cmd|bat)$/i.test(executable)) return [executable]
+  const pnpmBin = join(runtimeHome(), '.local', 'share', 'pnpm')
+  const fallback = join(pnpmBin, process.platform === 'win32' ? 'dsh.ps1' : 'dsh')
+  if (existsSync(fallback)) {
+    if (process.platform === 'win32') {
+      const shell = resolveExecutable('pwsh') || resolveExecutable('powershell')
+      return shell ? [shell, '-NoProfile', '-File', fallback] : null
+    }
+    return [fallback]
+  }
   return null
 }
 
@@ -987,10 +1097,11 @@ function registerMemoryRecallSkill(ctx, opts, memsearchCmd, collection, projectD
     .replace(/^﻿?---[\s\S]*?---\s*/u, '') // strip optional YAML frontmatter
     .replace(/^<!--[\s\S]*?-->\s*/u, '') // strip the human-facing metadata comment
     .replaceAll('{{AGENT_NAME}}', agentName)
-    .replaceAll('{{MEMSEARCH_CMD}}', memsearchCmd)
+    .replaceAll('{{MEMSEARCH_CMD}}', typeof memsearchCmd === 'string' ? memsearchCmd : commandForSkill(memsearchCmd))
+    .replaceAll('{{PYTHON_CMD}}', commandForSkill(detectPythonCmd() ?? ['python3']))
     .replaceAll('{{PLUGIN_DIR}}', PLUGIN_DIR)
     .replaceAll('{{PROJECT_DIR}}', projectDir)
-    .replaceAll('{{COLLECTION}}', collection || `$(bash "${PLUGIN_DIR}/scripts/derive-collection.sh")`)
+    .replaceAll('{{COLLECTION}}', collection || deriveCollection(PLUGIN_DIR, ''))
     .replaceAll('{{MILVUS_FLAG}}', opts.milvusUri ? `--milvus-uri "${opts.milvusUri}" ` : '')
   ctx.skills.register({
     name: 'memory-recall',
@@ -1299,6 +1410,18 @@ export function apply(ctx, config = {}) {
 // ---------------------------------------------------------------------------
 // Exports for tests / external use
 // ---------------------------------------------------------------------------
+
+/** Resolve an executable through PATH without shell parsing. */
+export { resolveExecutable }
+
+/** Detect the memsearch CLI as an argv spec. */
+export { detectMemsearchCmd }
+
+/** Derive the per-project Milvus collection name. */
+export { deriveCollection }
+
+/** Detect the Python interpreter used for plugin helper scripts. */
+export { detectPythonCmd }
 
 /** Detect the dsh CLI command used by `summarizeMode: dsh-headless`. */
 export { detectDshCmd }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -942,12 +942,13 @@ function summarizeCustomLlm(opts, render, projectDir) {
 /**
  * Resolve the dsh CLI command for one-shot headless summarization.
  *
- * `dsh` may not be on PATH (it is a pnpm-installed workspace bin). We check
- * PATH first, then `DSH_CLI` as an explicit override, then the pnpm global
- * bin directory. Returns the command as an argv array (`[cmd, ...args]`),
- * or null when not found. The array form is required because `DSH_CLI` may
- * be an interpreter invocation (e.g. `node /path/to/bin.js`), which `spawn`
- * cannot treat as a single executable.
+ * `dsh` may not be on PATH (it is a pnpm-installed workspace bin). Explicit
+ * environment overrides win first — `MEMSEARCH_DSH_COMMAND_JSON` (a JSON argv
+ * array), then `DSH_CLI` (a quoted shell-style command line) — then executable
+ * discovery on PATH, then the pnpm global bin directory. Returns the command
+ * as an argv array (`[cmd, ...args]`), or null when not found. The array form
+ * is required because the overrides may be an interpreter invocation (e.g.
+ * `node /path/to/bin.js`), which `spawn` cannot treat as a single executable.
  */
 function detectDshCmd() {
   const json = process.env.MEMSEARCH_DSH_COMMAND_JSON
@@ -1101,7 +1102,7 @@ function registerMemoryRecallSkill(ctx, opts, memsearchCmd, collection, projectD
     .replaceAll('{{PYTHON_CMD}}', commandForSkill(detectPythonCmd() ?? ['python3']))
     .replaceAll('{{PLUGIN_DIR}}', PLUGIN_DIR)
     .replaceAll('{{PROJECT_DIR}}', projectDir)
-    .replaceAll('{{COLLECTION}}', collection || deriveCollection(PLUGIN_DIR, ''))
+    .replaceAll('{{COLLECTION}}', collection || deriveCollection(projectDir, ''))
     .replaceAll('{{MILVUS_FLAG}}', opts.milvusUri ? `--milvus-uri "${opts.milvusUri}" ` : '')
   ctx.skills.register({
     name: 'memory-recall',

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -823,7 +823,7 @@ function sessionLogPath(ctx, session) {
  */
 function renderTurn(session, turnEndEvent) {
   const turn = turnEndEvent.data.turn
-  const events = session.events
+  const events = session.snapshotEvents()
   const startIndex = events.findIndex(
     (event) => event.type === 'turn/start' && event.data.turn === turn,
   )
@@ -988,8 +988,8 @@ function detectDshCmd() {
 }
 
 /**
- * Summarize one rendered turn by booting a one-shot DSH headless agent
- * (`dsh --profile headless`), mirroring how the Claude Code / Codex / OpenCode
+ * Summarize one rendered turn by booting a one-shot DSH agent from the
+ * configured summary profile (`headless` by default), mirroring how the Claude Code / Codex / OpenCode
  * plugins reuse their own agent's headless mode with a small model.
  *
  * The headless profile is the same one the user already has; the plugin does
@@ -1025,11 +1025,12 @@ function summarizeHeadless(ctx, opts, render, projectDir) {
     }
     const task = `${systemPrompt}\n\nTranscript:\n${render}`
 
-    const args = ['--profile', 'headless', task]
+    const args = ['--profile', opts.summarizeProfile || 'headless', task]
 
     const child = spawn(dshCmd[0], [...dshCmd.slice(1), ...args], {
       cwd: projectDir,
       env: { ...process.env, MEMSEARCH_DSH_SUMMARIZE: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
     })
     let stdout = ''
     let stderr = ''
@@ -1206,6 +1207,7 @@ export function apply(ctx, config = {}) {
     injectEnabled: config.injectEnabled !== false,
     summarizeEnabled: config.summarizeEnabled !== false,
     summarizeMode: config.summarizeMode,
+    summarizeProfile: config.summarizeProfile,
   }
 
   const memsearchCmd = detectMemsearchCmd()

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -84,7 +84,7 @@ def ensure_memsearch_importable(transcript: str = "") -> None:
         reexec_env["MEMSEARCH_DSH_TRANSCRIPT"] = transcript
 
     memsearch_bin = _which("memsearch")
-    if memsearch_bin:
+    if memsearch_bin and not memsearch_bin.lower().endswith((".exe", ".cmd", ".bat", ".com")):
         try:
             first_line = Path(memsearch_bin).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
             if first_line.startswith("#!"):
@@ -119,12 +119,20 @@ def ensure_memsearch_importable(transcript: str = "") -> None:
 
 def _which(name: str) -> str | None:
     """Return the first PATH match for ``name`` (no shell involved)."""
+    candidates = [name]
+    if os.name == "nt" and not Path(name).suffix:
+        # Windows resolves bare names through PATHEXT; memsearch installs as
+        # memsearch.exe, uv as uv.exe. Insert the default set after any
+        # explicit suffix so the plain name is still tried first.
+        pathext = os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        candidates.extend(f"{name}{ext}" for ext in pathext.split(os.pathsep) if ext)
     for directory in os.environ.get("PATH", "").split(os.pathsep):
         if not directory:
             continue
-        candidate = Path(directory) / name
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return str(candidate)
+        for candidate_name in candidates:
+            candidate = Path(directory) / candidate_name
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
     return None
 
 

--- a/plugins/dsh/skills/memory-config/references/dsh.md
+++ b/plugins/dsh/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/dsh/skills/memory-config/references/dsh.md
+++ b/plugins/dsh/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.

--- a/plugins/dsh/skills/memory-recall/SKILL.md
+++ b/plugins/dsh/skills/memory-recall/SKILL.md
@@ -44,7 +44,7 @@ When an expanded result contains an anchor comment like
 you can render the original conversation around that turn:
 
 ```bash
-python3 {{PLUGIN_DIR}}/scripts/parse-transcript.py --db "<path>" --turn <N> --context 3
+{{PYTHON_CMD}} {{PLUGIN_DIR}}/scripts/parse-transcript.py --db "<path>" --turn <N> --context 3
 ```
 
 Pass `--context 0` for just the target turn, or omit `--turn` to see the most recent turns.
@@ -56,5 +56,5 @@ Return a concise summary of the relevant context to the user, citing the memory 
 ## Notes
 
 - The memory store is plain markdown under `<project>/.memsearch/memory/YYYY-MM-DD.md`. Milvus is a derived search index; a chunk may be indexed slightly behind the markdown source.
-- If `memsearch` is not on PATH, prefix with the detected command `{{MEMSEARCH_CMD}}` (which may be `uvx --from 'memsearch[onnx]' memsearch`).
+- The commands above work in bash and PowerShell alike: `{{MEMSEARCH_CMD}}` and `{{PYTHON_CMD}}` are pre-resolved for this machine. If `memsearch` is not on PATH, the prefix may be a `uvx --from 'memsearch[onnx]' memsearch` fallback.
 - Prefer the final, user-facing outcome over raw transcript detail.

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -476,7 +476,7 @@ test('apply: summarizeEnabled:false writes the raw transcript (no summarizer)', 
   const session = {
     id: 'session-raw-test',
     header: { cwd: projDir },
-    events: [
+    snapshotEvents: () => [
       { type: 'turn/start', data: { turn: 1 } },
       { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'remember raw-marker-001' }] } },
       { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'ok' }] } } },
@@ -528,7 +528,7 @@ test('apply: summarize failure writes unavailable note (not raw)', async () => {
     const session = {
       id: 'session-fail-test',
       header: { cwd: projDir },
-      events: [
+      snapshotEvents: () => [
         { type: 'turn/start', data: { turn: 1 } },
         { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'secret raw content that must not leak' }] } },
         { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'ok' }] } } },
@@ -580,7 +580,7 @@ test('apply: multi-project capture writes to each project memory dir', async () 
     const mkSession = (id, cwd, marker) => ({
       id,
       header: { cwd },
-      events: [
+      snapshotEvents: () => [
         { type: 'turn/start', data: { turn: 1 } },
         { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: marker }] } },
         { type: 'turn/end', data: { turn: 1 } },
@@ -655,13 +655,15 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   fs.writeFileSync(
     recorder,
     'import { writeFileSync } from "node:fs";\n' +
-    `writeFileSync(${JSON.stringify(argvFile)}, process.argv.slice(2).join("\\n"));\n`,
+    'process.stdin.resume();\n' +
+    `process.stdin.once("end", () => writeFileSync(${JSON.stringify(argvFile)}, process.argv.slice(2).join("\\n")));\n`,
     'utf-8',
   )
   try {
     process.env.DSH_CLI = `"${process.execPath}" "${recorder}"`
     const opts = {
       summarizeMode: 'dsh-headless',
+      summarizeProfile: 'memsearch-summary',
       agentName: 'X',
       summarizeProvider: 'deepseek-zilliz',
       summarizeModel: 'deepseek-v4-pro',
@@ -671,6 +673,7 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
     const summary = await summarizeTurn(ctx, opts, render, process.cwd())
     assert.equal(summary, null, 'recorder exits 0 with no stdout -> null summary')
     const recorded = fs.readFileSync(argvFile, 'utf-8').trim().split('\n')
+    assert.equal(recorded[recorded.indexOf('--profile') + 1], 'memsearch-summary', 'configured summary profile')
     assert.ok(
       !recorded.includes('--patch'),
       `headless summarize must not pass --patch; got argv: ${JSON.stringify(recorded)}`,
@@ -691,7 +694,7 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
 
 test('renderTurn: renders user/assistant/tool events into the shared format', () => {
   const session = {
-    events: [
+    snapshotEvents: () => [
       { type: 'turn/start', data: { turn: 7 } },
       { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'hello there' }] } },
       { type: 'tool/call', data: { name: 'bash' } },
@@ -708,7 +711,7 @@ test('renderTurn: renders user/assistant/tool events into the shared format', ()
 
 test('renderTurn: returns null when no user message', () => {
   const session = {
-    events: [
+    snapshotEvents: () => [
       { type: 'turn/start', data: { turn: 1 } },
       { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'only assistant' }] } } },
       { type: 'turn/end', data: { turn: 1 } },

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -4,8 +4,9 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-import { detectDshCmd, resolveExecutable, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
+import { detectDshCmd, resolveExecutable, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget, deriveCollection } from '../index.js'
 
 test('resolveExecutable: Windows skips cmd and bat shims for direct spawn', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'msr-exe-'))
@@ -109,8 +110,39 @@ async function withInjectionFixture(searchResults, assertion) {
   }
 }
 
+test('deriveCollection: JavaScript port matches derive-collection.sh', {
+  skip: process.platform === 'win32' && 'the bash script uses POSIX path semantics; the win32 runtime derivation is JavaScript-only',
+}, () => {
+  const script = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'derive-collection.sh')
+  for (const projectDir of [
+    '/tmp/project',
+    '/tmp/project with spaces',
+    "/tmp/project's",
+    String.raw`/tmp/project\segment`,
+    '/tmp/项目-α',
+    '/tmp/project/',
+  ]) {
+    const expected = execFileSync('bash', [script, projectDir], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    assert.equal(deriveCollection(projectDir), expected, `diverged for ${JSON.stringify(projectDir)}`)
+  }
+})
+
+test('deriveCollection: sanitizes representative Windows project paths', {
+  skip: process.platform !== 'win32' && 'asserts win32 path semantics',
+}, () => {
+  assert.match(deriveCollection('D:\\CODE-AI\\my 项目'), /^ms_my_[0-9a-f]{8}$/, 'spaces and non-ASCII sanitize to underscores')
+  assert.match(deriveCollection('D:\\CODE-AI\\项目'), /^ms__[0-9a-f]{8}$/, 'a fully non-ASCII basename sanitizes to empty')
+  assert.equal(deriveCollection('D:\\x'), deriveCollection('D:\\x'), 'stable for the same input')
+  assert.notEqual(deriveCollection('D:\\x'), deriveCollection('D:\\y'), 'distinct paths derive distinct hashes')
+})
+
 test('detectDshCmd: prefers dsh on PATH as a plain argv', () => {
-  // DSH_CLI is checked after PATH; simulate PATH hit by masking DSH_CLI.
+  // Environment overrides (MEMSEARCH_DSH_COMMAND_JSON, then DSH_CLI) are
+  // checked before PATH; mask DSH_CLI so this test exercises PATH discovery.
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
   try {
@@ -734,7 +766,9 @@ test('apply: injectEnabled:false makes pre-step injection a no-op', async () => 
   assert.equal(result.messages.length, 1, 'no memory message injected')
 })
 
-test('apply: empty search result keeps pre-step context unchanged while recall stays available', async () => {
+test('apply: empty search result keeps pre-step context unchanged while recall stays available', {
+  skip: process.platform === 'win32' && 'fixture routes the fake CLI through /bin/sh and /usr/bin/bash shims',
+}, async () => {
   await withInjectionFixture([], async ({ result, unchanged, registeredSkillNames, callLog }) => {
     assert.equal(unchanged, true, 'empty search result must not inject a marker')
     assert.equal(result.messages.length, 1)
@@ -747,7 +781,9 @@ test('apply: empty search result keeps pre-step context unchanged while recall s
   })
 })
 
-test('apply: returned chunks inject one retrieved-context marker with plugin source metadata', async () => {
+test('apply: returned chunks inject one retrieved-context marker with plugin source metadata', {
+  skip: process.platform === 'win32' && 'fixture routes the fake CLI through /bin/sh and /usr/bin/bash shims',
+}, async () => {
   await withInjectionFixture(
     [{ source: 'memory/2026-09-07.md:4', content: 'The release marker is PINE-NEBULA-8643.' }],
     async ({ result, unchanged, registeredSkillNames, callLog }) => {

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -3,8 +3,29 @@ import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
+import path from 'node:path'
 
-import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
+import { detectDshCmd, resolveExecutable, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
+
+test('resolveExecutable: Windows skips cmd and bat shims for direct spawn', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'msr-exe-'))
+  try {
+    fs.writeFileSync(path.join(tmp, 'tool.cmd'), '@echo off\n')
+    fs.writeFileSync(path.join(tmp, 'tool.bat'), '@echo off\n')
+    assert.equal(
+      resolveExecutable('tool', { platform: 'win32', path: tmp, pathExt: '.CMD;.BAT' }),
+      null,
+      'batch files need cmd.exe and cannot be used by execFile/spawn directly',
+    )
+    fs.writeFileSync(path.join(tmp, 'tool.exe'), '')
+    assert.equal(
+      resolveExecutable('tool', { platform: 'win32', path: tmp, pathExt: '.CMD;.EXE' }),
+      path.join(tmp, 'tool.exe'),
+    )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
 
 async function withInjectionFixture(searchResults, assertion) {
   const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-inject-`)
@@ -197,28 +218,28 @@ test('resolveSummarizeMode: unknown explicit mode logs a warning and treats as a
 })
 
 test('resolveSummarizeMode: auto with configured provider selects custom-llm', () => {
-  // Simulate `[plugins.dsh.summarize] provider = "x"` by pointing memsearchCmd
-  // at a shim that echoes the requested key.
-  const prevPath = process.env.PATH
+  // Simulate `[plugins.dsh.summarize] provider = "x"` with a Node shim passed
+  // as an argv spec — no PATH manipulation, works on every platform.
   const tmp = os.tmpdir()
-  const shimBin = `${tmp}/memsearch-config-shim-${process.pid}`
-  fs.mkdirSync(shimBin, { recursive: true })
-  const shim = `${shimBin}/memsearch`
+  const shim = `${tmp}/memsearch-config-shim-${process.pid}.mjs`
   fs.writeFileSync(
     shim,
-    `#!/bin/sh\ncase "$3" in\n  plugins.dsh.summarize.provider) echo "deepseek-zilliz" ;;\n  plugins.dsh.summarize.model) echo "deepseek-v4-flash" ;;\n  plugins.dsh.summarize.enabled) echo "true" ;;\nesac\n`,
+    'const key = process.argv[process.argv.indexOf("get") + 1];\n' +
+    'const values = {\n' +
+    '  "plugins.dsh.summarize.provider": "deepseek-zilliz",\n' +
+    '  "plugins.dsh.summarize.model": "deepseek-v4-flash",\n' +
+    '  "plugins.dsh.summarize.enabled": "true",\n' +
+    '};\n' +
+    'if (values[key] !== undefined) console.log(values[key]);\n',
     'utf-8',
   )
-  fs.chmodSync(shim, 0o755)
   try {
-    process.env.PATH = `${shimBin}:${prevPath}`
-    const r = resolveSummarizeMode('memsearch', { summarizeMode: undefined, summarizeProvider: '', summarizeModel: '' }, {})
+    const r = resolveSummarizeMode([process.execPath, shim], { summarizeMode: undefined, summarizeProvider: '', summarizeModel: '' }, {})
     assert.equal(r.mode, 'custom-llm')
     assert.equal(r.provider, 'deepseek-zilliz')
     assert.equal(r.model, 'deepseek-v4-flash')
   } finally {
-    fs.rmSync(shimBin, { recursive: true, force: true })
-    process.env.PATH = prevPath
+    fs.rmSync(shim, { force: true })
   }
 })
 
@@ -273,23 +294,22 @@ test('summarizeTurn: dsh-headless mode without CLI errors visibly', async () => 
 })
 
 test('summarizeTurn: custom-llm forwards --provider/--model to summarize.py', async () => {
-  // Point a fake `python3` (argv recorder) at the front of PATH so the spawn
-  // inside summarizeCustomLlm hits it; assert the provider/model options from
-  // plugin config reach summarize.py as CLI args.
-  const prevPath = process.env.PATH
-  const tmp = await import('node:os').then((os) => os.tmpdir())
-  const fs = await import('node:fs')
-  const fakeBin = `${tmp}/memsearch-py3bin-${process.pid}`
+  // Point MEMSEARCH_PYTHON at a Node argv recorder via a JSON argv spec; the
+  // spawn inside summarizeCustomLlm hits it on every platform.
+  const tmp = os.tmpdir()
   const argvFile = `${tmp}/memsearch-py3argv-${process.pid}.txt`
-  fs.mkdirSync(fakeBin, { recursive: true })
+  const shim = `${tmp}/memsearch-py3rec-${process.pid}.mjs`
   fs.writeFileSync(
-    `${fakeBin}/python3`,
-    `#!/bin/sh\nprintf "%s\\n" "$@" > "${argvFile}"\ncat > /dev/null\nexit 0\n`,
+    shim,
+    'import { writeFileSync } from "node:fs";\n' +
+    `writeFileSync(${JSON.stringify(argvFile)}, process.argv.slice(2).join("\\n"));\n` +
+    'process.stdin.resume();\n' +
+    'process.stdin.on("end", () => process.exit(0));\n',
     'utf-8',
   )
-  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  const prevPython = process.env.MEMSEARCH_PYTHON
   try {
-    process.env.PATH = `${fakeBin}:${prevPath}`
+    process.env.MEMSEARCH_PYTHON = JSON.stringify([process.execPath, shim])
     const opts = {
       summarizeMode: 'custom-llm',
       agentName: 'AgentX',
@@ -301,15 +321,16 @@ test('summarizeTurn: custom-llm forwards --provider/--model to summarize.py', as
     const summary = await summarizeTurn(ctx, opts, render, process.cwd())
     assert.equal(summary, null, 'recorder exits 0 with no stdout -> null summary')
     const recorded = fs.readFileSync(argvFile, 'utf-8').trim().split('\n')
-    assert.ok(recorded[0].endsWith('scripts/summarize.py'), `first arg = summarize.py, got: ${recorded[0]}`)
+    assert.ok(recorded[0].replaceAll('\\', '/').endsWith('scripts/summarize.py'), `first arg = summarize.py, got: ${recorded[0]}`)
     const joined = recorded.join(' ')
     assert.ok(joined.includes('--provider deepseek-zilliz'), `--provider forwarded: ${joined}`)
     assert.ok(joined.includes('--model deepseek-v4-pro'), `--model forwarded: ${joined}`)
     assert.ok(joined.includes('--agent-name AgentX'), `--agent-name forwarded: ${joined}`)
   } finally {
-    try { fs.rmSync(fakeBin, { recursive: true, force: true }) } catch { /* cleanup */ }
+    fs.rmSync(shim, { force: true })
     try { fs.unlinkSync(argvFile) } catch { /* cleanup */ }
-    process.env.PATH = prevPath
+    if (prevPython === undefined) delete process.env.MEMSEARCH_PYTHON
+    else process.env.MEMSEARCH_PYTHON = prevPython
   }
 })
 
@@ -317,19 +338,18 @@ test('summarizeTurn: custom-llm surfaces summarize.py stderr as a visible error'
   // A failing summarize.py must reject with its stderr message (visible), not
   // silently resolve null/empty — so the caller writes the unavailable note
   // with the real reason.
-  const prevPath = process.env.PATH
-  const tmp = await import('node:os').then((os) => os.tmpdir())
-  const fs = await import('node:fs')
-  const fakeBin = `${tmp}/memsearch-py3fail-${process.pid}`
-  fs.mkdirSync(fakeBin, { recursive: true })
+  const tmp = os.tmpdir()
+  const shim = `${tmp}/memsearch-py3fail-${process.pid}.mjs`
   fs.writeFileSync(
-    `${fakeBin}/python3`,
-    '#!/bin/sh\necho "provider deepseek-zilliz not found in config" >&2\ncat > /dev/null\nexit 3\n',
+    shim,
+    'process.stderr.write("provider deepseek-zilliz not found in config\\n");\n' +
+    'process.stdin.resume();\n' +
+    'process.stdin.on("end", () => process.exit(3));\n',
     'utf-8',
   )
-  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  const prevPython = process.env.MEMSEARCH_PYTHON
   try {
-    process.env.PATH = `${fakeBin}:${prevPath}`
+    process.env.MEMSEARCH_PYTHON = JSON.stringify([process.execPath, shim])
     const opts = {
       summarizeMode: 'custom-llm',
       agentName: 'X',
@@ -343,8 +363,9 @@ test('summarizeTurn: custom-llm surfaces summarize.py stderr as a visible error'
       /provider deepseek-zilliz not found in config/,
     )
   } finally {
-    try { fs.rmSync(fakeBin, { recursive: true, force: true }) } catch { /* cleanup */ }
-    process.env.PATH = prevPath
+    fs.rmSync(shim, { force: true })
+    if (prevPython === undefined) delete process.env.MEMSEARCH_PYTHON
+    else process.env.MEMSEARCH_PYTHON = prevPython
   }
 })
 
@@ -352,18 +373,31 @@ test('detectDshCmd: falls back to pnpm global bin directory', async () => {
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
   const prevHome = process.env.HOME
-  const tmp = await import('node:os').then((os) => os.tmpdir())
-  const fs = await import('node:fs')
+  const prevProfile = process.env.USERPROFILE
+  const tmp = os.tmpdir()
   const fakeHome = `${tmp}/memsearch-home-${process.pid}`
   fs.mkdirSync(`${fakeHome}/.local/share/pnpm`, { recursive: true })
-  fs.writeFileSync(`${fakeHome}/.local/share/pnpm/dsh`, '#!/bin/sh\nexit 0\n', 'utf-8')
-  fs.chmodSync(`${fakeHome}/.local/share/pnpm/dsh`, 0o755)
+  const isWin = process.platform === 'win32'
+  const fallbackName = isWin ? 'dsh.ps1' : 'dsh'
+  const fallback = `${fakeHome}/.local/share/pnpm/${fallbackName}`
+  fs.writeFileSync(fallback, isWin ? 'exit 0\n' : '#!/bin/sh\nexit 0\n', 'utf-8')
+  if (!isWin) fs.chmodSync(fallback, 0o755)
   try {
     delete process.env.DSH_CLI
     delete process.env.PATH
     process.env.HOME = fakeHome
+    process.env.USERPROFILE = fakeHome
     const cmd = detectDshCmd()
-    assert.deepEqual(cmd, [`${fakeHome}/.local/share/pnpm/dsh`])
+    if (isWin) {
+      // Windows runs the PowerShell shim through pwsh/powershell; both may be
+      // absent in a stripped environment, in which case there is no safe launch.
+      if (cmd !== null) {
+        assert.ok(/pwsh|powershell/i.test(cmd[0]), `launched via PowerShell, got ${cmd[0]}`)
+        assert.equal(cmd[cmd.length - 1], fallback, 'runs the pnpm-global shim')
+      }
+    } else {
+      assert.deepEqual(cmd, [fallback])
+    }
   } finally {
     try { fs.rmSync(fakeHome, { recursive: true, force: true }) } catch { /* cleanup */ }
     if (prevCli === undefined) delete process.env.DSH_CLI
@@ -372,6 +406,8 @@ test('detectDshCmd: falls back to pnpm global bin directory', async () => {
     else process.env.PATH = prevPath
     if (prevHome === undefined) delete process.env.HOME
     else process.env.HOME = prevHome
+    if (prevProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevProfile
   }
 })
 
@@ -395,6 +431,15 @@ test('apply: summarizeEnabled:false writes the raw transcript (no summarizer)', 
     skills: { register: () => {} },
     on: (name, fn) => { listeners[name] = fn },
   }
+  // Isolate executable discovery so background index spawns fail fast (ENOENT)
+  // instead of starting a real uvx/memsearch child that locks the temp dir on
+  // Windows until cleanup hits EBUSY.
+  const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
+  const prevProfile = process.env.USERPROFILE
+  process.env.PATH = `${tmp}/memsearch-no-bin-${process.pid}`
+  process.env.HOME = `${tmp}/memsearch-no-home-${process.pid}`
+  process.env.USERPROFILE = process.env.HOME
   apply(ctx, { summarizeEnabled: false })
   const session = {
     id: 'session-raw-test',
@@ -419,6 +464,11 @@ test('apply: summarizeEnabled:false writes the raw transcript (no summarizer)', 
     assert.ok(content.includes('<!-- session:session-raw-test turn:1 '), 'anchor present')
   } finally {
     fs.rmSync(projDir, { recursive: true, force: true })
+    process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevProfile
   }
 })
 
@@ -436,10 +486,12 @@ test('apply: summarize failure writes unavailable note (not raw)', async () => {
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
   const prevHome = process.env.HOME
+  const prevProfile = process.env.USERPROFILE
   try {
     delete process.env.DSH_CLI
     process.env.PATH = '/nonexistent'
     process.env.HOME = '/nonexistent-home' // mask pnpm-global dsh fallback (would boot a real agent)
+    process.env.USERPROFILE = '/nonexistent-home' // and mask uvx fallback on Windows
     apply(ctx, {})
     const session = {
       id: 'session-fail-test',
@@ -466,6 +518,8 @@ test('apply: summarize failure writes unavailable note (not raw)', async () => {
     process.env.PATH = prevPath
     if (prevHome === undefined) delete process.env.HOME
     else process.env.HOME = prevHome
+    if (prevProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevProfile
   }
 })
 
@@ -481,9 +535,15 @@ test('apply: multi-project capture writes to each project memory dir', async () 
   }
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
+  const prevHome = process.env.HOME
+  const prevProfile = process.env.USERPROFILE
   try {
     delete process.env.DSH_CLI
     process.env.PATH = '/nonexistent'
+    // Mask both home variables so no real uvx/memsearch child starts and locks
+    // the temp project dirs on Windows.
+    process.env.HOME = '/nonexistent-home'
+    process.env.USERPROFILE = '/nonexistent-home'
     apply(ctx, { summarizeEnabled: false }) // raw writes, no CLI needed
     const mkSession = (id, cwd, marker) => ({
       id,
@@ -512,6 +572,10 @@ test('apply: multi-project capture writes to each project memory dir', async () 
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
     process.env.PATH = prevPath
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevProfile
   }
 })
 
@@ -549,23 +613,21 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   // The DSH settings user layer (`agent-default-model` in ~/.dsh/settings.yaml)
   // outranks any `--patch` overlay, so headless summarize must NOT emit one:
   // a real dsh boot here should not carry a memsearch-generated overlay file.
-  // We point DSH_CLI at a recorder script that writes its argv to a file, then
+  // We point DSH_CLI at a Node recorder that writes its argv to a file, then
   // assert the recorded args contain no `--patch` (and no temp overlay path).
   const prevCli = process.env.DSH_CLI
   const prevDshSummarize = process.env.MEMSEARCH_DSH_SUMMARIZE
-  const tmp = await import('node:os').then((os) => os.tmpdir())
-  const fs = await import('node:fs')
-  const recorder = `${tmp}/memsearch-dsh-argv-recorder-${process.pid}.sh`
+  const tmp = os.tmpdir()
+  const argvFile = `${tmp}/memsearch-dsh-argv-${process.pid}.txt`
+  const recorder = `${tmp}/memsearch-dsh-argv-recorder-${process.pid}.mjs`
   fs.writeFileSync(
     recorder,
-    '#!/bin/sh\nprintf "%s\\n" "$@" > "${MEMSEARCH_ARGV_FILE}"\nexit 0\n',
+    'import { writeFileSync } from "node:fs";\n' +
+    `writeFileSync(${JSON.stringify(argvFile)}, process.argv.slice(2).join("\\n"));\n`,
     'utf-8',
   )
-  fs.chmodSync(recorder, 0o755)
-  const argvFile = `${tmp}/memsearch-dsh-argv-${process.pid}.txt`
   try {
-    process.env.DSH_CLI = `sh ${recorder}`
-    process.env.MEMSEARCH_ARGV_FILE = argvFile
+    process.env.DSH_CLI = `"${process.execPath}" "${recorder}"`
     const opts = {
       summarizeMode: 'dsh-headless',
       agentName: 'X',
@@ -588,7 +650,6 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   } finally {
     try { fs.unlinkSync(recorder) } catch { /* cleanup */ }
     try { fs.unlinkSync(argvFile) } catch { /* cleanup */ }
-    delete process.env.MEMSEARCH_ARGV_FILE
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
     if (prevDshSummarize === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
@@ -649,7 +710,7 @@ test('memsearchDirFor: MEMSEARCH_DIR env wins (global scope)', () => {
     process.env.MEMSEARCH_DIR = '/global/memsearch'
     assert.equal(memsearchDirFor('/proj/x'), '/global/memsearch')
     delete process.env.MEMSEARCH_DIR
-    assert.equal(memsearchDirFor('/proj/x'), '/proj/x/.memsearch')
+    assert.equal(memsearchDirFor('/proj/x'), path.join('/proj/x', '.memsearch'))
   } finally {
     if (prev === undefined) delete process.env.MEMSEARCH_DIR
     else process.env.MEMSEARCH_DIR = prev
@@ -797,10 +858,22 @@ test('listSkillCandidates: malformed meta.json is skipped, not fatal', () => {
 })
 
 test('resolveSkillInstallTarget: paths config entry wins, relative resolves against project', () => {
-  
-  const target = resolveSkillInstallTarget('memsearch', '/proj')
-  // No configured paths on this machine → DSH default ~/.agents/skills.
-  assert.ok(target.endsWith('/.agents/skills'), `expected ~/.agents/skills default, got ${target}`)
+  const prevHome = process.env.HOME
+  const prevProfile = process.env.USERPROFILE
+  const fakeHome = path.join(os.tmpdir(), `msr-home-${process.pid}`)
+  try {
+    // Pin the home so the default target is deterministic on every platform.
+    process.env.HOME = fakeHome
+    process.env.USERPROFILE = fakeHome
+    const target = resolveSkillInstallTarget('definitely-not-a-real-cmd-xyz', '/proj')
+    // No configured paths on this machine → DSH default ~/.agents/skills.
+    assert.equal(target, path.join(fakeHome, '.agents', 'skills'), `expected ${fakeHome}/.agents/skills default, got ${target}`)
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevProfile
+  }
 })
 
 test('registerSkillReviewRoutes: GET candidates returns parsed list, pending first', async () => {
@@ -933,6 +1006,9 @@ test('registerSkillReviewRoutes: POST open-memsearch opens existing dir, 404 for
     await done1
     assert.equal(res1.status, 200)
     assert.equal(res1.body.ok, true)
+    // opened is true when a platform file manager exists (Windows explorer,
+    // macOS open), false on headless systems without xdg-open — both valid.
+    assert.equal(typeof res1.body.opened, 'boolean')
     assert.equal(res1.body.path, tmp, 'path is the memsearch dir (MEMSEARCH_DIR override)')
 
     // missing dir
@@ -958,7 +1034,15 @@ test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks travers
   fs.writeFileSync(`${tmp}/memory/2026-08-22.md`, '# hello')
   fs.writeFileSync(`${tmp}/config.toml`, 'x = 1')
   fs.writeFileSync(`${tmp}/.hidden`, 'no')
-  fs.symlinkSync(outside, `${tmp}/outside-link`)
+  // Symlinks require privilege on Windows; skip the symlink-escape assertions
+  // when the platform refuses to create them.
+  let symlinkAvailable = true
+  try {
+    fs.symlinkSync(outside, `${tmp}/outside-link`)
+  } catch (error) {
+    if (error.code === 'EPERM' || error.code === 'EACCES') symlinkAvailable = false
+    else throw error
+  }
   const routes = {}
   const webServer = { register: (r) => { routes[r.path] = r } }
   const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
@@ -983,9 +1067,11 @@ test('registerSkillReviewRoutes: list-memsearch lists dirs/files, blocks travers
     assert.equal(res2.status, 400)
 
     // A symlink inside .memsearch must not expose an outside directory.
-    const res3 = { writeHead: (s) => { res3.status = s }, end: (b) => { res3.body = JSON.parse(b) } }
-    route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch?path=outside-link' }, res3)
-    assert.equal(res3.status, 400)
+    if (symlinkAvailable) {
+      const res3 = { writeHead: (s) => { res3.status = s }, end: (b) => { res3.body = JSON.parse(b) } }
+      route.handler({ method: 'GET', url: '/memsearch-dsh/list-memsearch?path=outside-link' }, res3)
+      assert.equal(res3.status, 400)
+    }
   } finally {
     if (prev === undefined) delete process.env.MEMSEARCH_DIR
     else process.env.MEMSEARCH_DIR = prev
@@ -1000,7 +1086,13 @@ test('registerSkillReviewRoutes: read-file serves text, rejects binary/traversal
   fs.writeFileSync(`${tmp}/skill-candidates/foo/meta.json`, '{"name":"foo"}')
   fs.writeFileSync(`${tmp}/blob.bin`, Buffer.from([0, 1, 2, 3]))
   fs.writeFileSync(outside, 'outside secret')
-  fs.symlinkSync(outside, `${tmp}/escape.md`)
+  let symlinkAvailable = true
+  try {
+    fs.symlinkSync(outside, `${tmp}/escape.md`)
+  } catch (error) {
+    if (error.code === 'EPERM' || error.code === 'EACCES') symlinkAvailable = false
+    else throw error
+  }
   const routes = {}
   const webServer = { register: (r) => { routes[r.path] = r } }
   const ctx = { agents: { get: () => undefined }, logger: { warn: () => {} } }
@@ -1029,9 +1121,11 @@ test('registerSkillReviewRoutes: read-file serves text, rejects binary/traversal
     assert.equal(res3.status, 400)
 
     // A text-looking symlink must not expose a file outside .memsearch.
-    const res4 = { writeHead: (s) => { res4.status = s }, end: (b) => { res4.body = JSON.parse(b) } }
-    route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=escape.md' }, res4)
-    assert.equal(res4.status, 400)
+    if (symlinkAvailable) {
+      const res4 = { writeHead: (s) => { res4.status = s }, end: (b) => { res4.body = JSON.parse(b) } }
+      route.handler({ method: 'GET', url: '/memsearch-dsh/read-file?path=escape.md' }, res4)
+      assert.equal(res4.status, 400)
+    }
   } finally {
     if (prev === undefined) delete process.env.MEMSEARCH_DIR
     else process.env.MEMSEARCH_DIR = prev

--- a/plugins/openclaw/skills/memory-config/references/dsh.md
+++ b/plugins/openclaw/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/openclaw/skills/memory-config/references/dsh.md
+++ b/plugins/openclaw/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.

--- a/plugins/opencode/skills/memory-config/references/dsh.md
+++ b/plugins/opencode/skills/memory-config/references/dsh.md
@@ -70,13 +70,15 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
     injectEnabled: true      # inject returned memory candidates
     summarizeEnabled: true   # summarize turns before writing
     summarizeMode: auto      # auto | dsh-headless | custom-llm
+    summarizeProfile: headless # DSH application profile for dsh-headless
 ```
 
 ## Summarizer backends
 
 - **`auto`** (default) — if `[plugins.dsh.summarize] provider` is set, uses
   `custom-llm`; otherwise `dsh-headless`.
-- **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
+- **`dsh-headless`** — boots a one-shot `dsh --profile <summarizeProfile>` agent (`headless` by default). The
+  selected profile controls the sub-agent's model; a dedicated profile can isolate a cheaper summary model from the interactive agent. Without that isolation, the
   sub-agent's model is the deployment's `agent-default-model` from
   `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
@@ -90,8 +92,8 @@ dump.
 
 ## Native model defaults
 
-- `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
+- `dsh-headless` uses the selected `summarizeProfile` profile's effective `agent-default-model`. The default `headless` profile normally reads the Web UI selection from `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows); a dedicated profile can isolate another model.
+- `native` maintenance uses the DSH deployment's default model.
 
 ## Restart guidance
 

--- a/plugins/opencode/skills/memory-config/references/dsh.md
+++ b/plugins/opencode/skills/memory-config/references/dsh.md
@@ -22,7 +22,7 @@ Docs: https://zilliztech.github.io/memsearch/platforms/dsh/installation/
 
 DSH splits config across two surfaces, unlike the other platforms:
 
-1. **MemSearch TOML** (`~/.memsearch/config.toml`) — summarize provider/model,
+1. **MemSearch TOML** (`~/.memsearch/config.toml`, or `%USERPROFILE%\.memsearch\config.toml` on native Windows) — summarize provider/model,
    Milvus, collection, memory dir, and the maintenance tasks. Uses the
    `[plugins.dsh.*]` prefix.
 2. **Plugin-level switches** in the profile's `cordis.patch.yml` — the capture/
@@ -55,7 +55,7 @@ output_file = ".memsearch/USER.md"
 [plugins.dsh.memory_to_skill]
 enabled = false
 min_occurrences = 3
-paths = []          # install targets; default resolves to ~/.agents/skills
+paths = []          # install targets; default resolves to ~/.agents/skills (%USERPROFILE%\.agents\skills on Windows)
 ```
 
 ## Plugin-level switches (cordis.patch.yml)
@@ -78,7 +78,7 @@ These are NOT in the MemSearch TOML. They live in the profile patch under the
   `custom-llm`; otherwise `dsh-headless`.
 - **`dsh-headless`** — boots a one-shot `dsh --profile headless` agent. The
   sub-agent's model is the deployment's `agent-default-model` from
-  `~/.dsh/settings.yaml` (the same selection the Web UI model picker writes).
+  `~/.dsh/settings.yaml` (`%USERPROFILE%\.dsh\settings.yaml` on Windows) (the same selection the Web UI model picker writes).
   **`[plugins.dsh.summarize]` provider/model do NOT apply here** — change the
   model in DSH settings instead.
 - **`custom-llm`** — a direct LLM call using `[llm.providers.*]`; provider/model
@@ -91,7 +91,7 @@ dump.
 ## Native model defaults
 
 - `dsh-headless` and `native` maintenance use the DSH deployment's
-  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`).
+  `agent-default-model` (Web UI model picker / `~/.dsh/settings.yaml`, or `%USERPROFILE%\.dsh\settings.yaml` on Windows).
 
 ## Restart guidance
 
@@ -99,3 +99,12 @@ Restart the DSH profile after installing or updating the plugin so the
 `memory-recall` skill re-registers and the plugin rows reload. TOML changes
 apply on the next capture/recall/index/maintenance invocation; summarizer
 backend changes (`summarizeMode`) need the plugin config to reload.
+
+## Native Windows
+
+The DSH plugin runs MemSearch with direct executable arguments; Git Bash and
+WSL are not runtime requirements. Commands in this skill may be used from the
+DSH PowerShell shell. When an explicit helper command is needed, set
+`MEMSEARCH_DSH_COMMAND_JSON` or `MEMSEARCH_PYTHON` to a JSON string array of
+executable and arguments, for example `["C:\\Tools\\dsh.exe", "--profile",
+"headless"]`. This preserves paths containing spaces without shell quoting.


### PR DESCRIPTION
## Summary

Stacked on #721 (`fix/dsh-native-windows`) — please review only the last commit (`bafaf0b`); the diff will collapse to that commit once #721 merges.

- Add `summarizeProfile` plugin config (default `headless`) so the dsh-headless backend can boot a dedicated summary profile with its own lightweight model without touching the Web profile's model selection.
- Switch session log reads to `session.snapshotEvents()` to match the current DSH Session API (tests updated accordingly).
- Detach child stdin (`stdio: 'ignore'`) so the summarizer always sees EOF.
- Document the new option in README, `cordis.patch.yml` comments, memory-config skill references, and the DSH platform docs.
- Add `AGENTS.md` and a `plugins/dsh` section to `CLAUDE.md` so agents share the same plugin verification loop (unit tests + profile restart + one-turn capture/index/recall smoke).

## Testing

- `node --test tests/*.test.js` from `plugins/dsh` — all pass.
- Full Python suite unaffected: `413 passed, 7 skipped`.
- Manual E2E on native Windows: Web profile restart, one ordinary DSH turn, verified `.memsearch/memory/YYYY-MM-DD.md` gains a model summary (no fallback) and the collection is searchable.