### PR TITLE
feat(dsh): gate turn capture on memsearch quality before append

### DIFF
--- a/docs/home/configuration.md
+++ b/docs/home/configuration.md
@@ -298,6 +298,36 @@ The same maintenance state file records `memory_to_skill` failures under
 `<platform>.memory_to_skill.last_error`, which is the first place to check if
 background distillation is enabled but no candidates appear.
 
+## Memory Quality Filter
+
+Since v0.4.20, capture paths can score candidate memory sections **before**
+they are appended to `memory/YYYY-MM-DD.md`. The scorer is a pure function
+(no I/O, no LLM): it starts at 100 and subtracts penalties for meta-memory
+vocabulary (notes about the memory system itself), agent-verbosity
+boilerplate, ultra-short content, high token repetition, and near-duplicates
+of sections already in the current day's journal.
+
+```toml
+[quality_filter]
+enabled = true
+min_content_length = 40
+degrade_threshold = 60   # score >= this → write normally
+reject_threshold = 30    # score < this → skip; between → write, marked low-quality
+```
+
+You can score any text without writing anything:
+
+```bash
+echo "candidate summary text" | memsearch quality --json-output
+echo "candidate summary text" | memsearch quality --recent-file .memsearch/memory/$(date +%F).md
+```
+
+The command prints `score`, `action` (`write` / `degrade` / `reject`), and the
+triggered `reasons`, so shell-based capture hooks can gate appends on the
+action without reimplementing the rules. Rejected sections are simply not
+written — the transcript anchor keeps the raw turn reachable via
+`memsearch transcript`, so no information is lost.
+
 ## Platform-Specific Config
 
 Each plugin may have additional configuration. See:

--- a/plugins/claude-code/hooks/stop.sh
+++ b/plugins/claude-code/hooks/stop.sh
@@ -194,6 +194,27 @@ if [ -n "$SUMMARY_FAILURE" ]; then
   SUMMARY="- Memory summary unavailable: ${SUMMARY_FAILURE}; transcript content was omitted. Use the transcript anchor for progressive disclosure."
 fi
 
+# Pre-write quality gate (Proposal 002): score the summary before appending.
+# Reject skips the write (the transcript itself retains the turn); any gate
+# failure — older memsearch without the `quality` subcommand, timeout, config
+# unreadable — fails open and writes normally.
+QUALITY_TAG=""
+if memsearch_available; then
+  QUALITY_ENABLED=$(_memsearch config get quality_filter.enabled 2>/dev/null || echo "")
+  if [ "$QUALITY_ENABLED" != "false" ]; then
+    QUALITY_JSON=$(printf '%s' "$SUMMARY" | timeout 5 _run_summarizer "${MEMSEARCH_CMD[@]}" quality --json-output --recent-file "$MEMORY_FILE" 2>/dev/null || true)
+    QUALITY_ACTION=$(printf '%s' "$QUALITY_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('action',''))" 2>/dev/null || true)
+    if [ "$QUALITY_ACTION" = "reject" ]; then
+      echo '{}'
+      exit 0
+    fi
+    if [ "$QUALITY_ACTION" = "degrade" ]; then
+      QUALITY_SCORE=$(printf '%s' "$QUALITY_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('score',''))" 2>/dev/null || true)
+      [ -n "$QUALITY_SCORE" ] && QUALITY_TAG=" quality:${QUALITY_SCORE}"
+    fi
+  fi
+fi
+
 # Append under a session heading, writing the heading lazily on the first
 # content-bearing Stop of this session (SessionStart no longer writes it
 # eagerly, so sessions without summaries leave no stub journals). The
@@ -204,7 +225,7 @@ fi
   fi
   echo "### $NOW"
   if [ -n "$SESSION_ID" ]; then
-    echo "<!-- session:${SESSION_ID} turn:${LAST_USER_TURN_UUID} transcript:${TRANSCRIPT_PATH} -->"
+    echo "<!-- session:${SESSION_ID} turn:${LAST_USER_TURN_UUID}${QUALITY_TAG} transcript:${TRANSCRIPT_PATH} -->"
   fi
   echo "$SUMMARY"
   echo ""

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -815,8 +815,44 @@ function captureExists(memoryDir, sessionId, turn) {
   return false
 }
 
