### PR TITLE
feat(quality): pre-write memory quality filter

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -298,6 +298,36 @@ The same maintenance state file records `memory_to_skill` failures under
 `<platform>.memory_to_skill.last_error`, which is the first place to check if
 background distillation is enabled but no candidates appear.
 
+## Memory Quality Filter
+
+Since v0.4.20, capture paths can score candidate memory sections **before**
+they are appended to `memory/YYYY-MM-DD.md`. The scorer is a pure function
+(no I/O, no LLM): it starts at 100 and subtracts penalties for meta-memory
+vocabulary (notes about the memory system itself), agent-verbosity
+boilerplate, ultra-short content, high token repetition, and near-duplicates
+of sections already in the current day's journal.
+
+```toml
+[quality_filter]
+enabled = true
+min_content_length = 40
+degrade_threshold = 60   # score >= this → write normally
+reject_threshold = 30    # score < this → skip; between → write, marked low-quality
+```
+
+You can score any text without writing anything:
+
+```bash
+echo "candidate summary text" | memsearch quality --json-output
+echo "candidate summary text" | memsearch quality --recent-file .memsearch/memory/$(date +%F).md
+```
+
+The command prints `score`, `action` (`write` / `degrade` / `reject`), and the
+triggered `reasons`, so shell-based capture hooks can gate appends on the
+action without reimplementing the rules. Rejected sections are simply not
+written — the transcript anchor keeps the raw turn reachable via
+`memsearch transcript`, so no information is lost.
+
 ## Platform-Specific Config
 
 Each plugin may have additional configuration. See:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.19"
+version = "0.4.20"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1497,3 +1497,48 @@ def transcript_cmd(path: str, turn: str | None, context: int, json_output: bool)
         click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
     else:
         click.echo(transcript_mod.format_turns(turns))
