### PR TITLE
fix(dsh): snapshotEvents compat and stdin EOF for headless summarizer

### DIFF
--- a/docs/platforms/dsh/how-it-works.md
+++ b/docs/platforms/dsh/how-it-works.md
@@ -25,7 +25,7 @@ flowchart LR
 The plugin listens for DSH `session/event` notifications and handles completed turns. It:
 
 1. resolves the durable project directory from the session;
-2. renders user, assistant, and tool activity into a bounded transcript;
+2. renders user, assistant, and tool activity into a bounded transcript, reading the event log through `session.snapshotEvents()` (falling back to the legacy `session.events` array on older hosts);
 3. summarizes the turn without blocking the active conversation;
 4. appends the result to `.memsearch/memory/YYYY-MM-DD.md` with a session anchor;
 5. lets the shared MemSearch index make the new entry searchable.
@@ -55,7 +55,7 @@ The same markdown journal can contain entries produced by Claude Code, Codex, DS
 `summarizeMode` selects the capture backend:
 
 - **`auto`** (default) uses a configured `[plugins.dsh.summarize]` provider when present; otherwise it uses `dsh-headless`.
-- **`dsh-headless`** starts a one-shot headless DSH agent using the model selected by the DSH deployment. The child process disables the MemSearch plugin to prevent recursive capture.
+- **`dsh-headless`** starts a one-shot headless DSH agent using the model selected by the DSH deployment. The child process is spawned with a closed stdin (immediate EOF) so nothing waits on an open pipe, and disables the MemSearch plugin to prevent recursive capture.
 - **`custom-llm`** calls a provider from the shared MemSearch configuration directly, which is useful for assigning a small dedicated summarization model.
 
 There is no silent fallback to a different backend. If the selected summarizer is unavailable, the journal records a short unavailable note with the original transcript anchor instead of writing an unsummarized conversation dump.

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -841,6 +841,21 @@ function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Replace unpaired UTF-16 surrogate code units with U+FFFD.
+ *
+ * Transcripts can carry lone surrogates (e.g. from console-captured text);
+ * they cannot be encoded to UTF-8, and writing them to a child's stdin
+ * (or passing them as an argv value on Windows) throws instead of failing
+ * over a whole captured turn.
+ */
+function sanitizeSurrogates(text) {
+  return String(text).replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    '\uFFFD',
+  )
+}
+
+/**
  * Summarize one rendered turn via scripts/summarize.py — the memsearch-managed
  * `[llm.providers.*]` route (the `custom-llm` mode). Lightweight: a single
  * python process, no DSH boot. Model/provider come from memsearch config
@@ -869,7 +884,7 @@ function summarizeCustomLlm(opts, render, projectDir) {
         reject(new Error(stderr.trim() || `summarize.py exited with status ${code}`))
       }
     })
-    child.stdin.write(render)
+    child.stdin.write(sanitizeSurrogates(render))
     child.stdin.end()
     const timer = setTimeout(() => {
       try { child.kill('SIGKILL') } catch { /* already exited */ }
@@ -943,7 +958,7 @@ function summarizeHeadless(ctx, opts, render, projectDir) {
     } catch {
       systemPrompt = `You are a third-person note-taker for {{AGENT_NAME}}. Record the following transcript as 2-10 bullet points in the same language as the [User] text. Output ONLY bullet points.`.replaceAll('{{AGENT_NAME}}', opts.agentName)
     }
-    const task = `${systemPrompt}\n\nTranscript:\n${render}`
+    const task = `${systemPrompt}\n\nTranscript:\n${sanitizeSurrogates(render)}`
 
     const args = ['--profile', 'headless', task]
 
@@ -1362,6 +1377,9 @@ export { renderTurn }
 
 /** True when a session/turn anchor already exists in the memory dir. */
 export { captureExists }