+/**
+ * Run the pre-write quality gate (`memsearch quality`, Proposal 002) for a
+ * candidate capture body.
+ *
+ * Returns `{ action, score }`, or `null` to fail open (write normally) when
+ * the installed memsearch predates the `quality` subcommand, the config is
+ * unreadable, the call times out, or the filter is disabled in config. A
+ * gating failure must never lose a turn: the transcript anchor is the only
+ * durable record, so reject requires an authoritative `reject` action.
+ */
+function runQualityGate(memsearchCmd, body, memoryDir, logger) {
+  const enabled = readMemsearchConfigValue(memsearchCmd, 'quality_filter.enabled')
+  if (enabled.ok && enabled.value === 'false') return null
+  const todayFile = join(memoryDir, `${todayStr()}.md`)
+  const recentFlag = existsSync(todayFile) ? ` --recent-file '${shellEscape(todayFile)}'` : ''
+  try {
+    const result = execFileSync(
+      'bash',
+      ['-c', `${memsearchCmd} quality --json-output${recentFlag}`],
+      {
+        encoding: 'utf-8',
+        timeout: 5000,
+        input: body,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      },
+    )
+    const verdict = JSON.parse(result)
+    if (typeof verdict?.action !== 'string') return null
+    return { action: verdict.action, score: Number(verdict.score) }
+  } catch (error) {
+    // Older memsearch without the `quality` subcommand exits non-zero here.
+    logger?.warn?.(`[memsearch] quality gate unavailable (${error.message}); writing without scoring`)
+    return null
+  }
+}
+
 /** Append a captured turn to the daily memory file (shared 4-platform format). */
-function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
+function writeCapture(memoryDir, body, sessionId, turn, dbPath, quality) {
   mkdirSync(memoryDir, { recursive: true })
   const today = todayStr()
   const hhmm = hhmmStr()
@@ -824,7 +860,10 @@ function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
   if (!existsSync(file)) {
     writeFileSync(file, `# ${today}\n\n## Session ${hhmm}\n\n`, 'utf-8')
   }
-  const anchor = `<!-- session:${sessionId} turn:${turn} db:${dbPath} -->\n`
+  // `quality:` (when the gate degraded a section) sits after `turn:` so the
+  // `captureExists` prefix match on `<!-- session:… turn:… ` keeps working.
+  const qualityTag = quality !== undefined ? ` quality:${quality}` : ''
+  const anchor = `<!-- session:${sessionId} turn:${turn}${qualityTag} db:${dbPath} -->\n`
   const entry = `### ${hhmm}\n${anchor}${body}\n\n`
   appendFileSync(file, entry, 'utf-8')
 }
@@ -1248,7 +1287,22 @@ export function apply(ctx, config = {}) {
         body = `- Memory summary unavailable: ${reason}; transcript content was omitted. Use the transcript anchor for progressive disclosure.`
       }
     }
-    writeCapture(memoryDir, body, sessionId, turn, dbPath)
+    // Pre-write quality gate (Proposal 002): score the candidate section
+    // before appending. Reject skips the write entirely — the transcript
+    // anchor in the session log keeps the raw turn reachable — and degrade
+    // records the score in the section anchor.
+    let quality
+    const verdict = runQualityGate(memsearchCmd, body, memoryDir, ctx.logger)
+    if (verdict) {
+      if (verdict.action === 'reject') {
+        ctx.logger.warn(
+          `[memsearch] quality gate rejected turn capture (score ${verdict.score}); transcript anchor retains the turn`,
+        )
+        return
+      }
+      if (verdict.action === 'degrade') quality = verdict.score
+    }
+    writeCapture(memoryDir, body, sessionId, turn, dbPath, quality)
     // Index right after the write so the memory is searchable by the next
     // session (or by this one's later turns) instead of waiting for a future
     // boot-time index. The index is idempotent via chunk_hash dedup.
@@ -1351,6 +1405,9 @@ export { renderTurn }
 
 /** True when a session/turn anchor already exists in the memory dir. */
 export { captureExists }
