### PR TITLE
fix(codex): read a turn's messages from response_item rollouts

### DIFF
--- a/plugins/codex/scripts/parse-rollout.sh
+++ b/plugins/codex/scripts/parse-rollout.sh
@@ -11,6 +11,10 @@
 #   response_item + function_call_output → tool result (skipped)
 #   response_item + message (role=user)  → user content blocks
 #   response_item + message (role=assistant) → assistant content blocks
+#
+# codex-cli >= 0.153 stopped writing the event_msg user_message/agent_message
+# duplicates, so response_item messages are the ONLY place a turn's text lives
+# there. Both shapes are read, and a text seen in both is emitted once.
 #   event_msg + task_started   → turn boundary
 #   event_msg + task_complete  → turn end
 #
@@ -51,15 +55,52 @@ def find_last_turn_start(lines):
             pass
     return None
 
+def message_text(payload):
+    """The text of a response_item message, or "" when it carries none."""
+    blocks = payload.get("content") or []
+    parts = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text") or ""
+        if text.strip():
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+# The harness injects its own instructions as a user-role message. They are not
+# part of the conversation, and a summary built from them describes the system
+# prompt instead of the turn.
+INJECTED_PREFIXES = (
+    "# AGENTS.md instructions",
+    "<user_instructions>",
+    "<environment_context>",
+)
+
+
+def is_injected_instruction(text):
+    return text.startswith(INJECTED_PREFIXES) or "<INSTRUCTIONS>" in text[:200]
+
+
 def find_last_user_message(lines):
-    """Fallback: find the last user_message event."""
+    """Fallback: find the last user message, in either rollout shape."""
     for i in range(len(lines) - 1, -1, -1):
         try:
             obj = json.loads(lines[i])
-            if obj.get("type") == "event_msg":
-                payload = obj.get("payload", {})
-                if payload.get("type") == "user_message":
-                    return i
+            payload = obj.get("payload", {})
+            line_type = obj.get("type")
+            if line_type == "event_msg" and payload.get("type") == "user_message":
+                return i
+            # codex-cli >= 0.153 writes no user_message event, so a rollout
+            # without task_started would otherwise report no user message at
+            # all and the turn would never be summarized.
+            if (
+                line_type == "response_item"
+                and payload.get("type") == "message"
+                and payload.get("role") == "user"
+                and not is_injected_instruction(message_text(payload))
+            ):
+                return i
         except Exception:
             pass
     return None
@@ -67,6 +108,16 @@ def find_last_user_message(lines):
 def format_turn(lines):
     """Format a turn into structured text for LLM summarization."""
     output = ["=== Transcript of a conversation between User and Codex CLI ==="]
+    # (role, text) pairs already emitted. Versions that dual-write a message as
+    # both an event_msg and a response_item must not produce it twice.
+    seen = set()
+
+    def emit(role, text):
+        key = (role, text)
+        if not text or key in seen:
+            return
+        seen.add(key)
+        output.append(("[User]: " if role == "user" else "[Codex]: ") + text)
 
     for raw_line in lines:
         try:
@@ -81,22 +132,24 @@ def format_turn(lines):
             msg_type = payload.get("type", "")
 
             if msg_type == "user_message":
-                message = payload.get("message", "")
-                if message.strip():
-                    output.append(f"[User]: {message.strip()}")
+                emit("user", payload.get("message", "").strip())
 
             elif msg_type == "agent_message":
-                message = payload.get("message", "")
-                if message.strip():
-                    output.append(f"[Codex]: {message.strip()}")
+                emit("assistant", payload.get("message", "").strip())
 
             # Skip: task_started, task_complete, token_count, agent_reasoning
 
         elif line_type == "response_item":
             item_type = payload.get("type", "")
 
-            # Skip tool calls/results and response_item "message" duplicates.
-            # Skip: reasoning, session_meta, turn_context, web_search_call
+            if item_type == "message" and payload.get("role") in ("user", "assistant"):
+                text = message_text(payload)
+                if text and not is_injected_instruction(text):
+                    emit(payload["role"], text)
+
+            # Skip tool calls/results (function_call, function_call_output),
+            # developer-role messages, reasoning, session_meta, turn_context
+            # and web_search_call.
 
     return "\n".join(output)
 

--- a/tests/test_codex_parse_rollout.py
+++ b/tests/test_codex_parse_rollout.py
@@ -113,3 +113,180 @@ def test_parse_rollout_omits_tool_error_content(tmp_path: Path) -> None:
     assert "exit_code=2" not in output
     assert "final error marker" not in output
     assert "prefix " not in output