+
+/** Replace unpaired UTF-16 surrogates with U+FFFD before child I/O. */
+export { sanitizeSurrogates }
 
 /** Append a captured turn to the daily memory file (shared format). */
 export { writeCapture }

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -764,7 +764,14 @@ function sessionLogPath(ctx, session) {
  */
 function renderTurn(session, turnEndEvent) {
   const turn = turnEndEvent.data.turn
-  const events = session.events
+  // DSH Session replaced its public `events` array with `snapshotEvents()`.
+  // Prefer the current immutable projection while retaining compatibility with
+  // older hosts that still expose the array. Without either, capture skips the
+  // turn rather than throwing into the event listener.
+  const events = typeof session.snapshotEvents === 'function'
+    ? session.snapshotEvents()
+    : session.events
+  if (!Array.isArray(events)) return null
   const startIndex = events.findIndex(
     (event) => event.type === 'turn/start' && event.data.turn === turn,
   )
@@ -943,6 +950,10 @@ function summarizeHeadless(ctx, opts, render, projectDir) {
     const child = spawn(dshCmd[0], [...dshCmd.slice(1), ...args], {
       cwd: projectDir,
       env: { ...process.env, MEMSEARCH_DSH_SUMMARIZE: '1' },
+      // The child never reads stdin: give it an immediately-closed stream so
+      // anything waiting for EOF (the dsh CLI or a wrapper script) is not left
+      // hanging on an open pipe until the timeout kills the process.
+      stdio: ['ignore', 'pipe', 'pipe'],
     })
     let stdout = ''
     let stderr = ''

--- a/plugins/dsh/index.js
+++ b/plugins/dsh/index.js
@@ -763,38 +763,76 @@ function sessionLogPath(ctx, session) {
  * turn carries no genuine user message.
  */
 function renderTurn(session, turnEndEvent) {
-  const turn = turnEndEvent.data.turn
+  const turn = turnEndEvent?.data?.turn
+  if (turn === undefined) return null
   // DSH Session replaced its public `events` array with `snapshotEvents()`.
-  // Prefer the current immutable projection while retaining compatibility with
-  // older hosts that still expose the array. Without either, capture skips the
-  // turn rather than throwing into the event listener.
-  const events = typeof session.snapshotEvents === 'function'
-    ? session.snapshotEvents()
-    : session.events
-  if (!Array.isArray(events)) return null
-  const startIndex = events.findIndex(
-    (event) => event.type === 'turn/start' && event.data.turn === turn,
-  )
-  if (startIndex < 0) return null
-  const endIndex = events.findIndex(
-    (event) => event.type === 'turn/end' && event.data.turn === turn,
-  )
-  const turnEvents = endIndex > startIndex ? events.slice(startIndex + 1, endIndex) : []
+  // Prefer its immutable projection, but treat a throwing, malformed, empty,
+  // or incomplete projection as unusable and retry the legacy events array.
+  // Once a complete snapshot turn is found, its content is authoritative.
+  let snapshot
+  if (typeof session?.snapshotEvents === 'function') {
+    try {
+      snapshot = session.snapshotEvents()
+    } catch { /* retry the legacy projection */ }
+  }
+
+  const findTurn = (events) => {
+    if (!Array.isArray(events) || events.length === 0) return null
+
+    // Prefer the exact event that triggered capture. Identity works for the
+    // legacy array; seq works for immutable projections. Otherwise the latest
+    // matching end is the safest choice when malformed input repeats a turn.
+    let endIndex = events.findIndex(
+      (event) => event === turnEndEvent
+        && event?.type === 'turn/end'
+        && event?.data?.turn === turn,
+    )
+    if (endIndex < 0 && Number.isSafeInteger(turnEndEvent?.seq)) {
+      endIndex = events.findIndex(
+        (event) => event?.seq === turnEndEvent.seq
+          && event?.type === 'turn/end'
+          && event?.data?.turn === turn,
+      )
+    }
+    if (endIndex < 0) {
+      endIndex = events.findLastIndex(
+        (event) => event?.type === 'turn/end' && event?.data?.turn === turn,
+      )
+    }
+    if (endIndex < 0) return null
+
+    let startIndex = -1
+    for (let index = endIndex - 1; index >= 0; index -= 1) {
+      const event = events[index]
+      if (event?.type === 'turn/start' && event?.data?.turn === turn) {
+        startIndex = index
+        break
+      }
+    }
+    if (startIndex < 0) return null
+    return events.slice(startIndex + 1, endIndex)
+  }
+
+  let turnEvents = findTurn(snapshot)
+  if (turnEvents === null && session?.events !== snapshot) {
+    turnEvents = findTurn(session?.events)
+  }
+  if (turnEvents === null) return null
 
   const lines = [`=== Turn ${turn} ===`]
   let hasUser = false
   for (const event of turnEvents) {
-    if (event.type === 'user/message') {
-      if (event.data.source?.kind !== 'user') continue
-      const text = textFromContent(event.data.content)
+    if (event?.type === 'user/message') {
+      if (event.data?.source?.kind !== 'user') continue
+      const text = textFromContent(event.data?.content)
       if (!text) continue
       lines.push('', `[User]: ${text}`)
       hasUser = true
-    } else if (event.type === 'assistant/message') {
-      const text = textFromContent(event.data.message?.content)
+    } else if (event?.type === 'assistant/message') {
+      const text = textFromContent(event.data?.message?.content)
       if (!text) continue
       lines.push('', `[Assistant]: ${text}`)
-    } else if (event.type === 'tool/call') {
+    } else if (event?.type === 'tool/call' && event.data?.name) {
       lines.push('', `[Tool call]: ${event.data.name}`)
     }
   }
@@ -843,16 +881,88 @@ function writeCapture(memoryDir, body, sessionId, turn, dbPath) {
 /**
  * Replace unpaired UTF-16 surrogate code units with U+FFFD.
  *
- * Transcripts can carry lone surrogates (e.g. from console-captured text);
- * they cannot be encoded to UTF-8, and writing them to a child's stdin
- * (or passing them as an argv value on Windows) throws instead of failing
- * over a whole captured turn.
+ * Transcripts can carry lone surrogates (e.g. from console-captured text).
+ * Normalize them explicitly so UTF-8 streams and platform argv conversion
+ * produce the same replacement text instead of relying on implicit behavior.
  */
 function sanitizeSurrogates(text) {
   return String(text).replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
     '\uFFFD',
   )
+}
+
+/** Terminate a summarizer and its descendants after a timeout. */
+function killProcessTree(child) {
+  if (!child.pid) return
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
+      return
+    } catch { /* fall back to the direct child */ }
+  } else {
+    try {
+      process.kill(-child.pid, 'SIGKILL')
+      return
+    } catch { /* fall back to the direct child */ }
+  }
+  try { child.kill('SIGKILL') } catch { /* already exited */ }
+}
+
+/** Collect one summarizer child exactly once, waiting for close after timeout. */
+function collectSummarizerChild(child, {
+  input,
+  timeoutMs,
+  timeoutMessage,
+  exitMessage,
+}) {
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    let stderr = ''
+    let processError = null
+    let stdinError = null
+    let timedOut = false
+
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', (data) => { stdout += data })
+    child.stderr?.on('data', (data) => { stderr += data })
+    child.once('error', (error) => { processError ??= error })
+    child.stdin?.once('error', (error) => {
+      stdinError ??= error
+      killProcessTree(child)
+    })
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      killProcessTree(child)
+    }, timeoutMs)
+    timer.unref?.()
+
+    child.once('close', (code) => {
+      clearTimeout(timer)
+      if (timedOut) {
+        reject(new Error(timeoutMessage))
+      } else if (processError) {
+        reject(processError)
+      } else if (stdinError) {
+        reject(stdinError)
+      } else if (code === 0) {
+        resolve(stdout.trim() || null)
+      } else {
+        reject(new Error(stderr.trim() || `${exitMessage} ${code}`))
+      }
+    })
+
+    if (input !== undefined) {
+      try {
+        child.stdin.end(input)
+      } catch (error) {
+        stdinError = error
+        killProcessTree(child)
+      }
+    }
+  })
 }
 
 /**
@@ -863,34 +973,22 @@ function sanitizeSurrogates(text) {
  * `resolveSummarizeMode` into `opts.summarizeProvider` / `opts.summarizeModel`.
  */
 function summarizeCustomLlm(opts, render, projectDir) {
-  return new Promise((resolve, reject) => {
-    const args = [
-      join(PLUGIN_DIR, 'scripts', 'summarize.py'),
-      '--agent-name', opts.agentName,
-      '--project-dir', projectDir,
-    ]
-    if (opts.summarizeProvider) args.push('--provider', opts.summarizeProvider)
-    if (opts.summarizeModel) args.push('--model', opts.summarizeModel)
-    const child = spawn('python3', args, { cwd: projectDir })
-    let stdout = ''
-    let stderr = ''
-    child.stdout.on('data', (data) => { stdout += data })
-    child.stderr.on('data', (data) => { stderr += data })
-    child.on('error', reject)
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(stdout.trim() || null)
-      } else {
-        reject(new Error(stderr.trim() || `summarize.py exited with status ${code}`))
-      }
-    })
-    child.stdin.write(sanitizeSurrogates(render))
-    child.stdin.end()
-    const timer = setTimeout(() => {
-      try { child.kill('SIGKILL') } catch { /* already exited */ }
-      reject(new Error('summarization timed out'))
-    }, SUMMARIZE_TIMEOUT_MS)
-    timer.unref?.()
+  const args = [
+    join(PLUGIN_DIR, 'scripts', 'summarize.py'),
+    '--agent-name', opts.agentName,
+    '--project-dir', projectDir,
+  ]
+  if (opts.summarizeProvider) args.push('--provider', opts.summarizeProvider)
+  if (opts.summarizeModel) args.push('--model', opts.summarizeModel)
+  const child = spawn('python3', args, {
+    cwd: projectDir,
+    detached: process.platform !== 'win32',
+  })
+  return collectSummarizerChild(child, {
+    input: sanitizeSurrogates(render),
+    timeoutMs: opts.summarizeTimeoutMs ?? SUMMARIZE_TIMEOUT_MS,
+    timeoutMessage: 'summarization timed out',
+    exitMessage: 'summarize.py exited with status',
   })
 }
 
