### PR TITLE
fix(claude-code): deliver the UserPromptSubmit recall hint to the model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,11 @@ plugins/claude-code/
 
 **Supporting hooks:**
 - `SessionStart` injects cold-start context (recent daily logs) so Claude knows history exists
-- `UserPromptSubmit` returns a lightweight `systemMessage` capability hint ("[memsearch] Recall available if needed") to increase skill trigger awareness
+- `UserPromptSubmit` returns the lightweight capability hint ("[memsearch] Recall available if needed") in `systemMessage` for the user and in `hookSpecificOutput.additionalContext` for the model, to increase skill trigger awareness
 - `Stop` hook is async and non-blocking — extracts last turn only, calls `claude -p --model haiku` (with `CLAUDECODE=` to bypass nested session detection) to summarize as third-person notes, appends to daily `.md`
 
 When modifying hooks/skills, keep in mind:
-- All hooks output JSON to stdout (`additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}`)
+- All hooks output JSON to stdout (`additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}`); `systemMessage` is user-visible only, so a hint that also has to reach the model is returned in both fields
 - `common.sh` is sourced by every hook — changes there affect all hooks. It derives a per-project `COLLECTION_NAME` via `derive-collection.sh` and passes `--collection` automatically through `run_memsearch()` and `start_watch()`
 - The watch process uses a PID file (`.memsearch/.watch.pid`) for singleton behavior. Milvus Lite falls back to one-time `index()` at session start
 - `stop.sh` has a recursion guard (`stop_hook_active`) since it calls `claude -p` internally, and sets `MEMSEARCH_NO_WATCH=1` to prevent the child process from interfering with the main session's watch

--- a/docs/platforms/claude-code/how-it-works.md
+++ b/docs/platforms/claude-code/how-it-works.md
@@ -44,11 +44,11 @@ The plugin defines 4 lifecycle hooks that map to Claude Code's session events:
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
 | **SessionStart** | command | no | 10s | Start `memsearch watch` for Server or a one-shot index for Lite, inject recent memories as cold-start context, display config and index status |
-| **UserPromptSubmit** | command | no | 15s | Return `systemMessage` capability hint "[memsearch] Recall available if needed" (skips prompts < 10 chars) |
+| **UserPromptSubmit** | command | no | 15s | Return the capability hint "[memsearch] Recall available if needed" as `systemMessage` for you and as `hookSpecificOutput.additionalContext` for Claude (skips prompts < 10 chars) |
 | **Stop** | command | **yes** | 120s | Parse and summarize the last turn, lazily create its session heading, append to the daily `.md`; re-index immediately only for Server |
 | **SessionEnd** | command | **yes** | 10s | Asynchronously stop any Server watcher and clean up plugin-owned background index processes |
 
-All hooks output JSON to stdout -- `additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}` for no-op. The `common.sh` shared library is sourced by every hook, providing JSON parsing, memsearch binary detection, and watch process management.
+All hooks output JSON to stdout -- `additionalContext` for context injection, `systemMessage` for visible hints, or empty `{}` for no-op. `systemMessage` is shown in your terminal only, so a hook whose hint also has to reach Claude returns `hookSpecificOutput.additionalContext` next to it. The `common.sh` shared library is sourced by every hook, providing JSON parsing, memsearch binary detection, and watch process management.
 
 ### Hook Lifecycle Diagram
 