+
+/** Run the pre-write quality gate against a candidate capture body. */
+export { runQualityGate }
 
 /** Append a captured turn to the daily memory file (shared format). */
 export { writeCapture }

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 
-import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
+import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, runQualityGate, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
 
 async function withInjectionFixture(searchResults, assertion, oldCore = false) {
   const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-inject-`)
@@ -650,6 +650,107 @@ test('writeCapture + captureExists: writes shared format and dedups', () => {
     // dedup: same turn already captured
     assert.equal(captureExists(memoryDir, 'session-abc', 3), true)
     assert.equal(captureExists(memoryDir, 'session-abc', 4), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('writeCapture: quality tag lands in the anchor without breaking dedup', () => {
+  const tmp = os.tmpdir()
+  const dir = `${tmp}/memsearch-capture-quality-${process.pid}`
+  const memoryDir = `${dir}/memory`
+  try {
+    writeCapture(memoryDir, '- degraded note', 'session-q', 7, '/path/db.jsonl', 45)
+    const files = fs.readdirSync(memoryDir)
+    const content = fs.readFileSync(`${memoryDir}/${files[0]}`, 'utf-8')
+    assert.ok(content.includes('<!-- session:session-q turn:7 quality:45 db:/path/db.jsonl -->'), 'quality anchor')
+    assert.equal(captureExists(memoryDir, 'session-q', 7), true, 'dedup still matches')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runQualityGate: parses verdict, passes --recent-file when the journal exists', (t) => {
+  // The gate shells out through bash; when no usable bash exists (e.g. the
+  // WSL default distro has no coreutils), skip — the pre-existing
+  // bash-dependent tests fail the same way on such hosts.
+  try {
+    execFileSync('bash', ['-c', 'true'], { stdio: 'ignore' })
+  } catch {
+    t.skip('bash unavailable')
+    return
+  }
+  const tmp = os.tmpdir()
+  const dir = `${tmp}/memsearch-quality-${process.pid}`
+  const memoryDir = `${dir}/memory`
+  try {
+    fs.mkdirSync(memoryDir, { recursive: true })
+    // Fake memsearch CLI: a shell script on PATH that records its argv and
+    // echoes a canned verdict.
+    const binDir = `${dir}/bin`
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(
+      `${binDir}/fake-memsearch`,
+      [
+        '#!/usr/bin/env bash',
+        'echo "$@" >> "$CAPTURE_ARGS"',
+        `echo '{"score":45,"action":"degrade","reasons":["meta"]}'`,
+      ].join('\n'),
+    )
+    fs.chmodSync(`${binDir}/fake-memsearch`, 0o755)
+    const argsFile = `${dir}/args.txt`
+    fs.writeFileSync(argsFile, '')
+    const prevPath = process.env.PATH
+    process.env.PATH = `${binDir}:${prevPath}`
+    process.env.CAPTURE_ARGS = argsFile
+    let sawRecent = false
+    try {
+      const verdict = runQualityGate('fake-memsearch', 'candidate body', memoryDir, undefined)
+      assert.deepEqual(verdict, { action: 'degrade', score: 45 })
+      const args = fs.readFileSync(argsFile, 'utf-8')
+      // No journal yet → no --recent-file flag.
+      assert.ok(!args.includes('--recent-file'), 'no recent flag without journal')
+      // Create today's journal and gate again.
+      const today = new Date().toISOString().slice(0, 10)
+      fs.writeFileSync(`${memoryDir}/${today}.md`, '# journal\n', 'utf-8')
+      fs.writeFileSync(argsFile, '')
+      const verdict2 = runQualityGate('fake-memsearch', 'candidate body', memoryDir, undefined)
+      assert.equal(verdict2.action, 'degrade')
+      sawRecent = fs.readFileSync(argsFile, 'utf-8').includes('--recent-file')
+    } finally {
+      process.env.PATH = prevPath
+      delete process.env.CAPTURE_ARGS
+    }
+    assert.ok(sawRecent, 'recent flag passed once journal exists')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runQualityGate: fails open (null) when the CLI has no quality subcommand', (t) => {
+  try {
+    execFileSync('bash', ['-c', 'true'], { stdio: 'ignore' })
+  } catch {
+    t.skip('bash unavailable')
+    return
+  }
+  const tmp = os.tmpdir()
+  const dir = `${tmp}/memsearch-quality-fail-${process.pid}`
+  const memoryDir = `${dir}/memory`
+  try {
+    const binDir = `${dir}/bin`
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(`${binDir}/old-memsearch`, '#!/usr/bin/env bash\nexit 1\n')
+    fs.chmodSync(`${binDir}/old-memsearch`, 0o755)
+    const prevPath = process.env.PATH
+    process.env.PATH = `${binDir}:${prevPath}`
+    try {
+      const warnings = []
+      assert.equal(runQualityGate('old-memsearch', 'body', memoryDir, { warn: (m) => warnings.push(m) }), null)
+      assert.equal(warnings.length, 1, 'warns once on gate failure')
+    } finally {
+      process.env.PATH = prevPath
+    }
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.19"
+version = "0.4.20"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/src/memsearch/cli.py
+++ b/src/memsearch/cli.py
@@ -1497,3 +1497,48 @@ def transcript_cmd(path: str, turn: str | None, context: int, json_output: bool)
         click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
     else:
         click.echo(transcript_mod.format_turns(turns))
+
+
+@cli.command("quality")
+@click.option("--file", "-f", "file", default=None, type=click.Path(exists=True), help="Read candidate text from a file instead of stdin.")
+@click.option("--recent-file", "-r", default=None, type=click.Path(exists=True), help="Daily journal file to check for near-duplicate sections.")
+@click.option("--json-output", "-j", is_flag=True, help="Output as JSON (default). Plain output is human-readable.")
+def quality_cmd(file: str | None, recent_file: str | None, json_output: bool) -> None:
+    """Score a candidate memory section before it is written (quality filter).
+
+    Reads the candidate section text from stdin (or --file), applies the
+    [quality_filter] penalties, and prints score/action/reasons (JSON with
+    --json-output, human-readable otherwise). Capture hooks append only when
+    action is "write" or "degrade". Pass --recent-file with the current day's
+    journal for near-duplicate detection.
+    """
+    from . import quality as quality_mod
+    from .io import read_utf8_text_replace
+
+    if file:
+        text = read_utf8_text_replace(file)
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        click.echo("Error: provide candidate text via stdin or --file.", err=True)
+        raise SystemExit(1)
+
+    recent_sections: list[str] = []
+    if recent_file:
+        recent_sections = quality_mod.extract_sections(read_utf8_text_replace(recent_file))
+
+    cfg = _safe_resolve_config()
+    settings = quality_mod.QualityFilterSettings(
+        enabled=cfg.quality_filter.enabled,
+        min_content_length=cfg.quality_filter.min_content_length,
+        degrade_threshold=cfg.quality_filter.degrade_threshold,
+        reject_threshold=cfg.quality_filter.reject_threshold,
+    )
+    verdict = quality_mod.evaluate_section(text, recent_sections, settings)
+    if json_output:
+        click.echo(json.dumps(verdict.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        click.echo(f"score:   {verdict.score}")
+        click.echo(f"action:  {verdict.action}")
+        for reason in verdict.reasons:
+            click.echo(f"reason:  {reason}")

--- a/src/memsearch/config.py
+++ b/src/memsearch/config.py
@@ -27,7 +27,7 @@ GLOBAL_CONFIG_PATH = Path("~/.memsearch/config.toml").expanduser()
 PROJECT_CONFIG_PATH = Path(".memsearch.toml")
 
 # Fields that should be parsed as int when set via CLI strings
-_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences"}
+_INT_FIELDS = {"max_chunk_size", "overlap_lines", "debounce_ms", "batch_size", "min_interval_hours", "min_occurrences", "min_content_length", "degrade_threshold", "reject_threshold"}
 _BOOL_FIELDS = {"enabled"}
 _LIST_FIELDS = {"paths", "ignore_files", "exclude"}
 
@@ -92,6 +92,21 @@ class IndexingConfig:
 @dataclass
 class WatchConfig:
     debounce_ms: int = 1500
+
+
+@dataclass
+class QualityFilterConfig:
+    """Pre-write memory quality filter settings (Proposal 002).
+
+    Capture paths score candidate memory sections before appending them to
+    ``memory/YYYY-MM-DD.md``; ``degrade`` sections are written with a recorded
+    quality score and ``reject`` sections are skipped entirely.
+    """
+
+    enabled: bool = True
+    min_content_length: int = 40
+    degrade_threshold: int = 60
+    reject_threshold: int = 30
 
 
 @dataclass
@@ -215,6 +230,7 @@ class MemSearchConfig:
     chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
     indexing: IndexingConfig = field(default_factory=IndexingConfig)
     watch: WatchConfig = field(default_factory=WatchConfig)
+    quality_filter: QualityFilterConfig = field(default_factory=QualityFilterConfig)
     reranker: RerankerConfig = field(default_factory=RerankerConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
@@ -229,6 +245,7 @@ _SECTION_CLASSES: dict[str, type] = {
     "chunking": ChunkingConfig,
     "indexing": IndexingConfig,
     "watch": WatchConfig,
+    "quality_filter": QualityFilterConfig,
     "reranker": RerankerConfig,
     "llm": LLMConfig,
     "prompts": PromptsConfig,

--- a/src/memsearch/quality.py
+++ b/src/memsearch/quality.py
@@ -2,8 +2,8 @@
 
 A pure scorer for candidate memory sections: given the text a summarizer
 produced and the recent sections already written to the journal, compute a
-0–100 quality score and a capture action (``write`` / ``degrade`` /
-``reject``). No I/O, no shared state, no LLM — the caller owns the file
+0-100 quality score and a capture action (``write`` / ``degrade`` /
+``reject``). No I/O, no shared state, no LLM - the caller owns the file
 system and the journal, which keeps this module trivially testable and
 shareable across plugin capture paths via ``memsearch quality``.
 """
@@ -12,19 +12,20 @@ from __future__ import annotations
 
 import hashlib
 import re
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Iterable, Literal, Sequence
+from typing import Literal
 
 __all__ = [
-    "MIN_CONTENT_LENGTH_DEFAULT",
     "DEGRADE_THRESHOLD_DEFAULT",
+    "MIN_CONTENT_LENGTH_DEFAULT",
     "REJECT_THRESHOLD_DEFAULT",
-    "QualityVerdict",
     "QualityFilterSettings",
-    "score_section",
+    "QualityVerdict",
     "decide",
     "evaluate_section",
     "extract_sections",
+    "score_section",
 ]
 
 MIN_CONTENT_LENGTH_DEFAULT = 40
@@ -94,7 +95,9 @@ class QualityFilterSettings:
 
 
 def _normalize(text: str) -> str:
-    return _WHITESPACE_RE.sub(" ", text).strip()
+    # Drop lone surrogates that can arrive from platform pipes (e.g. Windows stdin).
+    cleaned = text.encode("utf-8", errors="ignore").decode("utf-8", errors="ignore")
+    return _WHITESPACE_RE.sub(" ", cleaned).strip()
 
 
 def _tokens(text: str) -> list[str]:
@@ -199,7 +202,7 @@ def evaluate_section(
     recent_sections: Sequence[str] | None = None,
     settings: QualityFilterSettings | None = None,
 ) -> QualityVerdict:
-    """Score and decide in one call — the main entry point for capture paths."""
+    """Score and decide in one call - the main entry point for capture paths."""
     cfg = settings or QualityFilterSettings()
     if not cfg.enabled:
         return QualityVerdict(score=100, action="write", reasons=("quality filter disabled",))

--- a/src/memsearch/quality.py
+++ b/src/memsearch/quality.py
@@ -1,0 +1,223 @@
+"""Pre-write memory quality filter (Proposal 002).
+
+A pure scorer for candidate memory sections: given the text a summarizer
+produced and the recent sections already written to the journal, compute a
+0–100 quality score and a capture action (``write`` / ``degrade`` /
+``reject``). No I/O, no shared state, no LLM — the caller owns the file
+system and the journal, which keeps this module trivially testable and
+shareable across plugin capture paths via ``memsearch quality``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Literal, Sequence
+
+__all__ = [
+    "MIN_CONTENT_LENGTH_DEFAULT",
+    "DEGRADE_THRESHOLD_DEFAULT",
+    "REJECT_THRESHOLD_DEFAULT",
+    "QualityVerdict",
+    "QualityFilterSettings",
+    "score_section",
+    "decide",
+    "evaluate_section",
+    "extract_sections",
+]
+
+MIN_CONTENT_LENGTH_DEFAULT = 40
+DEGRADE_THRESHOLD_DEFAULT = 60
+REJECT_THRESHOLD_DEFAULT = 30
+
+Action = Literal["write", "degrade", "reject"]
+
+# Vocabulary of notes that talk about the memory system itself rather than
+# the work. Matched case-insensitively on word boundaries.
+_META_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\[\s*memsearch\s*\]",
+        r"\bmemsearch recall\b",
+        r"\brecall available\b",
+        r"\bmemory recall (status|hint|message)\b",
+        r"\bmemory summary unavailable\b",
+        r"\bmaintenance task\b",
+        r"\bmemory journal\b",
+        r"\bquality filter\b",
+        r"\bsession[- ]wrapup\b",
+    )
+)
+
+# Self-referential agent verbosity boilerplate. These openings mark notes
+# about the conversation's shape rather than its content.
+_BOILERPLATE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"^\s*the user asked\b",
+        r"^\s*user (asked|said|сообщил|спросил)\b",
+        r"^\s*i (replied|answered|responded)\b",
+        r"^\s*я (ответил|предложил)\b",
+        r"\bas an ai\b",
+        r"\bas requested\b",
+        r"\bhere('?s| is) (a |the )?summary\b",
+    )
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_SHINGLE_SIZE = 4
+_MAX_SHINGLES = 512  # cap for bounded, predictable scoring time
+
+
+@dataclass(frozen=True)
+class QualityVerdict:
+    """Result of scoring one candidate section."""
+
+    score: int
+    action: Action
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return {"score": self.score, "action": self.action, "reasons": list(self.reasons)}
+
+
+@dataclass(frozen=True)
+class QualityFilterSettings:
+    """Knobs mirroring the ``[quality_filter]`` config section."""
+
+    enabled: bool = True
+    min_content_length: int = MIN_CONTENT_LENGTH_DEFAULT
+    degrade_threshold: int = DEGRADE_THRESHOLD_DEFAULT
+    reject_threshold: int = REJECT_THRESHOLD_DEFAULT
+
+
+def _normalize(text: str) -> str:
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _tokens(text: str) -> list[str]:
+    return _normalize(text).lower().split()
+
+
+def _token_shingles(tokens: Sequence[str], size: int = _SHINGLE_SIZE) -> set[int]:
+    """Hash word shingles to 64-bit ints for cheap Jaccard comparison."""
+    if len(tokens) < size:
+        if not tokens:
+            return set()
+        digest = hashlib.sha1(" ".join(tokens).encode("utf-8")).digest()
+        return {int.from_bytes(digest[:8], "big")}
+    shingles: set[int] = set()
+    for i in range(min(len(tokens) - size + 1, _MAX_SHINGLES)):
+        digest = hashlib.sha1(" ".join(tokens[i : i + size]).encode("utf-8")).digest()
+        shingles.add(int.from_bytes(digest[:8], "big"))
+    return shingles
+
+
+def _repetition_ratio(tokens: Sequence[str]) -> float:
+    """Fraction of the text covered by repeated tokens (content words only)."""
+    content = [t for t in tokens if len(t) > 3]
+    if not content:
+        return 0.0
+    counts: dict[str, int] = {}
+    for tok in content:
+        counts[tok] = counts.get(tok, 0) + 1
+    repeated = sum(c for c in counts.values() if c > 1)
+    return repeated / len(content)
+
+
+def _max_jaccard(candidate: str, recent_sections: Iterable[str]) -> float:
+    cand_shingles = _token_shingles(_tokens(candidate))
+    if not cand_shingles:
+        return 0.0
+    best = 0.0
+    for section in recent_sections:
+        other = _token_shingles(_tokens(section))
+        if not other:
+            continue
+        union = len(cand_shingles | other)
+        similarity = len(cand_shingles & other) / union if union else 0.0
+        if similarity > best:
+            best = similarity
+    return best
+
+
+def score_section(
+    text: str,
+    recent_sections: Sequence[str] | None = None,
+    settings: QualityFilterSettings | None = None,
+) -> tuple[int, tuple[str, ...]]:
+    """Score a candidate memory section from 0 to 100.
+
+    Higher is better; penalties subtract from a 100 start. Returns the score
+    and the list of triggered penalty reasons. Pure: same inputs, same output,
+    no side effects.
+    """
+    cfg = settings or QualityFilterSettings()
+    reasons: list[str] = []
+    score = 100
+
+    normalized = _normalize(text)
+
+    if any(p.search(text) for p in _META_PATTERNS):
+        score -= 25
+        reasons.append("meta-memory vocabulary")
+
+    if any(p.search(text) for p in _BOILERPLATE_PATTERNS):
+        score -= 10
+        reasons.append("agent-verbosity boilerplate")
+
+    if len(normalized) < cfg.min_content_length:
+        score -= 30
+        reasons.append(f"content shorter than min_content_length ({cfg.min_content_length})")
+
+    tokens = _tokens(text)
+    if tokens and _repetition_ratio(tokens) > 0.6:
+        score -= 20
+        reasons.append("high token repetition ratio")
+
+    if recent_sections and _max_jaccard(text, recent_sections) > 0.8:
+        score -= 40
+        reasons.append("near-duplicate of a recent section")
+
+    return max(score, 0), tuple(reasons)
+
+
+def decide(score: int, settings: QualityFilterSettings | None = None) -> Action:
+    """Map a quality score to a capture action."""
+    cfg = settings or QualityFilterSettings()
+    if score >= cfg.degrade_threshold:
+        return "write"
+    if score >= cfg.reject_threshold:
+        return "degrade"
+    return "reject"
+
+
+def evaluate_section(
+    text: str,
+    recent_sections: Sequence[str] | None = None,
+    settings: QualityFilterSettings | None = None,
+) -> QualityVerdict:
+    """Score and decide in one call — the main entry point for capture paths."""
+    cfg = settings or QualityFilterSettings()
+    if not cfg.enabled:
+        return QualityVerdict(score=100, action="write", reasons=("quality filter disabled",))
+    score, reasons = score_section(text, recent_sections, cfg)
+    return QualityVerdict(score=score, action=decide(score, cfg), reasons=reasons)
+
+
+_SECTION_SPLIT_RE = re.compile(r"^#{2,6}\s+\S", re.MULTILINE)
+_HTML_ANCHOR_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def extract_sections(journal_text: str) -> list[str]:
+    """Split a daily journal file into recent sections for near-dup checks.
+
+    Strips HTML anchor comments (session/turn metadata) so that two different
+    turns from the same session are not marked near-duplicates by their shared
+    anchor. Sections without any heading are kept as one block.
+    """
+    stripped = _HTML_ANCHOR_RE.sub("", journal_text)
+    parts = [p for p in _SECTION_SPLIT_RE.split(stripped) if _normalize(p)]
+    return [_normalize(p) for p in parts]

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,254 @@
+"""Tests for the pre-write memory quality filter (Proposal 002)."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memsearch.cli import cli
+from memsearch.quality import (
+    QualityFilterSettings,
+    decide,
+    evaluate_section,
+    extract_sections,
+    score_section,
+)
+
+GOOD_NOTE = (
+    "Implemented a pre-write scoring gate in memsearch: a new quality.py "
+    "module evaluates candidate memory sections before append, applying "
+    "penalties for meta talk, boilerplate, short content, repetition, and "
+    "near-duplicates."
+)
+
+META_NOTE = "[memsearch] Recall available if needed."
+
+SHORT_NOTE = "Fixed a bug."
+
+DUPLICATE_TEXT = " ".join(["word"] * 60)
+
+
+# -- score_section: individual penalties --
+
+
+def test_clean_section_scores_100() -> None:
+    score, reasons = score_section(GOOD_NOTE)
+    assert score == 100
+    assert reasons == ()
+
+
+def test_meta_memory_vocabulary_penalized() -> None:
+    # Long enough to avoid the short-content penalty, no other penalty.
+    text = "Discussed plugin behaviour: [memsearch] Recall available if needed, and hooks."
+    score, reasons = score_section(text)
+    assert score == 100 - 25
+    assert "meta-memory vocabulary" in reasons
+
+
+def test_agent_boilerplate_penalized() -> None:
+    text = "The user asked about deployment options. " + GOOD_NOTE
+    score, reasons = score_section(text)
+    assert score == 100 - 10
+    assert "agent-verbosity boilerplate" in reasons
+
+
+def test_short_content_penalized() -> None:
+    score, reasons = score_section(SHORT_NOTE)
+    assert "content shorter than min_content_length (40)" in reasons
+    assert score == 100 - 30
+
+
+def test_short_content_respects_setting() -> None:
+    cfg = QualityFilterSettings(min_content_length=5)
+    score, reasons = score_section(SHORT_NOTE, settings=cfg)
+    assert reasons == ()
+    assert score == 100
+
+
+def test_high_repetition_penalized() -> None:
+    text = " ".join(["important"] * 80)
+    score, reasons = score_section(text)
+    assert score == 100 - 20
+    assert "high token repetition ratio" in reasons
+
+
+def test_normal_prose_has_low_repetition() -> None:
+    _, reasons = score_section(GOOD_NOTE)
+    assert "high token repetition ratio" not in reasons
+
+
+def test_near_duplicate_penalized() -> None:
+    recent = [GOOD_NOTE]
+    score, reasons = score_section(GOOD_NOTE, recent_sections=recent)
+    assert score == 100 - 40
+    assert "near-duplicate of a recent section" in reasons
+
+
+def test_distinct_section_not_flagged_as_duplicate() -> None:
+    recent = [GOOD_NOTE]
+    other = (
+        "Ubuntu parity run completed: 413 passed, 7 skipped on the Linux "
+        "native clone; PR description updated with the verification matrix."
+    )
+    _, reasons = score_section(other, recent_sections=recent)
+    assert "near-duplicate of a recent section" not in reasons
+
+
+def test_penalties_stack() -> None:
+    text = "[memsearch] Recall available. short"
+    score, reasons = score_section(text)
+    assert score == 100 - 25 - 30
+    assert len(reasons) == 2
+
+
+def test_score_never_negative() -> None:
+    # All five penalties at once via a raised min_content_length.
+    text = "The user asked [memsearch] blah blah blah blah blah blah"
+    cfg = QualityFilterSettings(min_content_length=10_000)
+    score, reasons = score_section(text, recent_sections=[text], settings=cfg)
+    assert len(reasons) == 5
+    assert score == 0
+
+
+# -- decide / evaluate_section --
+
+
+def test_decide_boundaries() -> None:
+    assert decide(60) == "write"
+    assert decide(100) == "write"
+    assert decide(59) == "degrade"
+    assert decide(30) == "degrade"
+    assert decide(29) == "reject"
+    assert decide(0) == "reject"
+
+
+def test_disabled_filter_writes_everything() -> None:
+    verdict = evaluate_section(SHORT_NOTE, settings=QualityFilterSettings(enabled=False))
+    assert verdict.action == "write"
+    assert verdict.score == 100
+
+
+def test_evaluate_section_rejects_garbage() -> None:
+    text = "The user asked [memsearch] blah blah blah blah blah blah"
+    cfg = QualityFilterSettings(min_content_length=10_000)
+    verdict = evaluate_section(text, recent_sections=[text], settings=cfg)
+    assert verdict.action == "reject"
+
+
+# -- purity (property-style invariants) --
+
+
+def test_score_is_deterministic() -> None:
+    for _ in range(5):
+        assert score_section(META_NOTE + " " + DUPLICATE_TEXT) == score_section(
+            META_NOTE + " " + DUPLICATE_TEXT
+        )
+
+
+def test_score_does_not_mutate_inputs() -> None:
+    recent = [GOOD_NOTE]
+    snapshot = list(recent)
+    score_section(GOOD_NOTE, recent_sections=recent)
+    assert recent == snapshot
+
+
+# -- extract_sections --
+
+
+def test_extract_sections_splits_on_headings_and_strips_anchors() -> None:
+    journal = (
+        "### 01:10\n<!-- session:s1 turn:2 db:x -->\nFirst turn note.\n\n"
+        "### 01:23\n<!-- session:s2 turn:7 db:y -->\nSecond turn note.\n"
+    )
+    sections = extract_sections(journal)
+    assert len(sections) == 2
+    assert "session:s1" not in sections[0]
+    assert "First turn note." in sections[0]
+
+
+def test_anchors_do_not_create_false_duplicates() -> None:
+    # A new turn summary that only shares anchor metadata (and differs in
+    # content) must not be flagged as a near-duplicate; identical content must.
+    candidate = (
+        "Configured the DSH web profile to link the memsearch plugin and "
+        "documented restart instructions for future sessions."
+    )
+    journal = (
+        "### 01:10\n<!-- session:s1 turn:2 db:x -->\n" + GOOD_NOTE + "\n\n"
+        "### 01:20\n<!-- session:s1 turn:3 db:x -->\n" + GOOD_NOTE + "\n"
+    )
+    recent = extract_sections(journal)
+    _, reasons = score_section(candidate, recent_sections=recent)
+    assert "near-duplicate of a recent section" not in reasons
+    _, reasons = score_section(GOOD_NOTE, recent_sections=recent)
+    assert "near-duplicate of a recent section" in reasons
+
+
+# -- regression: real conversational turn summaries are not rejected --
+
+
+REAL_TURN_SUMMARIES = [
+    GOOD_NOTE,
+    "Opened PR zilliztech/memsearch#729 documenting three proposals: idle "
+    "consolidation, pre-write quality filter, and heat/cold archive.",
+    "Ubuntu parity run for feat/llm-audit finished: 413 passed, 7 skipped; "
+    "the PR was marked ready for review afterwards.",
+    "Reviewed the DSH plugin summarize path and confirmed the profile override "
+    "reaches the headless summarizer without changing the Web model.",
+    "Discussed merge timing for PR #721 with the user; expectations set to "
+    "several hours up to a few days depending on maintainer availability.",
+]
+
+
+def test_regression_reject_rate_on_real_turns() -> None:
+    written: list[str] = []
+    rejected = 0
+    for note in REAL_TURN_SUMMARIES:
+        verdict = evaluate_section(note, recent_sections=written)
+        if verdict.action == "reject":
+            rejected += 1
+        else:
+            written.append(note)
+    assert rejected == 0
+    assert len(written) == len(REAL_TURN_SUMMARIES)
+
+
+# -- CLI --
+
+
+def test_quality_cli_from_stdin_json() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "-j"], input=GOOD_NOTE)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] == "write"
+    assert payload["score"] == 100
+
+
+def test_quality_cli_rejects_meta_noise() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "-j"], input=META_NOTE)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] in {"degrade", "reject"}
+    assert "meta-memory vocabulary" in payload["reasons"]
+
+
+def test_quality_cli_recent_file(tmp_path) -> None:
+    journal = tmp_path / "2026-09-08.md"
+    journal.write_text(f"### 01:10\n<!-- anchor -->\n{GOOD_NOTE}\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["quality", "-j", "--recent-file", str(journal)], input=GOOD_NOTE
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "near-duplicate of a recent section" in payload["reasons"]
+
+
+def test_quality_cli_plain_output() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality"], input=SHORT_NOTE)
+    assert result.exit_code == 0, result.output
+    assert "action:" in result.output


### PR DESCRIPTION
Stacked on #731 (merge that first - the diff below includes its commits until then).

## Summary

Wires the Proposal 002 quality filter from #731 into the capture paths, so candidate sections are scored **before** they are appended to `memory/YYYY-MM-DD.md`:

- **`plugins/dsh/index.js`**: new `runQualityGate` helper calls `memsearch quality --json-output` (with `--recent-file` once the day's journal exists). Fail-open by design: a disabled filter, an older memsearch without the `quality` subcommand, a timeout, or a config read failure all write normally - a gating hiccup must never lose a turn. `processTurn` skips rejected turns (the session-log transcript anchor retains the raw turn) and records `quality:NN` in the section anchor for degraded ones; the tag sits after `turn:` so the `captureExists` prefix dedup keeps matching.
- **`plugins/claude-code/hooks/stop.sh`**: the same gate before the journal append - reject skips the write, degrade tags the anchor, failure writes normally.
- **Tests**: anchor format + dedup with the quality tag; gate verdict parsing and `--recent-file` propagation against a fake CLI; fail-open on an incompatible CLI. Bash-spawning tests skip cleanly on hosts without a usable bash (e.g. WSL default distro without coreutils).

## Testing

- `node --test plugins/dsh/tests` on Ubuntu: 46/47 - the single failure is a pre-existing environmental `dsh-headless` summarize timeout (30 s agent boot), unrelated to this change; both quality-gate tests pass there.
- Full pytest on Ubuntu: **450 passed, 7 skipped**.
- On Windows: 12 pre-existing bash/WSL environment failures (verified identical on clean `origin/main`); quality tests skip as designed.