+
+
+@cli.command("quality")
+@click.option("--file", "-f", "file", default=None, type=click.Path(exists=True), help="Read candidate text from a file instead of stdin.")
+@click.option("--recent-file", "-r", default=None, type=click.Path(exists=True), help="Daily journal file to check for near-duplicate sections.")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON (default). Plain output is human-readable.")
+def quality_cmd(file: str | None, recent_file: str | None, json_output: bool) -> None:
+    """Score a candidate memory section before it is written (quality filter).
+
+    Reads the candidate section text from stdin (or --file), applies the
+    [quality_filter] penalties, and prints score/action/reasons (JSON with
+    --json-output, human-readable otherwise). Capture hooks append only when
+    action is "write" or "degrade". Pass --recent-file with the current day's
+    journal for near-duplicate detection.
+    """
+    from . import quality as quality_mod
+    from .io import read_utf8_text_replace
+
+    if file:
+        text = read_utf8_text_replace(file)
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        click.echo("Error: provide candidate text via stdin or --file.", err=True)
+        raise SystemExit(1)
+
+    recent_sections: list[str] = []
+    if recent_file:
+        recent_sections = quality_mod.extract_sections(read_utf8_text_replace(recent_file))
+
+    cfg = _safe_resolve_config()
+    settings = quality_mod.QualityFilterSettings(
+        enabled=cfg.quality_filter.enabled,
+        min_content_length=cfg.quality_filter.min_content_length,
+        degrade_threshold=cfg.quality_filter.degrade_threshold,
+        reject_threshold=cfg.quality_filter.reject_threshold,
+    )
+    verdict = quality_mod.evaluate_section(text, recent_sections, settings)
+    if json_output:
+        click.echo(json.dumps(verdict.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        click.echo(f"score:   {verdict.score}")
+        click.echo(f"action:  {verdict.action}")
+        for reason in verdict.reasons:
+            click.echo(f"reason:  {reason}")

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -27,7 +27,7 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
+_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences", "min_content_length", "degrade_threshold", "reject_threshold"}
 _BOOL_FIELDS = {"enabled"}
 _LIST_FIELDS = {"paths", "ignore_files", "exclude"}
 
@@ -92,6 +92,21 @@ class IndexingConfig:
 @dataclass
 class WatchConfig:
     debounce_ms: int = 1500
+
+
+@dataclass
+class QualityFilterConfig:
+    """Pre-write memory quality filter settings (Proposal 002).
+
+    Capture paths score candidate memory sections before appending them to
+    ``memory/YYYY-MM-DD.md``; ``degrade`` sections are written with a recorded
+    quality score and ``reject`` sections are skipped entirely.
+    """
+
+    enabled: bool = True
+    min_content_length: int = 40
+    degrade_threshold: int = 60
+    reject_threshold: int = 30
 
 
 @dataclass
@@ -215,6 +230,7 @@ class MemSearchConfig:
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     indexing: IndexingConfig = field(default_factory=IndexingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
+    quality_filter: QualityFilterConfig = field(default_factory=QualityFilterConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
@@ -229,6 +245,7 @@ _SECTION_CLASSES: dict[str, type] = {
     "chunking": ChunkingConfig,
     "indexing": IndexingConfig,
     "watch": WatchConfig,
+    "quality_filter": QualityFilterConfig,
     "reranker": RerankerConfig,
     "llm": LLMConfig,
     "prompts": PromptsConfig,

--- a/src/memsearch/quality.py
+++ b/src/memsearch/quality.py
@@ -1,0 +1,223 @@
+"""Pre-write memory quality filter (Proposal 002).
+
+A pure scorer for candidate memory sections: given the text a summarizer
+produced and the recent sections already written to the journal, compute a
+0–100 quality score and a capture action (``write`` / ``degrade`` /
+``reject``). No I/O, no shared state, no LLM — the caller owns the file
+system and the journal, which keeps this module trivially testable and
+shareable across plugin capture paths via ``memsearch quality``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Literal, Sequence
+
+__all__ = [
+    "MIN_CONTENT_LENGTH_DEFAULT",
+    "DEGRADE_THRESHOLD_DEFAULT",
+    "REJECT_THRESHOLD_DEFAULT",
+    "QualityVerdict",
+    "QualityFilterSettings",
+    "score_section",
+    "decide",
+    "evaluate_section",
+    "extract_sections",
+]
+
+MIN_CONTENT_LENGTH_DEFAULT = 40
+DEGRADE_THRESHOLD_DEFAULT = 60
+REJECT_THRESHOLD_DEFAULT = 30
+
+Action = Literal["write", "degrade", "reject"]
+
+# Vocabulary of notes that talk about the memory system itself rather than
+# the work. Matched case-insensitively on word boundaries.
+_META_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\[\s*memsearch\s*\]",
+        r"\bmemsearch recall\b",
+        r"\brecall available\b",
+        r"\bmemory recall (status|hint|message)\b",
+        r"\bmemory summary unavailable\b",
+        r"\bmaintenance task\b",
+        r"\bmemory journal\b",
+        r"\bquality filter\b",
+        r"\bsession[- ]wrapup\b",
+    )
+)
+
+# Self-referential agent verbosity boilerplate. These openings mark notes
+# about the conversation's shape rather than its content.
+_BOILERPLATE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"^\s*the user asked\b",
+        r"^\s*user (asked|said|сообщил|спросил)\b",
+        r"^\s*i (replied|answered|responded)\b",
+        r"^\s*я (ответил|предложил)\b",
+        r"\bas an ai\b",
+        r"\bas requested\b",
+        r"\bhere('?s| is) (a |the )?summary\b",
+    )
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_SHINGLE_SIZE = 4
+_MAX_SHINGLES = 512  # cap for bounded, predictable scoring time
+
+
+@dataclass(frozen=True)
+class QualityVerdict:
+    """Result of scoring one candidate section."""
+
+    score: int
+    action: Action
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return {"score": self.score, "action": self.action, "reasons": list(self.reasons)}
+
+
+@dataclass(frozen=True)
+class QualityFilterSettings:
+    """Knobs mirroring the ``[quality_filter]`` config section."""
+
+    enabled: bool = True
+    min_content_length: int = MIN_CONTENT_LENGTH_DEFAULT
+    degrade_threshold: int = DEGRADE_THRESHOLD_DEFAULT
+    reject_threshold: int = REJECT_THRESHOLD_DEFAULT
+
+
+def _normalize(text: str) -> str:
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _tokens(text: str) -> list[str]:
+    return _normalize(text).lower().split()
+
+
+def _token_shingles(tokens: Sequence[str], size: int = _SHINGLE_SIZE) -> set[int]:
+    """Hash word shingles to 64-bit ints for cheap Jaccard comparison."""
+    if len(tokens) < size:
+        if not tokens:
+            return set()
+        digest = hashlib.sha1(" ".join(tokens).encode("utf-8")).digest()
+        return {int.from_bytes(digest[:8], "big")}
+    shingles: set[int] = set()
+    for i in range(min(len(tokens) - size + 1, _MAX_SHINGLES)):
+        digest = hashlib.sha1(" ".join(tokens[i : i + size]).encode("utf-8")).digest()
+        shingles.add(int.from_bytes(digest[:8], "big"))
+    return shingles
+
+
+def _repetition_ratio(tokens: Sequence[str]) -> float:
+    """Fraction of the text covered by repeated tokens (content words only)."""
+    content = [t for t in tokens if len(t) > 3]
+    if not content:
+        return 0.0
+    counts: dict[str, int] = {}
+    for tok in content:
+        counts[tok] = counts.get(tok, 0) + 1
+    repeated = sum(c for c in counts.values() if c > 1)
+    return repeated / len(content)
+
+
+def _max_jaccard(candidate: str, recent_sections: Iterable[str]) -> float:
+    cand_shingles = _token_shingles(_tokens(candidate))
+    if not cand_shingles:
+        return 0.0
+    best = 0.0
+    for section in recent_sections:
+        other = _token_shingles(_tokens(section))
+        if not other:
+            continue
+        union = len(cand_shingles | other)
+        similarity = len(cand_shingles & other) / union if union else 0.0
+        if similarity > best:
+            best = similarity
+    return best
+
+
+def score_section(
+    text: str,
+    recent_sections: Sequence[str] | None = None,
+    settings: QualityFilterSettings | None = None,
+) -> tuple[int, tuple[str, ...]]:
+    """Score a candidate memory section from 0 to 100.
+
+    Higher is better; penalties subtract from a 100 start. Returns the score
+    and the list of triggered penalty reasons. Pure: same inputs, same output,
+    no side effects.
+    """
+    cfg = settings or QualityFilterSettings()
+    reasons: list[str] = []
+    score = 100
+
+    normalized = _normalize(text)
+
+    if any(p.search(text) for p in _META_PATTERNS):
+        score -= 25
+        reasons.append("meta-memory vocabulary")
+
+    if any(p.search(text) for p in _BOILERPLATE_PATTERNS):
+        score -= 10
+        reasons.append("agent-verbosity boilerplate")
+
+    if len(normalized) < cfg.min_content_length:
+        score -= 30
+        reasons.append(f"content shorter than min_content_length ({cfg.min_content_length})")
+
+    tokens = _tokens(text)
+    if tokens and _repetition_ratio(tokens) > 0.6:
+        score -= 20
+        reasons.append("high token repetition ratio")
+
+    if recent_sections and _max_jaccard(text, recent_sections) > 0.8:
+        score -= 40
+        reasons.append("near-duplicate of a recent section")
+
+    return max(score, 0), tuple(reasons)
+
+
+def decide(score: int, settings: QualityFilterSettings | None = None) -> Action:
+    """Map a quality score to a capture action."""
+    cfg = settings or QualityFilterSettings()
+    if score >= cfg.degrade_threshold:
+        return "write"
+    if score >= cfg.reject_threshold:
+        return "degrade"
+    return "reject"
+
+
+def evaluate_section(
+    text: str,
+    recent_sections: Sequence[str] | None = None,
+    settings: QualityFilterSettings | None = None,
+) -> QualityVerdict:
+    """Score and decide in one call — the main entry point for capture paths."""
+    cfg = settings or QualityFilterSettings()
+    if not cfg.enabled:
+        return QualityVerdict(score=100, action="write", reasons=("quality filter disabled",))
+    score, reasons = score_section(text, recent_sections, cfg)
+    return QualityVerdict(score=score, action=decide(score, cfg), reasons=reasons)
+
+
+_SECTION_SPLIT_RE = re.compile(r"^#{2,6}\s+\S", re.MULTILINE)
+_HTML_ANCHOR_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def extract_sections(journal_text: str) -> list[str]:
+    """Split a daily journal file into recent sections for near-dup checks.
+
+    Strips HTML anchor comments (session/turn metadata) so that two different
+    turns from the same session are not marked near-duplicates by their shared
+    anchor. Sections without any heading are kept as one block.
+    """
+    stripped = _HTML_ANCHOR_RE.sub("", journal_text)
+    parts = [p for p in _SECTION_SPLIT_RE.split(stripped) if _normalize(p)]
+    return [_normalize(p) for p in parts]

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,254 @@
+"""Tests for the pre-write memory quality filter (Proposal 002)."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+from memsearch.quality import (
+    QualityFilterSettings,
+    decide,
+    evaluate_section,
+    extract_sections,
+    score_section,
+)
+
+GOOD_NOTE = (
+    "Implemented a pre-write scoring gate in memsearch: a new quality.py "
+    "module evaluates candidate memory sections before append, applying "
+    "penalties for meta talk, boilerplate, short content, repetition, and "
+    "near-duplicates."
+)
+
+META_NOTE = "[memsearch] Recall available if needed."
+
+SHORT_NOTE = "Fixed a bug."
+
+DUPLICATE_TEXT = " ".join(["word"] * 60)
+
+
+# -- score_section: individual penalties --
+
+
+def test_clean_section_scores_100() -> None:
+    score, reasons = score_section(GOOD_NOTE)
+    assert score == 100
+    assert reasons == ()
+
+
+def test_meta_memory_vocabulary_penalized() -> None:
+    # Long enough to avoid the short-content penalty, no other penalty.
+    text = "Discussed plugin behaviour: [memsearch] Recall available if needed, and hooks."
+    score, reasons = score_section(text)
+    assert score == 100 - 25
+    assert "meta-memory vocabulary" in reasons
+
+
+def test_agent_boilerplate_penalized() -> None:
+    text = "The user asked about deployment options. " + GOOD_NOTE
+    score, reasons = score_section(text)
+    assert score == 100 - 10
+    assert "agent-verbosity boilerplate" in reasons
+
+
+def test_short_content_penalized() -> None:
+    score, reasons = score_section(SHORT_NOTE)
+    assert "content shorter than min_content_length (40)" in reasons
+    assert score == 100 - 30
+
+
+def test_short_content_respects_setting() -> None:
+    cfg = QualityFilterSettings(min_content_length=5)
+    score, reasons = score_section(SHORT_NOTE, settings=cfg)
+    assert reasons == ()
+    assert score == 100
+
+
+def test_high_repetition_penalized() -> None:
+    text = " ".join(["important"] * 80)
+    score, reasons = score_section(text)
+    assert score == 100 - 20
+    assert "high token repetition ratio" in reasons
+
+
+def test_normal_prose_has_low_repetition() -> None:
+    _, reasons = score_section(GOOD_NOTE)
+    assert "high token repetition ratio" not in reasons
+
+
+def test_near_duplicate_penalized() -> None:
+    recent = [GOOD_NOTE]
+    score, reasons = score_section(GOOD_NOTE, recent_sections=recent)
+    assert score == 100 - 40
+    assert "near-duplicate of a recent section" in reasons
+
+
+def test_distinct_section_not_flagged_as_duplicate() -> None:
+    recent = [GOOD_NOTE]
+    other = (
+        "Ubuntu parity run completed: 413 passed, 7 skipped on the Linux "
+        "native clone; PR description updated with the verification matrix."
+    )
+    _, reasons = score_section(other, recent_sections=recent)
+    assert "near-duplicate of a recent section" not in reasons
+
+
+def test_penalties_stack() -> None:
+    text = "[memsearch] Recall available. short"
+    score, reasons = score_section(text)
+    assert score == 100 - 25 - 30
+    assert len(reasons) == 2
+
+
+def test_score_never_negative() -> None:
+    # All five penalties at once via a raised min_content_length.
+    text = "The user asked [memsearch] blah blah blah blah blah blah"
+    cfg = QualityFilterSettings(min_content_length=10_000)
+    score, reasons = score_section(text, recent_sections=[text], settings=cfg)
+    assert len(reasons) == 5
+    assert score == 0
+
+
+# -- decide / evaluate_section --
+
+
+def test_decide_boundaries() -> None:
+    assert decide(60) == "write"
+    assert decide(100) == "write"
+    assert decide(59) == "degrade"
+    assert decide(30) == "degrade"
+    assert decide(29) == "reject"
+    assert decide(0) == "reject"
+
+
+def test_disabled_filter_writes_everything() -> None:
+    verdict = evaluate_section(SHORT_NOTE, settings=QualityFilterSettings(enabled=False))
+    assert verdict.action == "write"
+    assert verdict.score == 100
+
+
+def test_evaluate_section_rejects_garbage() -> None:
+    text = "The user asked [memsearch] blah blah blah blah blah blah"
+    cfg = QualityFilterSettings(min_content_length=10_000)
+    verdict = evaluate_section(text, recent_sections=[text], settings=cfg)
+    assert verdict.action == "reject"
+
+
+# -- purity (property-style invariants) --
+
+
+def test_score_is_deterministic() -> None:
+    for _ in range(5):
+        assert score_section(META_NOTE + " " + DUPLICATE_TEXT) == score_section(
+            META_NOTE + " " + DUPLICATE_TEXT
+        )
+
+
+def test_score_does_not_mutate_inputs() -> None:
+    recent = [GOOD_NOTE]
+    snapshot = list(recent)
+    score_section(GOOD_NOTE, recent_sections=recent)
+    assert recent == snapshot
+
+
+# -- extract_sections --
+
+
+def test_extract_sections_splits_on_headings_and_strips_anchors() -> None:
+    journal = (
+        "### 01:10\n<!-- session:s1 turn:2 db:x -->\nFirst turn note.\n\n"
+        "### 01:23\n<!-- session:s2 turn:7 db:y -->\nSecond turn note.\n"
+    )
+    sections = extract_sections(journal)
+    assert len(sections) == 2
+    assert "session:s1" not in sections[0]
+    assert "First turn note." in sections[0]
+
+
+def test_anchors_do_not_create_false_duplicates() -> None:
+    # A new turn summary that only shares anchor metadata (and differs in
+    # content) must not be flagged as a near-duplicate; identical content must.
+    candidate = (
+        "Configured the DSH web profile to link the memsearch plugin and "
+        "documented restart instructions for future sessions."
+    )
+    journal = (
+        "### 01:10\n<!-- session:s1 turn:2 db:x -->\n" + GOOD_NOTE + "\n\n"
+        "### 01:20\n<!-- session:s1 turn:3 db:x -->\n" + GOOD_NOTE + "\n"
+    )
+    recent = extract_sections(journal)
+    _, reasons = score_section(candidate, recent_sections=recent)
+    assert "near-duplicate of a recent section" not in reasons
+    _, reasons = score_section(GOOD_NOTE, recent_sections=recent)
+    assert "near-duplicate of a recent section" in reasons
+
+
+# -- regression: real conversational turn summaries are not rejected --
+
+
+REAL_TURN_SUMMARIES = [
+    GOOD_NOTE,
+    "Opened PR zilliztech/memsearch#729 documenting three proposals: idle "
+    "consolidation, pre-write quality filter, and heat/cold archive.",
+    "Ubuntu parity run for feat/llm-audit finished: 413 passed, 7 skipped; "
+    "the PR was marked ready for review afterwards.",
+    "Reviewed the DSH plugin summarize path and confirmed the profile override "
+    "reaches the headless summarizer without changing the Web model.",
+    "Discussed merge timing for PR #721 with the user; expectations set to "
+    "several hours up to a few days depending on maintainer availability.",
+]
+
+
+def test_regression_reject_rate_on_real_turns() -> None:
+    written: list[str] = []
+    rejected = 0
+    for note in REAL_TURN_SUMMARIES:
+        verdict = evaluate_section(note, recent_sections=written)
+        if verdict.action == "reject":
+            rejected += 1
+        else:
+            written.append(note)
+    assert rejected == 0
+    assert len(written) == len(REAL_TURN_SUMMARIES)
+
+
+# -- CLI --
+
+
+def test_quality_cli_from_stdin_json() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "-j"], input=GOOD_NOTE)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] == "write"
+    assert payload["score"] == 100
+
+
+def test_quality_cli_rejects_meta_noise() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "-j"], input=META_NOTE)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] in {"degrade", "reject"}
+    assert "meta-memory vocabulary" in payload["reasons"]
+
+
+def test_quality_cli_recent_file(tmp_path) -> None:
+    journal = tmp_path / "2026-09-08.md"
+    journal.write_text(f"### 01:10\n<!-- anchor -->\n{GOOD_NOTE}\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["quality", "-j", "--recent-file", str(journal)], input=GOOD_NOTE
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "near-duplicate of a recent section" in payload["reasons"]
+
+
+def test_quality_cli_plain_output() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality"], input=SHORT_NOTE)
+    assert result.exit_code == 0, result.output
+    assert "action:" in result.output


### PR DESCRIPTION
## Summary

Implements [Proposal 002](https://github.com/zilliztech/memsearch/blob/docs/proposals/proposals/002-write-quality-filter.md) (see #729): a pure-function quality scorer that capture paths call **before** appending a section to ``memory/YYYY-MM-DD.md``, cutting meta-noise, ultra-short notes, and near-duplicates at capture time.

- **``src/memsearch/quality.py``** (new): ``score_section`` / ``decide`` / ``evaluate_section`` - no I/O, no LLM, deterministic. Penalties: meta-memory vocabulary (?25), agent-verbosity boilerplate (?10), content < ``min_content_length`` (?30), token repetition ratio > 0.6 (?20), near-duplicate of a recent section via sha1 hash-shingle Jaccard > 0.8 (?40). ``extract_sections`` splits a daily journal into sections for near-dup checks, stripping HTML anchors so shared session metadata cannot create false duplicates.
- **Actions**: ``write`` (score >= 60), ``degrade`` (30-59, written but marked), ``reject`` (< 30, skipped - the transcript anchor keeps the raw turn reachable via ``memsearch transcript``, so nothing is lost).
- **Config**: new ``[quality_filter]`` section (``enabled``, ``min_content_length``, ``degrade_threshold``, ``reject_threshold``).
- **CLI**: ``memsearch quality`` (stdin/``--file``, ``--recent-file``, ``--json-output``) - the single shared gate that shell hooks of all plugins can call without reimplementing the rules.
- **Docs**: new section in ``docs/home/configuration.md``; version bump 0.4.19 ? 0.4.20.

## Out of scope (deliberately)

- Milvus ``quality`` scalar field + search-time down-weighting - deferred to Proposal 003 (heat), which already requires the schema migration.
- Wiring into ``plugins/dsh/index.js`` and ``stop.sh`` capture pipelines - a small follow-up PR after this lands so hooks never depend on an unmerged CLI.

## Testing

- ``tests/test_quality.py``: per-rule unit tests, boundary scores, purity/determinism invariants, journal anchor handling, regression fixture of real conversational turn summaries (0% rejected), CLI tests via CliRunner - 23 tests.
- Full suite: **450 passed, 7 skipped** on Ubuntu; new tests pass on Windows too (remaining Windows-only failures are pre-existing bash/HOME-vs-USERPROFILE environment issues, verified identical on clean ``origin/main``).