@@ -945,12 +1043,11 @@ function detectDshCmd() {
  * gets re-captured and re-summarized in an infinite loop.
  */
 function summarizeHeadless(ctx, opts, render, projectDir) {
-  return new Promise((resolve, reject) => {
-    const dshCmd = detectDshCmd()
-    if (!dshCmd) {
-      reject(new Error('dsh CLI not found; set DSH_CLI or install dsh on PATH for summarizeMode=dsh-headless'))
-      return
-    }
+  const dshCmd = detectDshCmd()
+  if (!dshCmd) {
+    return Promise.reject(new Error('dsh CLI not found; set DSH_CLI or install dsh on PATH for summarizeMode=dsh-headless'))
+  }
+  try {
     const promptFile = join(PLUGIN_DIR, 'prompts', 'summarize.txt')
     let systemPrompt
     try {
@@ -965,31 +1062,20 @@ function summarizeHeadless(ctx, opts, render, projectDir) {
     const child = spawn(dshCmd[0], [...dshCmd.slice(1), ...args], {
       cwd: projectDir,
       env: { ...process.env, MEMSEARCH_DSH_SUMMARIZE: '1' },
+      detached: process.platform !== 'win32',
       // The child never reads stdin: give it an immediately-closed stream so
       // anything waiting for EOF (the dsh CLI or a wrapper script) is not left
       // hanging on an open pipe until the timeout kills the process.
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    let stdout = ''
-    let stderr = ''
-    child.stdout.on('data', (data) => { stdout += data })
-    child.stderr.on('data', (data) => { stderr += data })
-    child.on('error', (error) => {
-      reject(error)
+    return collectSummarizerChild(child, {
+      timeoutMs: opts.summarizeTimeoutMs ?? SUMMARIZE_TIMEOUT_MS,
+      timeoutMessage: 'dsh headless summarization timed out',
+      exitMessage: 'dsh headless summarize exited with status',
     })
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(stdout.trim() || null)
-      } else {
-        reject(new Error(stderr.trim() || `dsh headless summarize exited with status ${code}`))
-      }
-    })
-    const timer = setTimeout(() => {
-      try { child.kill('SIGKILL') } catch { /* already exited */ }
-      reject(new Error('dsh headless summarization timed out'))
-    }, SUMMARIZE_TIMEOUT_MS)
-    timer.unref?.()
-  })
+  } catch (error) {
+    return Promise.reject(error)
+  }
 }
 
 /**

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -36,7 +36,7 @@ import sys
 from pathlib import Path
 
 # The child inherits the host's console code page (e.g. cp1251 on ru-RU
-# Windows); summaries legitimately contain characters outside it (×, ≈, CJK).
+# Windows); summaries legitimately contain multiplication/approximation signs and CJK.
 # Force UTF-8 with replacement so printing the summary never crashes.
 if sys.stdout and hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")

--- a/plugins/dsh/scripts/summarize.py
+++ b/plugins/dsh/scripts/summarize.py
@@ -35,6 +35,14 @@ import os
 import sys
 from pathlib import Path
 
+# The child inherits the host's console code page (e.g. cp1251 on ru-RU
+# Windows); summaries legitimately contain characters outside it (×, ≈, CJK).
+# Force UTF-8 with replacement so printing the summary never crashes.
+if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr and hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # ---------------------------------------------------------------------------
 # memsearch importability bootstrap (shared with plugins/_shared/scripts)
 # ---------------------------------------------------------------------------

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 
-import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget } from '../index.js'
+import { detectDshCmd, summarizeTurn, apply, resolveSummarizeMode, renderTurn, captureExists, writeCapture, memsearchDirFor, listSkillCandidates, resolveSkillInstallTarget, sanitizeSurrogates } from '../index.js'
 
 async function withInjectionFixture(searchResults, assertion, oldCore = false) {
   const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-inject-`)
@@ -700,6 +700,16 @@ test('renderTurn: prefers session.snapshotEvents() over the legacy events array'
 test('renderTurn: returns null when neither snapshotEvents nor events is available', () => {
   assert.equal(renderTurn({}, { data: { turn: 1 } }), null)
   assert.equal(renderTurn({ snapshotEvents: () => null }, { data: { turn: 1 } }), null)
+})
+
+test('sanitizeSurrogates: lone surrogates become U+FFFD, valid pairs survive', () => {
+  const lone = '\udc98' // unpaired low surrogate from console-captured text
+  const pair = '\uD83D\uDE00' // 😀 (valid surrogate pair)
+  const out = sanitizeSurrogates(`a${lone}b${pair}c`)
+  assert.ok(!out.includes(lone), 'lone surrogate removed')
+  assert.ok(out.includes(pair), 'valid surrogate pair preserved')
+  // The result must be encodable to UTF-8 (the property child stdin requires).
+  assert.doesNotThrow(() => Buffer.from(out, 'utf-8'))
 })
 
 test('writeCapture + captureExists: writes shared format and dedups', () => {

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -608,6 +608,47 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   }
 })
 
+test('summarizeHeadless: child receives EOF on stdin and does not hang', async () => {
+  // The spawned dsh child must not be left waiting on an open stdin pipe:
+  // a child (or wrapper script) that reads stdin to EOF would otherwise hang
+  // until the summarize timeout kills it. Point DSH_CLI at a Node recorder
+  // that exits only after stdin ends, then assert it completed promptly.
+  const prevCli = process.env.DSH_CLI
+  const prevDshSummarize = process.env.MEMSEARCH_DSH_SUMMARIZE
+  const tmp = os.tmpdir()
+  const recorder = `${tmp}/memsearch-dsh-stdin-eof-${process.pid}.mjs`
+  const markerFile = `${tmp}/memsearch-dsh-stdin-eof-${process.pid}.txt`
+  fs.writeFileSync(
+    recorder,
+    'import { writeFileSync } from "node:fs";\n' +
+      'process.stdin.resume();\n' +
+      `process.stdin.once("end", () => { writeFileSync(${JSON.stringify(markerFile)}, "eof"); process.exit(0); });\n` +
+      'setTimeout(() => process.exit(4), 25000).unref();\n',
+    'utf-8',
+  )
+  try {
+    // detectDshCmd splits DSH_CLI on whitespace; quote the interpreter path is
+    // not needed because process.execPath and tmpdir contain no spaces here.
+    process.env.DSH_CLI = `${process.execPath} ${recorder}`
+    const opts = { summarizeMode: 'dsh-headless', agentName: 'X' }
+    const ctx = { logger: { warn: () => {} } }
+    const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
+    const started = Date.now()
+    const summary = await summarizeTurn(ctx, opts, render, process.cwd())
+    const elapsed = Date.now() - started
+    assert.equal(summary, null, 'recorder exits 0 with no stdout -> null summary')
+    assert.ok(elapsed < 20000, `recorder should exit on stdin EOF, took ${elapsed}ms`)
+    assert.equal(fs.readFileSync(markerFile, 'utf-8'), 'eof', 'stdin EOF reached the child')
+  } finally {
+    try { fs.unlinkSync(recorder) } catch { /* cleanup */ }
+    try { fs.unlinkSync(markerFile) } catch { /* cleanup */ }
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    if (prevDshSummarize === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
+    else process.env.MEMSEARCH_DSH_SUMMARIZE = prevDshSummarize
+  }
+})
+
 test('renderTurn: renders user/assistant/tool events into the shared format', () => {
   const session = {
     events: [
@@ -634,6 +675,31 @@ test('renderTurn: returns null when no user message', () => {
     ],
   }
   assert.equal(renderTurn(session, { data: { turn: 1 } }), null)
+})
+
+test('renderTurn: prefers session.snapshotEvents() over the legacy events array', () => {
+  // Newer DSH Session replaced the public `events` array with an immutable
+  // snapshotEvents() projection; when both are present the snapshot wins.
+  const session = {
+    events: [
+      { type: 'turn/start', data: { turn: 2 } },
+      { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'stale legacy events' }] } },
+      { type: 'turn/end', data: { turn: 2 } },
+    ],
+    snapshotEvents: () => [
+      { type: 'turn/start', data: { turn: 2 } },
+      { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'snapshot capture marker' }] } },
+      { type: 'turn/end', data: { turn: 2 } },
+    ],
+  }
+  const render = renderTurn(session, { data: { turn: 2 } })
+  assert.ok(render.includes('snapshot capture marker'), 'uses snapshotEvents instead of the removed events array')
+  assert.ok(!render.includes('stale legacy events'), 'legacy array is not read when snapshotEvents exists')
+})
+
+test('renderTurn: returns null when neither snapshotEvents nor events is available', () => {
+  assert.equal(renderTurn({}, { data: { turn: 1 } }), null)
+  assert.equal(renderTurn({ snapshotEvents: () => null }, { data: { turn: 1 } }), null)
 })
 
 test('writeCapture + captureExists: writes shared format and dedups', () => {

--- a/plugins/dsh/tests/index.test.js
+++ b/plugins/dsh/tests/index.test.js
@@ -360,6 +360,62 @@ test('summarizeTurn: custom-llm surfaces summarize.py stderr as a visible error'
   }
 })
 