@@ -68,7 +68,7 @@ stateDiagram-v2
     state Prompting {
         [*] --> UserInput
         UserInput --> Hint: UserPromptSubmit hook
-        Hint --> ClaudeProcesses: "[memsearch] Recall available if needed"
+        Hint --> ClaudeProcesses: systemMessage and additionalContext carry "[memsearch] Recall available if needed"
         ClaudeProcesses --> MemoryRecall: needs context?
         MemoryRecall --> Subagent: memory-recall skill [fork]
         Subagent --> ClaudeResponds: curated summary
@@ -102,9 +102,20 @@ The cold-start injection is critical for early-session context. Without it, Clau
 
 ### UserPromptSubmit -- The Recall Capability Hint
 
-A lightweight hook that returns a `systemMessage` capability hint: `[memsearch] Recall available if needed`. The hook does not search or imply a match; it keeps Claude aware that the memory system exists, increasing the likelihood that it will invoke the memory-recall skill when a question benefits from historical context.
+A lightweight hook that returns the capability hint `[memsearch] Recall available if needed` in two fields: `systemMessage`, the one-liner you see in the terminal, and `hookSpecificOutput.additionalContext`, the field Claude Code forwards to the model on `UserPromptSubmit`. Both carry the same text, because `systemMessage` alone never reaches the model. The hook does not search or imply a match; it keeps Claude aware that the memory system exists, increasing the likelihood that it will invoke the memory-recall skill when a question benefits from historical context.
 
 The hook skips prompts shorter than 10 characters (e.g., "y", "ok") to avoid noise on trivial confirmations.
+
+**Checking that the hint was delivered.** The two fields arrive as two separate attachments in the session transcript, so delivery can be read off the runtime instead of guessed from Claude's answer:
+
+```bash
+claude -p "Explain what changed in this project recently." --debug-file /tmp/hook.log
+# newest transcript for this directory:
+TRANSCRIPT=$(ls -t ~/.claude/projects/$(pwd | sed 's#/#-#g')/*.jsonl | head -1)
+jq -c 'select(.type == "attachment") | .attachment | select(.hookEvent == "UserPromptSubmit")' "$TRANSCRIPT"
+```
+
+The turn writes one `hook_system_message` attachment, the one-liner shown in the terminal, and one `hook_additional_context` attachment whose `content` array holds the same marker, which is the copy the model is given. `/tmp/hook.log` records the same thing as `provided additionalContext (38 chars)`. Whether Claude then calls the memory-recall skill is its own decision and is deliberately not forced by this hook.
 
 ### Stop -- Capturing the Conversation
 
@@ -240,7 +251,7 @@ plugins/claude-code/
 │   ├── hooks.json               # Hook definitions (4 lifecycle hooks)
 │   ├── common.sh                # Shared setup: env, PATH, memsearch detection, watch management
 │   ├── session-start.sh         # Start Server watch or Lite one-shot + inject context
-│   ├── user-prompt-submit.sh    # Lightweight systemMessage hint
+│   ├── user-prompt-submit.sh    # Hint in systemMessage and additionalContext
 │   ├── stop.sh                  # Parse transcript -> summarize -> lazily create heading -> append
 │   ├── parse-transcript.sh      # Deterministic JSONL-to-text parser
 │   └── session-end.sh           # Async watcher and owned-index cleanup
@@ -258,7 +269,7 @@ plugins/claude-code/
 | `hooks.json` | Defines the 4 lifecycle hooks with their types, timeouts, and async flags. |
 | `common.sh` | Shared shell library sourced by all hooks. Handles stdin JSON parsing, PATH setup, memsearch binary detection (prefers PATH, falls back to `uv run`), memory directory management, and the watch singleton (start/stop with PID file and orphan cleanup). Changes here affect all hooks. |
 | `session-start.sh` | Starts the Server watcher or Lite one-shot index, reports persisted index health, reads recent memory files for cold-start injection, and checks for updates. |
-| `user-prompt-submit.sh` | Returns lightweight `systemMessage` hint. No search -- retrieval is handled by the memory-recall skill. |
+| `user-prompt-submit.sh` | Returns the lightweight capability hint in `systemMessage` (for you) and `hookSpecificOutput.additionalContext` (for Claude). No search -- retrieval is handled by the memory-recall skill. |
 | `stop.sh` | Extracts and validates the transcript, calls `parse-transcript.sh`, summarizes via native Haiku by default or a configured API provider, creates the session heading on the first captured turn, and appends with anchors. Server indexes immediately; Lite defers indexing to the next SessionStart. Has recursion guard (`stop_hook_active`) and sets `CLAUDECODE=` / `MEMSEARCH_NO_WATCH=1` on child processes. |
 | `parse-transcript.sh` | Standalone last-turn extractor using Python 3. Outputs role-labeled text. No `jq` dependency. |
 | `session-end.sh` | Asynchronously stops the Server watcher and cleans up plugin-owned background index processes. |

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -123,7 +123,7 @@ stateDiagram-v2
     state Prompting {
         [*] --> UserInput
         UserInput --> Hint: UserPromptSubmit hook
-        Hint --> ClaudeProcesses: "[memsearch] Recall available if needed"
+        Hint --> ClaudeProcesses: systemMessage and additionalContext carry "[memsearch] Recall available if needed"
         ClaudeProcesses --> MemoryRecall: needs context?
         MemoryRecall --> Subagent: memory-recall skill [fork]
         Subagent --> ClaudeResponds: curated summary

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -147,7 +147,7 @@ stateDiagram-v2
 | Hook | Type | Async | Timeout | What It Does |
 |------|------|-------|---------|-------------|
 | **SessionStart** | command | no | 10s | Start the Server `memsearch watch` singleton or a Lite one-shot index, inject recent daily logs as cold-start context via `additionalContext`, display config and index status in `systemMessage` |
-| **UserPromptSubmit** | command | no | 15s | Capability hint: returns `systemMessage` "[memsearch] Recall available if needed" (skip if < 10 chars). No search — recall is handled by the memory-recall skill |
+| **UserPromptSubmit** | command | no | 15s | Capability hint: returns "[memsearch] Recall available if needed" as `systemMessage` (visible to you) and as `additionalContext` (visible to Claude); skip if < 10 chars. No search — recall is handled by the memory-recall skill |
 | **Stop** | command | **yes** | 120s | Extract and summarize the last turn, lazily create its session heading, append the summary with session/turn anchors to the daily `.md`; index immediately only for Server |
 | **SessionEnd** | command | **yes** | 10s | Asynchronously stop the Server watcher and clean up plugin-owned background indexes, including a running Lite one-shot |
 
@@ -171,7 +171,7 @@ Fires on every user prompt before Claude processes it. This hook:
 
 1. **Extracts the prompt** from the hook input JSON.
 2. **Skips short prompts** (under 10 characters) — greetings and single words don't need memory hints.
-3. **Returns a lightweight capability hint.** Outputs `systemMessage: "[memsearch] Recall available if needed"` — a visible one-liner that keeps Claude aware of the memory system without performing a search or implying a match.
+3. **Returns a lightweight capability hint.** Outputs "[memsearch] Recall available if needed" twice: as `systemMessage`, the visible one-liner in your terminal, and as `hookSpecificOutput.additionalContext`, which is what actually reaches Claude on `UserPromptSubmit` (`systemMessage` alone is shown to the user only). This keeps Claude aware of the memory system without performing a search or implying a match.
 
 The actual memory retrieval is handled by the **[memory-recall skill](#how-the-skill-works)**, which Claude invokes automatically when it judges the user's question needs historical context.
 

--- a/plugins/claude-code/hooks/user-prompt-submit.sh
+++ b/plugins/claude-code/hooks/user-prompt-submit.sh
@@ -18,4 +18,7 @@ if ! memsearch_available; then
   exit 0
 fi
 
-echo '{"systemMessage": "[memsearch] Recall available if needed"}'
+# systemMessage is shown to the user in the terminal only; on UserPromptSubmit the
+# model sees hookSpecificOutput.additionalContext (or plain stdout), so the hint has
+# to travel in both to keep the visible one-liner and actually reach Claude.
+echo '{"systemMessage": "[memsearch] Recall available if needed", "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "[memsearch] Recall available if needed"}}'

--- a/tests/test_user_prompt_submit_hooks.py
+++ b/tests/test_user_prompt_submit_hooks.py
@@ -9,7 +9,20 @@ import pytest
 
 CAPABILITY_MARKER = "[memsearch] Recall available if needed"
 RETRIEVED_MARKER = "[memsearch] Retrieved memory context attached."
-EXPECTED_CAPABILITY_OUTPUT = json.dumps({"systemMessage": CAPABILITY_MARKER}, separators=(",", ": ")).encode() + b"\n"
+# Claude Code shows systemMessage to the user only; the model reads
+# hookSpecificOutput.additionalContext, so the Claude hook carries the hint in both.
+# Codex has no such split and keeps the plain systemMessage.
+EXPECTED_CAPABILITY_JSON = {
+    "claude-code": {
+        "systemMessage": CAPABILITY_MARKER,
+        "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": CAPABILITY_MARKER},
+    },
+    "codex": {"systemMessage": CAPABILITY_MARKER},
+}
+EXPECTED_CAPABILITY_OUTPUT = {
+    platform: json.dumps(payload, separators=(", ", ": ")).encode() + b"\n"
+    for platform, payload in EXPECTED_CAPABILITY_JSON.items()
+}
 HOOKS = {
     "claude-code": Path("plugins/claude-code/hooks/user-prompt-submit.sh"),
     "codex": Path("plugins/codex/hooks/user-prompt-submit.sh"),
@@ -72,9 +85,9 @@ def test_user_prompt_submit_long_prompt_emits_capability_without_search(tmp_path
     )
 
     assert result.returncode == 0, result.stderr.decode(errors="replace")
-    assert result.stdout == EXPECTED_CAPABILITY_OUTPUT
+    assert result.stdout == EXPECTED_CAPABILITY_OUTPUT[platform]
     assert result.stdout[-1:] == b"\n"
-    assert json.loads(result.stdout) == {"systemMessage": CAPABILITY_MARKER}
+    assert json.loads(result.stdout) == EXPECTED_CAPABILITY_JSON[platform]
     assert not call_log.exists(), "The capability hook must not invoke memsearch search or any other CLI command"
 
 


### PR DESCRIPTION
Closes #738.

## What was wrong

`plugins/claude-code/hooks/user-prompt-submit.sh` returned the capability hint as `systemMessage` only. On `UserPromptSubmit`, Claude Code shows `systemMessage` to the user in the terminal and does not add it to the model's context; only `hookSpecificOutput.additionalContext` (or plain stdout) reaches Claude. So the hint the memory-recall skill description relies on ("Also use when you see `[memsearch] Recall available if needed` capability hints injected via SessionStart or UserPromptSubmit") was delivered to the human and never to the model, which matches the audit in the issue (0 recall invocations over 252 sessions).

## Change

The hook now emits the hint in both fields:

```json
{"systemMessage": "[memsearch] Recall available if needed", "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "[memsearch] Recall available if needed"}}
```

`systemMessage` keeps the visible one-liner that the README documents and users are used to; `additionalContext` is what actually reaches Claude, the same mechanism `SessionStart` already uses for the cold-start context. The short-prompt and missing-CLI early exits are unchanged, and no CLI command is invoked.

The Codex hook is untouched (Codex has no such split), so `tests/test_user_prompt_submit_hooks.py` now carries per-platform expected output. The README hook table and the UserPromptSubmit walkthrough describe the two fields.

## Tests

```
pytest tests/test_user_prompt_submit_hooks.py
8 passed
```

The Claude case asserts the exact bytes and parsed JSON of the new payload, still with a trailing newline and still without any `memsearch` CLI call; the Codex case asserts the unchanged output. The marker-synchronisation tests keep passing since the marker string itself did not change.