### PR TITLE
release: prepare v0.4.20

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "memsearch",
       "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "source": "./plugins/claude-code",
       "category": "productivity",
       "author": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memsearch",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Automatic semantic memory for Claude Code — remembers what you worked on across sessions"
 }

--- a/plugins/dsh/package.json
+++ b/plugins/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-dsh",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MemSearch plugin for DeepSeek Harness: shared markdown memory across agents, with capture, pre-step context injection, memory-recall skill, and a skill-candidate review panel.",
   "type": "module",
   "main": "index.js",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memsearch",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Semantic memory search plugin for OpenClaw — persistent cross-session memory powered by Milvus vector search. Automatically captures conversation summaries and recalls relevant context.",
   "type": "module",
   "files": [

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliz/memsearch-opencode",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "memsearch plugin for OpenCode — semantic memory search across sessions",
   "type": "module",
   "main": "index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsearch"
-version = "0.4.19"
+version = "0.4.20"
 description = "Semantic memory search for markdown knowledge bases"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1481,7 +1481,7 @@ wheels = [
 
 [[package]]
 name = "memsearch"
-version = "0.4.19"
+version = "0.4.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- release MemSearch and marketplace metadata as 0.4.20
- release DSH as 0.1.5
- release OpenCode as 0.3.16 and OpenClaw as 0.3.19

## Validation

- `uv lock --check`
- full Python test suite and formatting checks
- DSH, OpenCode, and OpenClaw tests and package audits
- source plugin capture-to-recall checks for marketplace, Codex, and DSH

OpenCode and OpenClaw source end-to-end coverage is a documented best-effort release risk; package tests and artifact audits passed.