+test('summarizeTurn: custom-llm normalizes stdin and preserves split UTF-8 stdout', async () => {
+  const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-custom-unicode-`)
+  const fakeBin = `${root}/bin`
+  const recorder = `${root}/recorder.mjs`
+  const stdinFile = `${root}/stdin.txt`
+  const prevPath = process.env.PATH
+  fs.mkdirSync(fakeBin)
+  fs.writeFileSync(
+    recorder,
+    'import { writeFileSync } from "node:fs";\n' +
+      'let input = "";\n' +
+      'process.stdin.setEncoding("utf8");\n' +
+      'process.stdin.on("data", (chunk) => { input += chunk; });\n' +
+      `process.stdin.on("end", () => { writeFileSync(${JSON.stringify(stdinFile)}, input, "utf8"); const bytes = Buffer.from("总结 × 😀", "utf8"); process.stdout.write(bytes.subarray(0, 2)); setImmediate(() => { process.stdout.write(bytes.subarray(2)); process.exit(0); }); });\n`,
+    'utf-8',
+  )
+  fs.writeFileSync(
+    `${fakeBin}/python3`,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(recorder)}\n`,
+    'utf-8',
+  )
+  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  try {
+    process.env.PATH = `${fakeBin}:/usr/bin:/bin`
+    const opts = { summarizeMode: 'custom-llm', agentName: 'X' }
+    const ctx = { logger: { warn: () => {} } }
+    const summary = await summarizeTurn(ctx, opts, `low:\udc98 pair:😀`, process.cwd())
+    assert.equal(summary, '总结 × 😀')
+    assert.equal(fs.readFileSync(stdinFile, 'utf-8'), 'low:� pair:😀')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeTurn: custom-llm rejects an early stdin close', async () => {
+  const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-custom-epipe-`)
+  const fakeBin = `${root}/bin`
+  const prevPath = process.env.PATH
+  fs.mkdirSync(fakeBin)
+  fs.writeFileSync(`${fakeBin}/python3`, '#!/bin/sh\nexit 0\n', 'utf-8')
+  fs.chmodSync(`${fakeBin}/python3`, 0o755)
+  try {
+    process.env.PATH = `${fakeBin}:/usr/bin:/bin`
+    const opts = { summarizeMode: 'custom-llm', agentName: 'X', summarizeTimeoutMs: 1000 }
+    const ctx = { logger: { warn: () => {} } }
+    await assert.rejects(
+      summarizeTurn(ctx, opts, 'x'.repeat(8 * 1024 * 1024), process.cwd()),
+      /EPIPE|write/i,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+    process.env.PATH = prevPath
+  }
+})
+
 test('detectDshCmd: falls back to pnpm global bin directory', async () => {
   const prevCli = process.env.DSH_CLI
   const prevPath = process.env.PATH
@@ -564,6 +620,7 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   // We point DSH_CLI at a recorder script that writes its argv to a file, then
   // assert the recorded args contain no `--patch` (and no temp overlay path).
   const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
   const prevDshSummarize = process.env.MEMSEARCH_DSH_SUMMARIZE
   const tmp = await import('node:os').then((os) => os.tmpdir())
   const fs = await import('node:fs')
@@ -577,6 +634,7 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
   const argvFile = `${tmp}/memsearch-dsh-argv-${process.pid}.txt`
   try {
     process.env.DSH_CLI = `sh ${recorder}`
+    process.env.PATH = '/usr/bin:/bin'
     process.env.MEMSEARCH_ARGV_FILE = argvFile
     const opts = {
       summarizeMode: 'dsh-headless',
@@ -603,6 +661,7 @@ test('summarizeHeadless: does not build a --patch overlay for the model', async 
     delete process.env.MEMSEARCH_ARGV_FILE
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
     if (prevDshSummarize === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
     else process.env.MEMSEARCH_DSH_SUMMARIZE = prevDshSummarize
   }
@@ -614,6 +673,7 @@ test('summarizeHeadless: child receives EOF on stdin and does not hang', async (
   // until the summarize timeout kills it. Point DSH_CLI at a Node recorder
   // that exits only after stdin ends, then assert it completed promptly.
   const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
   const prevDshSummarize = process.env.MEMSEARCH_DSH_SUMMARIZE
   const tmp = os.tmpdir()
   const recorder = `${tmp}/memsearch-dsh-stdin-eof-${process.pid}.mjs`
@@ -630,6 +690,7 @@ test('summarizeHeadless: child receives EOF on stdin and does not hang', async (
     // detectDshCmd splits DSH_CLI on whitespace; quote the interpreter path is
     // not needed because process.execPath and tmpdir contain no spaces here.
     process.env.DSH_CLI = `${process.execPath} ${recorder}`
+    process.env.PATH = '/usr/bin:/bin'
     const opts = { summarizeMode: 'dsh-headless', agentName: 'X' }
     const ctx = { logger: { warn: () => {} } }
     const render = '=== Turn 1 ===\n\n[User]: hi\n\n[Assistant]: hello'
@@ -644,8 +705,94 @@ test('summarizeHeadless: child receives EOF on stdin and does not hang', async (
     try { fs.unlinkSync(markerFile) } catch { /* cleanup */ }
     if (prevCli === undefined) delete process.env.DSH_CLI
     else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
     if (prevDshSummarize === undefined) delete process.env.MEMSEARCH_DSH_SUMMARIZE
     else process.env.MEMSEARCH_DSH_SUMMARIZE = prevDshSummarize
+  }
+})
+
+test('summarizeHeadless: preserves split UTF-8 stdout and Unicode stderr', async () => {
+  const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-child-unicode-`)
+  const recorder = `${root}/recorder.mjs`
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  fs.writeFileSync(
+    recorder,
+    'const mode = process.env.MEMSEARCH_TEST_CHILD_MODE;\n' +
+      'const bytes = Buffer.from(mode === "ok" ? "摘要 × 😀" : "ошибка 中文", "utf8");\n' +
+      'const stream = mode === "ok" ? process.stdout : process.stderr;\n' +
+      'stream.write(bytes.subarray(0, 2));\n' +
+      'setImmediate(() => { stream.write(bytes.subarray(2)); process.exit(mode === "ok" ? 0 : 7); });\n',
+    'utf-8',
+  )
+  try {
+    process.env.DSH_CLI = `${process.execPath} ${recorder}`
+    process.env.PATH = '/usr/bin:/bin'
+    const opts = { summarizeMode: 'dsh-headless', agentName: 'X' }
+    const ctx = { logger: { warn: () => {} } }
+    process.env.MEMSEARCH_TEST_CHILD_MODE = 'ok'
+    assert.equal(await summarizeTurn(ctx, opts, 'render', process.cwd()), '摘要 × 😀')
+    process.env.MEMSEARCH_TEST_CHILD_MODE = 'fail'
+    await assert.rejects(summarizeTurn(ctx, opts, 'render', process.cwd()), /ошибка 中文/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+    delete process.env.MEMSEARCH_TEST_CHILD_MODE
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeHeadless: timeout reaps the child process group before rejecting', async () => {
+  const root = fs.mkdtempSync(`${os.tmpdir()}/memsearch-child-timeout-`)
+  const recorder = `${root}/recorder.mjs`
+  const pidFile = `${root}/pids.json`
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  fs.writeFileSync(
+    recorder,
+    'import { spawn } from "node:child_process";\n' +
+      'import { writeFileSync } from "node:fs";\n' +
+      'const descendant = spawn(process.execPath, ["--eval", "setInterval(() => {}, 1000)"], { stdio: "ignore" });\n' +
+      `writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, descendant.pid]));\n` +
+      'setInterval(() => {}, 1000);\n',
+    'utf-8',
+  )
+  const isAlive = (pid) => {
+    try { process.kill(pid, 0); return true } catch { return false }
+  }
+  try {
+    process.env.DSH_CLI = `${process.execPath} ${recorder}`
+    process.env.PATH = '/usr/bin:/bin'
+    const opts = { summarizeMode: 'dsh-headless', agentName: 'X', summarizeTimeoutMs: 200 }
+    const ctx = { logger: { warn: () => {} } }
+    await assert.rejects(summarizeTurn(ctx, opts, 'render', process.cwd()), /timed out/)
+    const pids = JSON.parse(fs.readFileSync(pidFile, 'utf-8'))
+    for (let attempt = 0; attempt < 40 && pids.some(isAlive); attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    assert.ok(pids.every((pid) => !isAlive(pid)), `no residual processes: ${JSON.stringify(pids)}`)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
+  }
+})
+
+test('summarizeHeadless: spawn errors reject without a timeout race', async () => {
+  const prevCli = process.env.DSH_CLI
+  const prevPath = process.env.PATH
+  try {
+    process.env.DSH_CLI = '/definitely/not/a/dsh-command'
+    process.env.PATH = '/usr/bin:/bin'
+    const opts = { summarizeMode: 'dsh-headless', agentName: 'X', summarizeTimeoutMs: 1000 }
+    const ctx = { logger: { warn: () => {} } }
+    await assert.rejects(summarizeTurn(ctx, opts, 'render', process.cwd()), /ENOENT/)
+  } finally {
+    if (prevCli === undefined) delete process.env.DSH_CLI
+    else process.env.DSH_CLI = prevCli
+    process.env.PATH = prevPath
   }
 })
 
@@ -677,6 +824,34 @@ test('renderTurn: returns null when no user message', () => {
   assert.equal(renderTurn(session, { data: { turn: 1 } }), null)
 })
 
+test('renderTurn: snapshot and legacy event projections produce identical capture text', () => {
+  const events = [
+    { seq: 20, type: 'turn/start', data: { turn: 6 } },
+    {
+      seq: 21,
+      type: 'user/message',
+      data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'equivalence 中文 😀' }] },
+    },
+    {
+      seq: 22,
+      type: 'assistant/message',
+      data: {
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'same output' }],
+        },
+      },
+    },
+    { seq: 23, type: 'turn/end', data: { turn: 6 } },
+  ]
+  const snapshotEvents = structuredClone(events)
+  const legacyEvents = structuredClone(events)
+  assert.equal(
+    renderTurn({ snapshotEvents: () => snapshotEvents }, snapshotEvents.at(-1)),
+    renderTurn({ events: legacyEvents }, legacyEvents.at(-1)),
+  )
+})
+
 test('renderTurn: prefers session.snapshotEvents() over the legacy events array', () => {
   // Newer DSH Session replaced the public `events` array with an immutable
   // snapshotEvents() projection; when both are present the snapshot wins.
@@ -700,6 +875,57 @@ test('renderTurn: prefers session.snapshotEvents() over the legacy events array'
 test('renderTurn: returns null when neither snapshotEvents nor events is available', () => {
   assert.equal(renderTurn({}, { data: { turn: 1 } }), null)
   assert.equal(renderTurn({ snapshotEvents: () => null }, { data: { turn: 1 } }), null)
+})
+
+test('renderTurn: falls back when snapshotEvents is unusable or lacks the completed turn', () => {
+  const events = [
+    { type: 'turn/start', data: { turn: 3 } },
+    { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'legacy fallback' }] } },
+    { type: 'turn/end', data: { turn: 3 } },
+  ]
+  const snapshots = [
+    () => { throw new Error('synthetic snapshot failure') },
+    () => null,
+    () => [],
+    () => [
+      { type: 'turn/start', data: { turn: 2 } },
+      { type: 'turn/end', data: { turn: 2 } },
+    ],
+  ]
+  for (const snapshotEvents of snapshots) {
+    assert.match(renderTurn({ snapshotEvents, events }, { data: { turn: 3 } }), /legacy fallback/)
+  }
+})
+
+test('renderTurn: anchors duplicate turn numbers to the emitted end event', () => {
+  const end = { seq: 5, type: 'turn/end', data: { turn: 4 } }
+  const session = {
+    snapshotEvents: () => [
+      { seq: 0, type: 'turn/start', data: { turn: 4 } },
+      { seq: 1, type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'stale duplicate' }] } },
+      { seq: 2, type: 'turn/end', data: { turn: 4 } },
+      { seq: 3, type: 'turn/start', data: { turn: 4 } },
+      { seq: 4, type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'current duplicate' }] } },
+      end,
+    ],
+  }
+  const render = renderTurn(session, end)
+  assert.match(render, /current duplicate/)
+  assert.doesNotMatch(render, /stale duplicate/)
+})
+
+test('renderTurn: ignores malformed entries and an out-of-order earlier end', () => {
+  const session = {
+    snapshotEvents: () => [
+      null,
+      { type: 'turn/end', data: { turn: 8 } },
+      { type: 'turn/start', data: { turn: 8 } },
+      { type: 'user/message' },
+      { type: 'user/message', data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'safe marker' }] } },
+      { type: 'turn/end', data: { turn: 8 } },
+    ],
+  }
+  assert.match(renderTurn(session, { data: { turn: 8 } }), /safe marker/)
 })
 
 test('sanitizeSurrogates: lone surrogates become U+FFFD, valid pairs survive', () => {

--- a/plugins/dsh/tests/test_summarize.py
+++ b/plugins/dsh/tests/test_summarize.py
@@ -6,6 +6,8 @@ memsearch config objects — no LLM calls, no subprocesses.
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +18,27 @@ SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import summarize  # noqa: E402  (inserted above)
+
+
+def test_import_forces_utf8_stdout_and_stderr_under_legacy_code_page() -> None:
+    env = {**os.environ, "PYTHONIOENCODING": "cp1251:strict"}
+    expected_stdout = "摘要 \N{MULTIPLICATION SIGN} 😀"
+    code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(SCRIPTS)!r}); "
+        "import summarize; "
+        f"print({expected_stdout!r}); "
+        "print('ошибка 中文', file=sys.stderr)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert result.stdout.decode("utf-8").strip() == expected_stdout
+    assert result.stderr.decode("utf-8").strip() == "ошибка 中文"
 
 
 def _provider(type_: str, model: str = "", base_url: str = "", api_key: str = "") -> SimpleNamespace:
@@ -30,9 +53,7 @@ def make_config(**overrides) -> SimpleNamespace:
     llm = SimpleNamespace(provider="", model="", base_url="", api_key="", providers=providers)
     compact = SimpleNamespace(llm_provider="", llm_model="", base_url="", api_key="")
     prompts = SimpleNamespace(summarize="")
-    plugins = SimpleNamespace(
-        dsh=SimpleNamespace(summarize=SimpleNamespace(enabled=True, provider="", model=""))
-    )
+    plugins = SimpleNamespace(dsh=SimpleNamespace(summarize=SimpleNamespace(enabled=True, provider="", model="")))
     config = SimpleNamespace(llm=llm, compact=compact, prompts=prompts, plugins=plugins)
     return config
 


### PR DESCRIPTION
## Summary

Standalone follow-up split out of #730 per review feedback: only the two correctness fixes, no `summarizeProfile` and no repository-level agent instruction files.

- **`session.snapshotEvents()` compatibility.** Newer DSH `Session` replaced the public `events` array with an immutable `snapshotEvents()` projection. `renderTurn` now prefers `snapshotEvents()` and falls back to the legacy `session.events` array on older hosts; when neither yields an array it returns `null` so the turn is skipped instead of throwing inside the event listener.
- **stdin EOF for the headless summarizer child.** `summarizeHeadless` spawns the one-shot `dsh` child with `stdio: ['ignore', 'pipe', 'pipe']`, so the child sees an immediate EOF on stdin instead of inheriting an open pipe that is never closed - a child (or wrapper script) that waits for stdin EOF previously hung until the summarize timeout killed it.

## Tests

- `renderTurn` prefers `snapshotEvents()` over a stale legacy array.
- `renderTurn` returns `null` when neither source is available.
- `summarizeHeadless` child-exit test: a Node recorder that exits only after stdin `end` completes in ~150 ms (previously it would hang until the 30 s timeout).

Cross-platform: the new tests use a plain Node recorder via `DSH_CLI`, no `sh`/bash dependency. The 12 pre-existing Windows test failures on `main` (symlink-privilege and bash-shim fixtures) are unchanged by this PR.

## Docs

`docs/platforms/dsh/how-it-works.md` notes the `snapshotEvents()` read path and the closed stdin for the headless child.