### PR TITLE
docs(plugin): explain model selection for forked skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ When modifying hooks/skills, keep in mind:
 - The watch process uses a PID file (`.memsearch/.watch.pid`) for singleton behavior. Milvus Lite falls back to one-time `index()` at session start
 - `stop.sh` has a recursion guard (`stop_hook_active`) since it calls `claude -p` internally, and sets `MEMSEARCH_NO_WATCH=1` to prevent the child process from interfering with the main session's watch
 - The `memory-recall` skill uses `context: fork` — the subagent has its own context window and does not see main conversation history
+- Leave `model` unset in the Claude Code skills' frontmatter so users can choose a default through `CLAUDE_CODE_SUBAGENT_MODEL`. See [skill model selection](docs/platforms/claude-code/memory-recall.md#which-model-runs-the-skill) for precedence and overrides
 - `transcript.py` lives in the plugin directory (not in core library) since it is entirely Claude Code JSONL-specific
 
 ## Key Design Decisions

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -263,5 +263,5 @@ plugins/claude-code/
 | `parse-transcript.sh` | Standalone last-turn extractor using Python 3. Outputs role-labeled text. No `jq` dependency. |
 | `session-end.sh` | Asynchronously stops the Server watcher and cleans up plugin-owned background index processes. |
 | `derive-collection.sh` | Generates a deterministic per-project Milvus collection name from the project path (e.g., `ms_myproject_a1b2c3`). |
-| `SKILL.md` | The memory-recall skill definition. Uses `context: fork` to run in an isolated subagent. |
+| `SKILL.md` | The memory-recall skill definition. Uses `context: fork` to run in an isolated subagent and leaves `model` unset. See [model selection](memory-recall.md#which-model-runs-the-skill). |
 | `transcript.py` | Python JSONL parser for Claude Code conversations. Plugin-specific (not in core library); exercised by `tests/test_transcript.py`. The `memory-recall` skill's L3 drill-down uses the core `memsearch transcript` CLI (which auto-detects the format) rather than calling this file directly. |

--- a/docs/platforms/claude-code/memory-recall.md
+++ b/docs/platforms/claude-code/memory-recall.md
@@ -126,6 +126,26 @@ memsearch index .memsearch/memory/ --force
 
 ---
 
+## Which Model Runs the Skill
+
+The plugin's three skills (`memory-recall`, `memory-config`, and `memory-to-skill`) use `context: fork` and leave `model` unset in their frontmatter. By default, they use `CLAUDE_CODE_SUBAGENT_MODEL` when set, or your main conversation's model otherwise.
+
+For example, to use Sonnet as the default for subagents, add this entry to the `env` object in your Claude Code `settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
+  }
+}
+```
+
+Start a new session to use the setting. It also affects other subagents, so it is not specific to this plugin.
+
+In Claude Code 2.1.251 and later, a per-invocation model or a frontmatter `model` takes precedence over this default. The plugin leaves `model` unset to preserve your choice of default. Claude Code also provides `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` to override model selections; see [the subagent model rules](https://code.claude.com/docs/en/sub-agents#choose-a-model) for details and exceptions.
+
+---
+
 ## Comparison with claude-mem's Recall
 
 Both memsearch and [claude-mem](https://github.com/thedotmack/claude-mem) provide memory recall for Claude Code, but the retrieval architecture differs significantly:

--- a/docs/platforms/claude-code/memory-recall.md
+++ b/docs/platforms/claude-code/memory-recall.md
@@ -142,7 +142,17 @@ For example, to use Sonnet as the default for subagents, add this entry to the `
 
 Start a new session to use the setting. It also affects other subagents, so it is not specific to this plugin.
 
-In Claude Code 2.1.251 and later, a per-invocation model or a frontmatter `model` takes precedence over this default. The plugin leaves `model` unset to preserve your choice of default. Claude Code also provides `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` to override model selections; see [the subagent model rules](https://code.claude.com/docs/en/sub-agents#choose-a-model) for details and exceptions.
+In Claude Code 2.1.251 and later, an ordinary subagent's model is selected in this order: a per-invocation `model`, the agent or forked skill's frontmatter `model`, `CLAUDE_CODE_SUBAGENT_MODEL`, then the main conversation's model. Before 2.1.251, the environment variable came first, even over `model: inherit`. The plugin leaves `model` unset, so its forked skills use your configured default. Setting only `CLAUDE_CODE_SUBAGENT_MODEL` does not change the built-in Explore or Plan subagents.
+
+Every requested model is still checked against your organization's `availableModels` allowlist. If a blocked value is a model-family alias, Claude Code substitutes the newest allowed model in that family. Other blocked values, providers where substitution is unavailable, and families with no allowed model fall back to the inherited model.
+
+Claude Code 2.1.257 and later also supports `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1`:
+
+- With both variables set, ordinary subagents and the built-in Explore and Plan subagents use `CLAUDE_CODE_SUBAGENT_MODEL`, ignoring per-invocation and frontmatter choices.
+- With only `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` set, subagents use the main conversation's model, although Explore keeps its model cap.
+- Conversation forks always use the main conversation's model. A `context: fork` skill with an explicit `model: inherit` does too, even when both variables are set. The MemSearch skills do not declare `model: inherit`; they omit `model`, so this exception does not apply to them.
+
+See [the Claude Code subagent model rules](https://code.claude.com/docs/en/sub-agents#choose-a-model) and [forked skill rules](https://code.claude.com/docs/en/skills#run-skills-in-a-subagent) for the authoritative behavior.
 
 ---
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -222,6 +222,18 @@ When Claude detects that a user's question could benefit from past context, it a
 
 The main agent only sees the final summary — all intermediate search results, raw expand output, and transcript parsing happen inside the subagent.
 
+**Which model runs the skill.** The plugin's three skills leave `model` unset in their frontmatter. By default, they use `CLAUDE_CODE_SUBAGENT_MODEL` when set, or your main conversation's model otherwise. For example, to default subagents to Sonnet, add this entry to the `env` object in your Claude Code `settings.json`, then start a new session:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
+  }
+}
+```
+
+This setting also affects other subagents. See [model selection](../../docs/platforms/claude-code/memory-recall.md#which-model-runs-the-skill) for precedence and overrides.
+
 Users can manually invoke the skill:
 
 ```


### PR DESCRIPTION
The docs explain that the plugin's three skills run in isolated subagents, but omit how their models are chosen. Without a configured default, these skills use the main conversation's model.

Document `CLAUDE_CODE_SUBAGENT_MODEL` with a `settings.json` example, explain precedence and overrides, and note that the setting also affects other subagents. Add this guidance to the recall page and plugin README, with links from the plugin file table and contributor instructions.

The skills leave `model` unset so users can configure the default. This PR changes documentation only.

## Validation

- Strict MkDocs build and JSON example validation passed.
- The original Claude Code 2.1.263 probes observed session-model inheritance and a Sonnet frontmatter selection. They did not exercise the environment-variable setting; that behavior is documented from Claude Code's subagent reference.

Assisted-by: Claude:claude-fable-5-1
Assisted-by: Codex:gpt-6