+
+
+# --- codex-cli >= 0.153: message text lives only in response_item (#742) -----
+
+
+def test_parse_rollout_reads_response_item_messages(tmp_path: Path) -> None:
+    """The 0.153 rollout writes no user_message/agent_message events at all.
+
+    Reading only those events left the transcript empty but for its header, so
+    the summarizer reported the user's question as missing and the daily entry
+    carried the final assistant line at best.
+    """
+    rollout = tmp_path / "rollout.jsonl"
+    _write_jsonl(
+        rollout,
+        [
+            {"type": "event_msg", "payload": {"type": "task_started"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "What is 3+3?"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {"type": "reasoning", "content": [{"type": "reasoning_text", "text": "adding"}]},
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "6"}],
+                },
+            },
+            {"type": "event_msg", "payload": {"type": "token_count"}},
+            {"type": "event_msg", "payload": {"type": "task_complete"}},
+        ],
+    )
+
+    output = _run_parse(rollout)
+
+    assert "[User]: What is 3+3?" in output
+    assert "[Codex]: 6" in output
+    assert "adding" not in output
+
+
+def test_parse_rollout_drops_injected_instructions(tmp_path: Path) -> None:
+    """The harness injects its own instructions as a user-role message.
+
+    They are not part of the conversation, and a summary built from them
+    describes the system prompt instead of the turn.
+    """
+    rollout = tmp_path / "rollout.jsonl"
+    _write_jsonl(
+        rollout,
+        [
+            {"type": "event_msg", "payload": {"type": "task_started"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "developer preamble"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "# AGENTS.md instructions for /repo\n<INSTRUCTIONS>obey</INSTRUCTIONS>",
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "<environment_context>cwd=/repo</environment_context>"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Summarize the journal"}],
+                },
+            },
+        ],
+    )
+
+    output = _run_parse(rollout)
+
+    assert "[User]: Summarize the journal" in output
+    assert "AGENTS.md instructions" not in output
+    assert "obey" not in output
+    assert "environment_context" not in output
+    assert "developer preamble" not in output
+
+
+def test_parse_rollout_does_not_duplicate_dual_written_messages(tmp_path: Path) -> None:
+    """Older codex versions write a message twice, as event and as item."""
+    rollout = tmp_path / "rollout.jsonl"
+    _write_jsonl(
+        rollout,
+        [
+            {"type": "event_msg", "payload": {"type": "task_started"}},
+            {"type": "event_msg", "payload": {"type": "user_message", "message": "What is 3+3?"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "What is 3+3?"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "6"}],
+                },
+            },
+            {"type": "event_msg", "payload": {"type": "agent_message", "message": "6"}},
+        ],
+    )
+
+    output = _run_parse(rollout)
+
+    assert output.count("[User]: What is 3+3?") == 1
+    assert output.count("[Codex]: 6") == 1
+
+
+def test_parse_rollout_falls_back_to_a_response_item_user_message(tmp_path: Path) -> None:
+    """No task_started: the fallback has to know the new shape too.
+
+    It looked for a user_message event, which 0.153 never writes, so a rollout
+    without a turn boundary reported no user message and was dropped whole.
+    """
+    rollout = tmp_path / "rollout.jsonl"
+    _write_jsonl(
+        rollout,
+        [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Where is the config?"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "In ~/.memsearch."}],
+                },
+            },
+        ],
+    )
+
+    output = _run_parse(rollout)
+
+    assert "no user message found" not in output
+    assert "[User]: Where is the config?" in output
+    assert "[Codex]: In ~/.memsearch." in output


### PR DESCRIPTION
## What

On codex-cli 0.153 the rollout no longer carries the `event_msg` `user_message` / `agent_message` duplicates, and `parse-rollout.sh` read only those. A turn's text lives solely in `response_item` messages there, which the parser skipped by design, so the transcript was its header line and nothing else. The summarizer then reported the user's question as missing and the daily entry carried the final assistant line at best.

Fixes #742.

## How

`response_item` messages with a `user` or `assistant` role are read, with their content blocks joined. Three consequences, each handled:

- **Injected instructions are not conversation.** The harness writes its own preamble as a user-role message (`# AGENTS.md instructions`, `<user_instructions>`, `<environment_context>`, or an `<INSTRUCTIONS>` block in the first 200 characters). Those are dropped, and `developer`-role messages with them, or the summary describes the system prompt instead of the turn.
- **No duplicates on older versions.** A version that dual-writes a message as both an event and an item would emit it twice, so an emitted `(role, text)` pair is emitted once. The issue called a dedupe pass optional; it is one `set`, and a doubled transcript is worse input for the summarizer than a single one.
- **The fallback knew only the old shape.** With no `task_started` in the rollout, `find_last_user_message` looked for a `user_message` event, which 0.153 never writes, so such a rollout reported "(no user message found)" and was dropped whole. It now recognizes a user-role `response_item` too, ignoring the injected instructions when it does.

Tool calls and tool results stay excluded, which the existing three tests still pin.

## Evidence

`tests/test_codex_parse_rollout.py`: 7 passed, four cases added.

| case | asserts |
|---|---|
| `reads_response_item_messages` | a 0.153-shaped rollout yields `[User]` and `[Codex]` lines, and no reasoning text |
| `drops_injected_instructions` | AGENTS.md / `<environment_context>` / developer-role text absent, the real question present |
| `does_not_duplicate_dual_written_messages` | each line appears exactly once when both shapes are present |
| `falls_back_to_a_response_item_user_message` | no `task_started`: the turn is still parsed instead of reported as having no user message |

Negative controls, each reverted on its own: removing the `response_item` read fails three of the four, removing the dedupe fails the duplicate case, and removing the fallback's new shape fails the fallback case.

End to end on two synthetic rollouts through the real script:

```
# 0.153.4 shape (response_item only, with an injected AGENTS.md message)
=== Transcript of a conversation between User and Codex CLI ===
[User]: What is 3+3?
[Codex]: 6

# older shape (dual write)
=== Transcript of a conversation between User and Codex CLI ===
[User]: What is 3+3?
[Codex]: 6
```

`ruff check` and `ruff format --check` clean on the test file; `bash -n` clean on the script.

## Not covered

I have no codex-cli 0.153 installation here, so the shapes above come from the rollout structure the issue documents, not from a captured session of my own. If the real 0.153 rollout nests message text somewhere else as well, that is the assumption to check first.
